### PR TITLE
`cargo pgx status` always defaults to `all`

### DIFF
--- a/cargo-pgx/src/command/status.rs
+++ b/cargo-pgx/src/command/status.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
 // governed by the MIT license that can be found in the LICENSE file.
 
-use eyre::{eyre};
+use eyre::eyre;
 use owo_colors::OwoColorize;
 use pgx_utils::pg_config::{PgConfig, PgConfigSelector, Pgx};
 use std::{
@@ -33,7 +33,12 @@ impl CommandExecute for Status {
     fn execute(self) -> eyre::Result<()> {
         let pgx = Pgx::from_config()?;
 
-        for pg_config in pgx.iter(PgConfigSelector::All) {
+        let pg_version = match self.pg_version {
+            Some(s) => s,
+            None => "all".to_string(),
+        };
+
+        for pg_config in pgx.iter(PgConfigSelector::new(&pg_version)) {
             let pg_config = pg_config?;
             if status_postgres(pg_config)? {
                 println!(

--- a/cargo-pgx/src/command/status.rs
+++ b/cargo-pgx/src/command/status.rs
@@ -1,14 +1,13 @@
 // Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
 // governed by the MIT license that can be found in the LICENSE file.
 
-use eyre::{eyre, WrapErr};
+use eyre::{eyre};
 use owo_colors::OwoColorize;
 use pgx_utils::pg_config::{PgConfig, PgConfigSelector, Pgx};
 use std::{
     process::Stdio,
     path::PathBuf,
 };
-use cargo_toml::Manifest;
 
 use crate::CommandExecute;
 
@@ -34,23 +33,7 @@ impl CommandExecute for Status {
     fn execute(self) -> eyre::Result<()> {
         let pgx = Pgx::from_config()?;
 
-        let pg_version = match self.pg_version {
-            Some(s) => s,
-            None => {
-                let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-                    .wrap_err("couldn't get cargo metadata")?;
-                crate::metadata::validate(&metadata)?;
-                let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                    .wrap_err("Couldn't get manifest path")?;
-                let package_manifest = Manifest::from_path(&package_manifest_path)
-                    .wrap_err("Couldn't parse manifest")?;
-                
-                crate::manifest::default_pg_version(&package_manifest)
-                    .ok_or(eyre!("no provided `pg$VERSION` flag."))?
-            }
-        };
-
-        for pg_config in pgx.iter(PgConfigSelector::new(&pg_version)) {
+        for pg_config in pgx.iter(PgConfigSelector::All) {
             let pg_config = pg_config?;
             if status_postgres(pg_config)? {
                 println!(


### PR DESCRIPTION
`cargo pgx status` should report the status of all pgx-managed Postgres versions.  It should not be dependent on what's in `Cargo.toml`.