### PR TITLE
Allow compilation on OpenBSD

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -559,8 +559,9 @@ fn build_shim_for_version(
         .unwrap();
     }
 
+    let make = env!("MAKE").unwrap_or("make".to_string());
     let rc = run_command(
-        Command::new("make")
+        Command::new(make)
             .arg("clean")
             .arg(&format!("libpgx-cshim-{}.a", major_version))
             .env("PG_TARGET_VERSION", format!("{}", major_version))

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -559,7 +559,7 @@ fn build_shim_for_version(
         .unwrap();
     }
 
-    let make = env!("MAKE").unwrap_or("make".to_string());
+    let make = option_env!("MAKE").unwrap_or("make").to_string();
     let rc = run_command(
         Command::new(make)
             .arg("clean")

--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -20,7 +20,7 @@ extern "C" {
     ) -> std::os::raw::c_int;
 }
 
-#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 extern "C" {
     pub(crate) fn sigsetjmp(
         env: *mut crate::sigjmp_buf,


### PR DESCRIPTION
Two changes to allow to build pgx on OpenBSD :
- pgx requires GNU `make`. Base `make` is BSD `make` so we need to pass `gmake` (via an envvar)
- OpenBSD has `sigsetjmp`