### PR TITLE
Prepare 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pgx-utils",
  "proc-macro-crate",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "eyre",
  "libc",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atty",
  "convert_case",

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgx' to make Postgres extension development easy"
@@ -23,7 +23,7 @@ semver = "1.0.6"
 owo-colors = { version = "3.2.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils", version = "0.4.0" }
+pgx-utils = { path = "../pgx-utils", version = "0.4.1" }
 proc-macro2 = { version = "1.0.36", features = [ "span-locations" ] }
 quote = "1.0.15"
 rayon = "1.5.1"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.4.0"
+pgx = "0.4.1"
 
 [dev-dependencies]
-pgx-tests = "0.4.0"
+pgx-tests = "0.4.1"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,13 +16,13 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.4.0"
-pgx-macros = "0.4.0"
-pgx-utils = "0.4.0"
+pgx = "0.4.1"
+pgx-macros = "0.4.1"
+pgx-utils = "0.4.1"
 
 
 [dev-dependencies]
-pgx-tests = "0.4.0"
+pgx-tests = "0.4.1"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgx'"
@@ -18,7 +18,7 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.4.0" }
+pgx-utils = { path = "../pgx-utils", version = "0.4.1" }
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 syn = { version = "1.0.86", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgx'"
@@ -29,14 +29,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.5"
 once_cell = "1.9.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.4.0" }
+pgx-macros = { path = "../pgx-macros/", version = "0.4.1" }
 
 [build-dependencies]
 bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }
 build-deps = "0.1.4"
 owo-colors = "3.2.0"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils/", version = "0.4.0" }
+pgx-utils = { path = "../pgx-utils/", version = "0.4.1" }
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 rayon = "1.5.1"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgx'-based Postgres extensions"
@@ -34,9 +34,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 owo-colors = "3.2.0"
 once_cell = "1.9.0"
 libc = "0.2.119"
-pgx = { path = "../pgx", default-features = false, version= "0.4.0" }
-pgx-macros = { path = "../pgx-macros", version= "0.4.0" }
-pgx-utils = { path = "../pgx-utils", version= "0.4.0" }
+pgx = { path = "../pgx", default-features = false, version= "0.4.1" }
+pgx-macros = { path = "../pgx-macros", version= "0.4.1" }
+pgx-utils = { path = "../pgx-utils", version= "0.4.1" }
 postgres = "0.19.2"
 regex = "1.5.4"
 serde = "1.0.136"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Utility functions for 'pgx'"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgx:  A Rust framework for creating Postgres extensions"
@@ -34,9 +34,9 @@ cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.14"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.4.0" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.4.0" }
-pgx-utils = { path = "../pgx-utils/", version = "0.4.0" }
+pgx-macros = { path = "../pgx-macros/", version = "0.4.1" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.4.1" }
+pgx-utils = { path = "../pgx-utils/", version = "0.4.1" }
 serde = { version = "1.0.136", features = [ "derive" ] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.79"

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -61,10 +61,4 @@ done
 
 cargo generate-lockfile
 
-for example in ./pgx-examples/*/; do
-    pushd ${example}
-    cargo generate-lockfile
-    popd
-done
-
 PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE=1 cargo test --no-run --workspace --no-default-features --features "pg14"


### PR DESCRIPTION
This release includes some minor performance and UX improvements.

Release notes

----

# 0.4.1

## Upgrading

Please make sure to run `cargo install cargo-pgx --version 0.4.1` and update all the `pgx` extension `Cargo.toml`'s `pgx*` versions to `0.4.1`.

## What's Changed

* `Internal::get_or_insert_default`, and similar functions were doing some unnecessary allocations. Removing them improves the speed of these functions significantly. (#488)
* We now `#[inline(always)]` on `pgx::Aggregate`'s memory context swapping code. (#487)
* `cargo pgx status` will by default show the status of all `pgx` managed PostgreSQLs, instead of the default if one exists in the `Cargo.toml`. (#505)
* `cargo pgx schema` was producing color codes outside of the normal `xterm-256color` codes, this produced unpleasant output on some terminals (notably Mac's `terminal.app`). When the output of `cargo pgx schema` is a TTY it will now produce `xterm-256color` style codes, and use the user's terminal colors. This removes the need to specify if the user was using a light theme. (#507)
* If `cargo pgx test` experiences a `cargo` related error, we don't report a full eyre error, we just report the cargo errors. (#491)
* Documentation fixes.  (#496)