### PR TITLE
update copyright headers

### DIFF
--- a/.licensure.yml
+++ b/.licensure.yml
@@ -22,7 +22,9 @@ licenses:
       - name: ZomboDB, LLC and Technology Concepts & Design, Inc.
         email: support@tcdi.com
     template: |
-      Copyright 2019-[year] [name of author]. All rights reserved. 
+      Portions Copyright 2019-2021 ZomboDB, LLC. 
+      Portions Copyright 2021-[year] Technology Concepts & Design, Inc. <support@tcdi.com>.
+      All rights reserved. 
       Use of this source code is governed by the [ident] license that can be found in the LICENSE file.
 comments:
   - columns: 80

--- a/.licensure.yml
+++ b/.licensure.yml
@@ -1,14 +1,55 @@
-author: ZomboDB, LLC
-ident: MIT
-email: zombodb@gmail.com
+change_in_place: true
 excludes:
   - Cargo.toml
-  - ".*\\.h"
-  - "\\.cargo/config"
+  - Cargo.lock
+  - LICENSE
+  - pgx-utils/assets/ansi.tmTheme
+  - ".envrc"
+  - ".gitignore"
+  - "flake\\..*"
+  - "logo.*"
+  - ".github/**/*"
+  - ".cargo/config"
   - "cargo-pgx/src/templates/*"
-  - ".github/workflows/*"
   - ".*\\.control"
   - ".*\\.md"
+  - ".*\\.nix"
   - ".*\\.yml"
-  - ".*\\.sh"
-  - load-order.txt
+licenses:
+  - files: any
+    ident: MIT
+    authors:
+      - name: ZomboDB, LLC and Technology Concepts & Design, Inc.
+        email: support@tcdi.com
+    template: |
+      Copyright 2019-[year] [name of author]. All rights reserved. 
+      Use of this source code is governed by the [ident] license that can be found in the LICENSE file.
+comments:
+  - columns: 80
+    extensions:
+      - rs
+      - c
+      - h
+    commenter:
+      type: line
+      comment_char: "//"
+      trailing_lines: 0
+  - columns: 120
+    extension: sql
+    commenter:
+      type: block
+      start_block_char: "/*\n"
+      end_block_char: "\n*/\n"
+  - columns: 120
+    extension: html
+    commenter:
+      type: block
+      start_block_char: "<!--\n"
+      end_block_char: "-->"
+  - columns: 80
+    extension: any
+    commenter:
+      type: line
+      comment_char: "#"
+      trailing_lines: 0
+    

--- a/.licensure.yml
+++ b/.licensure.yml
@@ -19,25 +19,25 @@ licenses:
   - files: any
     ident: MIT
     authors:
-      - name: ZomboDB, LLC and Technology Concepts & Design, Inc.
+      - name: Technology Concepts & Design, Inc.
         email: support@tcdi.com
     template: |
-      Portions Copyright 2019-2021 ZomboDB, LLC. 
-      Portions Copyright 2021-[year] Technology Concepts & Design, Inc. <support@tcdi.com>.
-      All rights reserved. 
+      Portions Copyright 2019-2021 ZomboDB, LLC.
+      
+      Portions Copyright 2021-[year] [name of author]
+      
+      
+      All rights reserved.
+      
+      
       Use of this source code is governed by the [ident] license that can be found in the LICENSE file.
 comments:
-  - columns: 80
+  - columns: 120
     extensions:
       - rs
       - c
       - h
-    commenter:
-      type: line
-      comment_char: "//"
-      trailing_lines: 0
-  - columns: 120
-    extension: sql
+      - sql
     commenter:
       type: block
       start_block_char: "/*\n"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 ZomboDB, LLC
+Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
-Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.
+All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -273,6 +273,6 @@ time goes on.  Your feedback about what you'd like to be able to do with `pgx` i
 ## License
 
 ```
-Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved.
+Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 ```

--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ time goes on.  Your feedback about what you'd like to be able to do with `pgx` i
 ## License
 
 ```
-Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.
+Portions Copyright 2019-2021 ZomboDB, LLC.  
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>. 
+All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 ```

--- a/cargo-pgx/src/command/connect.rs
+++ b/cargo-pgx/src/command/connect.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     command::{get::get_property, run::exec_psql, start::start_postgres},

--- a/cargo-pgx/src/command/connect.rs
+++ b/cargo-pgx/src/command/connect.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     command::{get::get_property, run::exec_psql, start::start_postgres},

--- a/cargo-pgx/src/command/connect.rs
+++ b/cargo-pgx/src/command/connect.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     command::{get::get_property, run::exec_psql, start::start_postgres},
@@ -49,11 +53,13 @@ impl CommandExecute for Connect {
                     // It's actually the dbname! We should infer from the manifest.
                     self.dbname = Some(pg_version);
 
-                    let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-                        .wrap_err("couldn't get cargo metadata")?;
+                    let metadata =
+                        crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
+                            .wrap_err("couldn't get cargo metadata")?;
                     crate::metadata::validate(&metadata)?;
-                    let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                        .wrap_err("Couldn't get manifest path")?;
+                    let package_manifest_path =
+                        crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                            .wrap_err("Couldn't get manifest path")?;
                     let package_manifest = Manifest::from_path(&package_manifest_path)
                         .wrap_err("Couldn't parse manifest")?;
 
@@ -64,11 +70,13 @@ impl CommandExecute for Connect {
             },
             None => {
                 // We should infer from the manifest.
-                let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-                    .wrap_err("couldn't get cargo metadata")?;
+                let metadata =
+                    crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
+                        .wrap_err("couldn't get cargo metadata")?;
                 crate::metadata::validate(&metadata)?;
-                let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                    .wrap_err("Couldn't get manifest path")?;
+                let package_manifest_path =
+                    crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                        .wrap_err("Couldn't get manifest path")?;
                 let package_manifest = Manifest::from_path(&package_manifest_path)
                     .wrap_err("Couldn't parse manifest")?;
 
@@ -82,16 +90,18 @@ impl CommandExecute for Connect {
             Some(dbname) => dbname,
             None => {
                 // We should infer from package
-                let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-                    .wrap_err("couldn't get cargo metadata")?;
+                let metadata =
+                    crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
+                        .wrap_err("couldn't get cargo metadata")?;
                 crate::metadata::validate(&metadata)?;
-                let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                    .wrap_err("Couldn't get manifest path")?;
+                let package_manifest_path =
+                    crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                        .wrap_err("Couldn't get manifest path")?;
 
                 get_property(&package_manifest_path, "extname")
                     .wrap_err("could not determine extension name")?
                     .ok_or(eyre!("extname not found in control file"))?
-            },
+            }
         };
 
         connect_psql(Pgx::from_config()?.get(&pg_version)?, &dbname)

--- a/cargo-pgx/src/command/get.rs
+++ b/cargo-pgx/src/command/get.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use eyre::{eyre, WrapErr};
 use std::{

--- a/cargo-pgx/src/command/get.rs
+++ b/cargo-pgx/src/command/get.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use eyre::{eyre, WrapErr};
 use std::{

--- a/cargo-pgx/src/command/get.rs
+++ b/cargo-pgx/src/command/get.rs
@@ -1,8 +1,13 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
 
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+use crate::CommandExecute;
 use eyre::{eyre, WrapErr};
 use std::{
     fs::File,
@@ -10,7 +15,6 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use crate::CommandExecute;
 
 /// Get a property from the extension control file
 #[derive(clap::Args, Debug)]
@@ -34,8 +38,9 @@ impl CommandExecute for Get {
         let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
-        let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-            .wrap_err("Couldn't get manifest path")?;
+        let package_manifest_path =
+            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                .wrap_err("Couldn't get manifest path")?;
 
         if let Some(value) = get_property(&package_manifest_path, &self.name)? {
             println!("{}", value);
@@ -81,22 +86,37 @@ pub fn get_property(manifest_path: impl AsRef<Path>, name: &str) -> eyre::Result
     Ok(None)
 }
 
-pub(crate) fn find_control_file(manifest_path: impl AsRef<Path>) -> eyre::Result<(PathBuf, String)> {
-    let parent = manifest_path
-        .as_ref()
-        .parent()
-        .ok_or_else(|| eyre!("could not get parent of `{}`", manifest_path.as_ref().display()))?;
-    
-    for f in std::fs::read_dir(parent)
-        .wrap_err_with(|| eyre!("cannot open current directory `{}` for reading", parent.display()))? {
+pub(crate) fn find_control_file(
+    manifest_path: impl AsRef<Path>,
+) -> eyre::Result<(PathBuf, String)> {
+    let parent = manifest_path.as_ref().parent().ok_or_else(|| {
+        eyre!(
+            "could not get parent of `{}`",
+            manifest_path.as_ref().display()
+        )
+    })?;
+
+    for f in std::fs::read_dir(parent).wrap_err_with(|| {
+        eyre!(
+            "cannot open current directory `{}` for reading",
+            parent.display()
+        )
+    })? {
         if f.is_ok() {
             if let Ok(f) = f {
                 let f_path = f.path();
                 if f_path.extension() == Some("control".as_ref()) {
-                    let file_stem = f_path.file_stem()
-                        .ok_or_else(|| eyre!("could not get file stem of `{}`", f_path.display()))?;
-                    let file_stem = file_stem.to_str()
-                        .ok_or_else(|| eyre!("could not get file stem as String from `{}`", f_path.display()))?
+                    let file_stem = f_path.file_stem().ok_or_else(|| {
+                        eyre!("could not get file stem of `{}`", f_path.display())
+                    })?;
+                    let file_stem = file_stem
+                        .to_str()
+                        .ok_or_else(|| {
+                            eyre!(
+                                "could not get file stem as String from `{}`",
+                                f_path.display()
+                            )
+                        })?
                         .to_string();
                     return Ok((f_path, file_stem));
                 }
@@ -104,7 +124,10 @@ pub(crate) fn find_control_file(manifest_path: impl AsRef<Path>) -> eyre::Result
         }
     }
 
-    Err(eyre!("control file not found in `{}`", manifest_path.as_ref().display()))
+    Err(eyre!(
+        "control file not found in `{}`",
+        manifest_path.as_ref().display()
+    ))
 }
 
 fn determine_git_hash() -> eyre::Result<Option<String>> {

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::command::stop::stop_postgres;
 use crate::CommandExecute;
@@ -437,7 +441,8 @@ pub(crate) fn initdb(bindir: &PathBuf, datadir: &PathBuf) -> eyre::Result<()> {
     let command_str = format!("{:?}", command);
     tracing::debug!(command = %command_str, "Running");
 
-    let output = command.output()
+    let output = command
+        .output()
         .wrap_err_with(|| eyre!("unable to execute: {}", command_str))?;
     tracing::trace!(command = %command_str, status_code = %output.status, "Finished");
 

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::command::stop::stop_postgres;
 use crate::CommandExecute;

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::command::stop::stop_postgres;
 use crate::CommandExecute;

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     command::get::{find_control_file, get_property},

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     command::get::{find_control_file, get_property},
@@ -49,10 +53,11 @@ impl CommandExecute for Install {
         let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
-        let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-            .wrap_err("Couldn't get manifest path")?;
-        let package_manifest = Manifest::from_path(&package_manifest_path)
-            .wrap_err("Couldn't parse manifest")?;
+        let package_manifest_path =
+            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                .wrap_err("Couldn't get manifest path")?;
+        let package_manifest =
+            Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
 
         let pg_config = match self.pg_config {
             None => PgConfig::from_path(),
@@ -60,7 +65,8 @@ impl CommandExecute for Install {
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
 
-        let features = crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
+        let features =
+            crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
 
         install_extension(
             self.manifest_path.as_ref(),
@@ -108,7 +114,12 @@ pub(crate) fn install_extension(
         ));
     }
 
-    let build_command_output = build_extension(user_manifest_path.as_ref(), user_package, is_release, &features)?;
+    let build_command_output = build_extension(
+        user_manifest_path.as_ref(),
+        user_package,
+        is_release,
+        &features,
+    )?;
     let build_command_bytes = build_command_output.stdout;
     let build_command_reader = BufReader::new(build_command_bytes.as_slice());
     let build_command_stream = cargo_metadata::Message::parse_stream(build_command_reader);
@@ -124,8 +135,18 @@ pub(crate) fn install_extension(
     {
         let mut dest = base_directory.clone();
         dest.push(&extdir);
-        dest.push(&control_file.file_name().ok_or_else(|| eyre!("Could not get filename for `{}`", control_file.display()))?);
-        copy_file(&control_file, &dest, "control file", true, &package_manifest_path)?;
+        dest.push(
+            &control_file
+                .file_name()
+                .ok_or_else(|| eyre!("Could not get filename for `{}`", control_file.display()))?,
+        );
+        copy_file(
+            &control_file,
+            &dest,
+            "control file",
+            true,
+            &package_manifest_path,
+        )?;
     }
 
     {
@@ -143,7 +164,13 @@ pub(crate) fn install_extension(
                 })?;
             }
         }
-        copy_file(&shlibpath, &dest, "shared library", false, &package_manifest_path)?;
+        copy_file(
+            &shlibpath,
+            &dest,
+            "shared library",
+            false,
+            &package_manifest_path,
+        )?;
     }
 
     copy_sql_files(
@@ -163,7 +190,13 @@ pub(crate) fn install_extension(
     Ok(())
 }
 
-fn copy_file(src: &PathBuf, dest: &PathBuf, msg: &str, do_filter: bool, package_manifest_path: impl AsRef<Path>) -> eyre::Result<()> {
+fn copy_file(
+    src: &PathBuf,
+    dest: &PathBuf,
+    msg: &str,
+    do_filter: bool,
+    package_manifest_path: impl AsRef<Path>,
+) -> eyre::Result<()> {
     if !dest.parent().unwrap().exists() {
         std::fs::create_dir_all(dest.parent().unwrap()).wrap_err_with(|| {
             format!(
@@ -218,7 +251,7 @@ pub(crate) fn build_extension(
         command.arg("--package");
         command.arg(user_package);
     }
-    
+
     if is_release {
         command.arg("--release");
     }
@@ -260,7 +293,11 @@ pub(crate) fn build_extension(
     }
 }
 
-fn get_target_sql_file(manifest_path: impl AsRef<Path>, extdir: &PathBuf, base_directory: &PathBuf) -> eyre::Result<PathBuf> {
+fn get_target_sql_file(
+    manifest_path: impl AsRef<Path>,
+    extdir: &PathBuf,
+    base_directory: &PathBuf,
+) -> eyre::Result<PathBuf> {
     let mut dest = base_directory.clone();
     dest.push(extdir);
 
@@ -311,7 +348,13 @@ fn copy_sql_files(
                     dest.push(extdir);
                     dest.push(filename);
 
-                    copy_file(&sql.path(), &dest, "extension schema upgrade file", true, &package_manifest_path)?;
+                    copy_file(
+                        &sql.path(),
+                        &dest,
+                        "extension schema upgrade file",
+                        true,
+                        &package_manifest_path,
+                    )?;
                 }
             }
         }

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     command::get::{find_control_file, get_property},

--- a/cargo-pgx/src/command/mod.rs
+++ b/cargo-pgx/src/command/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 pub(crate) mod connect;
 pub(crate) mod get;

--- a/cargo-pgx/src/command/mod.rs
+++ b/cargo-pgx/src/command/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 pub(crate) mod connect;
 pub(crate) mod get;

--- a/cargo-pgx/src/command/mod.rs
+++ b/cargo-pgx/src/command/mod.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 pub(crate) mod connect;
 pub(crate) mod get;

--- a/cargo-pgx/src/command/new.rs
+++ b/cargo-pgx/src/command/new.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use eyre::eyre;
 use std::{io::Write, path::PathBuf, str::FromStr};

--- a/cargo-pgx/src/command/new.rs
+++ b/cargo-pgx/src/command/new.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use eyre::eyre;
 use std::{io::Write, path::PathBuf, str::FromStr};

--- a/cargo-pgx/src/command/new.rs
+++ b/cargo-pgx/src/command/new.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use eyre::eyre;
 use std::{io::Write, path::PathBuf, str::FromStr};

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     command::{get::get_property, install::install_extension},

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -1,16 +1,20 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     command::{get::get_property, install::install_extension},
     CommandExecute,
 };
-use eyre::{eyre, WrapErr};
 use cargo_toml::Manifest;
+use eyre::{eyre, WrapErr};
 use pgx_utils::{get_target_dir, pg_config::PgConfig};
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 /// Create an installation package directory.
 #[derive(clap::Args, Debug)]
@@ -46,10 +50,11 @@ impl CommandExecute for Package {
         let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
-        let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-            .wrap_err("Couldn't get manifest path")?;
-        let package_manifest = Manifest::from_path(&package_manifest_path)
-            .wrap_err("Couldn't parse manifest")?;
+        let package_manifest_path =
+            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                .wrap_err("Couldn't get manifest path")?;
+        let package_manifest =
+            Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
 
         let pg_config = match self.pg_config {
             None => PgConfig::from_path(),
@@ -57,14 +62,24 @@ impl CommandExecute for Package {
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
 
-        let features = crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
-        
+        let features =
+            crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
+
         let out_dir = if let Some(out_dir) = self.out_dir {
             out_dir
         } else {
             build_base_path(&pg_config, &package_manifest_path, self.debug)?
         };
-        package_extension(self.manifest_path.as_ref(), self.package.as_ref(), &package_manifest_path, &pg_config, out_dir, self.debug, self.test, &features)
+        package_extension(
+            self.manifest_path.as_ref(),
+            self.package.as_ref(),
+            &package_manifest_path,
+            &pg_config,
+            out_dir,
+            self.debug,
+            self.test,
+            &features,
+        )
     }
 }
 
@@ -99,10 +114,15 @@ pub(crate) fn package_extension(
     )
 }
 
-fn build_base_path(pg_config: &PgConfig, manifest_path: impl AsRef<Path>, is_debug: bool) -> eyre::Result<PathBuf> {
+fn build_base_path(
+    pg_config: &PgConfig,
+    manifest_path: impl AsRef<Path>,
+    is_debug: bool,
+) -> eyre::Result<PathBuf> {
     let mut target_dir = get_target_dir()?;
     let pgver = pg_config.major_version()?;
-    let extname = get_property(manifest_path, "extname")?.ok_or(eyre!("could not determine extension name"))?;
+    let extname = get_property(manifest_path, "extname")?
+        .ok_or(eyre!("could not determine extension name"))?;
     target_dir.push(if is_debug { "debug" } else { "release" });
     target_dir.push(format!("{}-pg{}", extname, pgver));
     Ok(target_dir)

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     command::{get::get_property, install::install_extension},

--- a/cargo-pgx/src/command/pgx.rs
+++ b/cargo-pgx/src/command/pgx.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::CommandExecute;
 use owo_colors::OwoColorize;
 use std::path::Path;

--- a/cargo-pgx/src/command/pgx.rs
+++ b/cargo-pgx/src/command/pgx.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::CommandExecute;
 use owo_colors::OwoColorize;
 use std::path::Path;

--- a/cargo-pgx/src/command/pgx.rs
+++ b/cargo-pgx/src/command/pgx.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::CommandExecute;
 use owo_colors::OwoColorize;
 use std::path::Path;

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     command::{

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     command::{
@@ -9,14 +13,14 @@ use crate::{
     },
     CommandExecute,
 };
+use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use pgx_utils::{
     createdb,
     pg_config::{PgConfig, Pgx},
 };
-use cargo_toml::Manifest;
-use std::{path::Path, os::unix::process::CommandExt, process::Command};
+use std::{os::unix::process::CommandExt, path::Path, process::Command};
 /// Compile/install extension to a pgx-managed Postgres instance and start psql
 #[derive(clap::Args, Debug)]
 #[clap(author)]
@@ -47,10 +51,11 @@ impl CommandExecute for Run {
         let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
-        let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-            .wrap_err("Couldn't get manifest path")?;
-        let package_manifest = Manifest::from_path(&package_manifest_path)
-            .wrap_err("Couldn't parse manifest")?;
+        let package_manifest_path =
+            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                .wrap_err("Couldn't get manifest path")?;
+        let package_manifest =
+            Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
 
         let pgx = Pgx::from_config()?;
 
@@ -64,8 +69,9 @@ impl CommandExecute for Run {
                         }
                         // It's actually the dbname! We should infer from the manifest.
                         self.dbname = Some(pg_version);
-                        let default_pg_version = crate::manifest::default_pg_version(&package_manifest)
-                            .ok_or(eyre!("No provided `pg$VERSION` flag."))?;
+                        let default_pg_version =
+                            crate::manifest::default_pg_version(&package_manifest)
+                                .ok_or(eyre!("No provided `pg$VERSION` flag."))?;
                         (pgx.get(&default_pg_version)?, default_pg_version)
                     }
                 }
@@ -78,11 +84,13 @@ impl CommandExecute for Run {
             }
         };
 
-        let features = crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
+        let features =
+            crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
 
         let dbname = match self.dbname {
             Some(dbname) => dbname,
-            None => get_property(&package_manifest_path, "extname")?.ok_or(eyre!("could not determine extension name"))?,
+            None => get_property(&package_manifest_path, "extname")?
+                .ok_or(eyre!("could not determine extension name"))?,
         };
 
         run_psql(
@@ -105,7 +113,7 @@ impl CommandExecute for Run {
 pub(crate) fn run_psql(
     pg_config: &PgConfig,
     user_manifest_path: Option<impl AsRef<Path>>,
-    user_package: Option< &String>,
+    user_package: Option<&String>,
     package_manifest_path: impl AsRef<Path>,
     dbname: &str,
     is_release: bool,
@@ -116,7 +124,14 @@ pub(crate) fn run_psql(
 
     // install the extension
     install_extension(
-        user_manifest_path, user_package, package_manifest_path, pg_config, is_release, false, None, features,
+        user_manifest_path,
+        user_package,
+        package_manifest_path,
+        pg_config,
+        is_release,
+        false,
+        None,
+        features,
     )?;
 
     // restart postgres

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     command::{

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::{
     command::{
         get::{find_control_file, get_property},

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::{
     command::{
         get::{find_control_file, get_property},

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::{
     command::{
         get::{find_control_file, get_property},
@@ -9,6 +13,7 @@ use crate::{
     },
     CommandExecute,
 };
+use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
 use object::Object;
 use owo_colors::OwoColorize;
@@ -23,7 +28,6 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
-use cargo_toml::Manifest;
 // Since we support extensions with `#[no_std]`
 extern crate alloc;
 use alloc::vec::Vec;
@@ -70,10 +74,11 @@ impl CommandExecute for Schema {
         let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
-        let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-            .wrap_err("Couldn't get manifest path")?;
-        let package_manifest = Manifest::from_path(&package_manifest_path)
-            .wrap_err("Couldn't parse manifest")?;
+        let package_manifest_path =
+            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                .wrap_err("Couldn't get manifest path")?;
+        let package_manifest =
+            Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
 
         let log_level = if let Ok(log_level) = std::env::var("RUST_LOG") {
             Some(log_level)
@@ -105,7 +110,8 @@ impl CommandExecute for Schema {
             }
         };
 
-        let features = crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
+        let features =
+            crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
 
         generate_schema(
             &pg_config,
@@ -185,7 +191,7 @@ pub(crate) fn generate_schema(
             command.arg("--manifest-path");
             command.arg(user_manifest_path.as_ref());
         }
-        
+
         if is_release {
             command.arg("--release");
         }

--- a/cargo-pgx/src/command/start.rs
+++ b/cargo-pgx/src/command/start.rs
@@ -1,20 +1,20 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::command::init::initdb;
 use crate::command::status::status_postgres;
 use crate::CommandExecute;
+use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use pgx_utils::pg_config::{PgConfig, PgConfigSelector, Pgx};
-use std::{
-    os::unix::process::CommandExt,
-    process::Stdio,
-    path::PathBuf,
-};
-use cargo_toml::Manifest;
+use std::{os::unix::process::CommandExt, path::PathBuf, process::Stdio};
 
 /// Start a pgx-managed Postgres instance
 #[derive(clap::Args, Debug)]
@@ -41,14 +41,16 @@ impl CommandExecute for Start {
         let pg_version = match self.pg_version {
             Some(s) => s,
             None => {
-                let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-                    .wrap_err("couldn't get cargo metadata")?;
+                let metadata =
+                    crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
+                        .wrap_err("couldn't get cargo metadata")?;
                 crate::metadata::validate(&metadata)?;
-                let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                    .wrap_err("Couldn't get manifest path")?;
+                let package_manifest_path =
+                    crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                        .wrap_err("Couldn't get manifest path")?;
                 let package_manifest = Manifest::from_path(&package_manifest_path)
                     .wrap_err("Couldn't parse manifest")?;
-                
+
                 crate::manifest::default_pg_version(&package_manifest)
                     .ok_or(eyre!("no provided `pg$VERSION` flag."))?
             }

--- a/cargo-pgx/src/command/start.rs
+++ b/cargo-pgx/src/command/start.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::command::init::initdb;
 use crate::command::status::status_postgres;

--- a/cargo-pgx/src/command/start.rs
+++ b/cargo-pgx/src/command/start.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::command::init::initdb;
 use crate::command::status::status_postgres;

--- a/cargo-pgx/src/command/status.rs
+++ b/cargo-pgx/src/command/status.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use eyre::eyre;
 use owo_colors::OwoColorize;

--- a/cargo-pgx/src/command/status.rs
+++ b/cargo-pgx/src/command/status.rs
@@ -1,15 +1,16 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use eyre::eyre;
 use owo_colors::OwoColorize;
 use pgx_utils::pg_config::{PgConfig, PgConfigSelector, Pgx};
-use std::{
-    process::Stdio,
-    path::PathBuf,
-};
+use std::{path::PathBuf, process::Stdio};
 
 use crate::CommandExecute;
 

--- a/cargo-pgx/src/command/status.rs
+++ b/cargo-pgx/src/command/status.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use eyre::eyre;
 use owo_colors::OwoColorize;

--- a/cargo-pgx/src/command/stop.rs
+++ b/cargo-pgx/src/command/stop.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{command::status::status_postgres, CommandExecute};
 use owo_colors::OwoColorize;

--- a/cargo-pgx/src/command/stop.rs
+++ b/cargo-pgx/src/command/stop.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{command::status::status_postgres, CommandExecute};
 use owo_colors::OwoColorize;

--- a/cargo-pgx/src/command/stop.rs
+++ b/cargo-pgx/src/command/stop.rs
@@ -1,17 +1,18 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{command::status::status_postgres, CommandExecute};
-use owo_colors::OwoColorize;
-use pgx_utils::pg_config::{PgConfig, PgConfigSelector, Pgx};
 use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
-use std::{
-    path::PathBuf,
-    process::Stdio
-};
+use owo_colors::OwoColorize;
+use pgx_utils::pg_config::{PgConfig, PgConfigSelector, Pgx};
+use std::{path::PathBuf, process::Stdio};
 
 /// Stop a pgx-managed Postgres instance
 #[derive(clap::Args, Debug)]
@@ -38,11 +39,13 @@ impl CommandExecute for Stop {
         let pg_version = match self.pg_version {
             Some(s) => s,
             None => {
-                let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-                    .wrap_err("couldn't get cargo metadata")?;
+                let metadata =
+                    crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
+                        .wrap_err("couldn't get cargo metadata")?;
                 crate::metadata::validate(&metadata)?;
-                let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                    .wrap_err("Couldn't get manifest path")?;
+                let package_manifest_path =
+                    crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                        .wrap_err("Couldn't get manifest path")?;
                 let package_manifest = Manifest::from_path(&package_manifest_path)
                     .wrap_err("Couldn't parse manifest")?;
 

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use eyre::{eyre, WrapErr};
 use pgx_utils::{

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use eyre::{eyre, WrapErr};
 use pgx_utils::{

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -1,17 +1,21 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
 
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
 use pgx_utils::{
     get_target_dir,
     pg_config::{PgConfig, PgConfigSelector, Pgx},
 };
-use cargo_toml::Manifest;
 use std::{
+    path::{Path, PathBuf},
     process::{Command, Stdio},
-    path::{PathBuf, Path},
 };
 
 use crate::CommandExecute;
@@ -50,21 +54,21 @@ impl CommandExecute for Test {
     #[tracing::instrument(level = "error", skip(self))]
     fn execute(self) -> eyre::Result<()> {
         let pgx = Pgx::from_config()?;
-        
+
         let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
-        let package_manifest_path = crate::manifest::manifest_path(&metadata, self.package.as_ref())
-            .wrap_err("Couldn't get manifest path")?;
-        let package_manifest = Manifest::from_path(&package_manifest_path)
-            .wrap_err("Couldn't parse manifest")?;
+        let package_manifest_path =
+            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+                .wrap_err("Couldn't get manifest path")?;
+        let package_manifest =
+            Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
 
         let pg_version = match self.pg_version {
             Some(ref s) => s.clone(),
             None => crate::manifest::default_pg_version(&package_manifest)
                 .ok_or(eyre!("No provided `pg$VERSION` flag."))?,
         };
-
 
         for pg_config in pgx.iter(PgConfigSelector::new(&pg_version)) {
             let mut testname = self.testname.clone();
@@ -85,7 +89,11 @@ impl CommandExecute for Test {
             };
             let pg_version = format!("pg{}", pg_config.major_version()?);
 
-            let features = crate::manifest::features_for_version(self.features.clone(), &package_manifest, &pg_version);
+            let features = crate::manifest::features_for_version(
+                self.features.clone(),
+                &package_manifest,
+                &pg_version,
+            );
 
             test_extension(
                 pg_config,

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 mod command;
 mod manifest;

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 mod command;
 mod manifest;

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 mod command;
 mod manifest;

--- a/cargo-pgx/src/manifest.rs
+++ b/cargo-pgx/src/manifest.rs
@@ -1,25 +1,34 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use cargo_metadata::Metadata;
 use cargo_toml::Manifest;
 use eyre::eyre;
-use std::path::PathBuf;
 use pgx_utils::SUPPORTED_MAJOR_VERSIONS;
+use std::path::PathBuf;
 
 #[tracing::instrument(skip_all)]
-pub(crate) fn manifest_path(metadata: &Metadata, package_name: Option<&String>) -> eyre::Result<PathBuf> {
+pub(crate) fn manifest_path(
+    metadata: &Metadata,
+    package_name: Option<&String>,
+) -> eyre::Result<PathBuf> {
     let manifest_path = if let Some(package_name) = package_name {
-        let found = metadata.packages.iter()
+        let found = metadata
+            .packages
+            .iter()
             .find(|v| v.name == *package_name)
             .ok_or_else(|| eyre!("Could not find package `{}`", package_name))?;
         tracing::debug!(manifest_path = %found.manifest_path, "Found workspace package");
         found.manifest_path.clone().into_std_path_buf()
     } else {
-        let root = metadata
-            .root_package()
-            .ok_or(eyre!("`pgx` requires a root package in a workspace when `--package` is not specified."))?;
+        let root = metadata.root_package().ok_or(eyre!(
+            "`pgx` requires a root package in a workspace when `--package` is not specified."
+        ))?;
         tracing::debug!(manifest_path = %root.manifest_path, "Found root package");
         root.manifest_path.clone().into_std_path_buf()
     };

--- a/cargo-pgx/src/manifest.rs
+++ b/cargo-pgx/src/manifest.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use cargo_metadata::Metadata;
 use cargo_toml::Manifest;
 use eyre::eyre;

--- a/cargo-pgx/src/manifest.rs
+++ b/cargo-pgx/src/manifest.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use cargo_metadata::Metadata;
 use cargo_toml::Manifest;
 use eyre::eyre;

--- a/cargo-pgx/src/metadata.rs
+++ b/cargo-pgx/src/metadata.rs
@@ -1,13 +1,20 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use cargo_metadata::{Metadata, MetadataCommand};
 use eyre::eyre;
 use semver::{Version, VersionReq};
 use std::path::Path;
 
-pub fn metadata(features: &clap_cargo::Features, manifest_path: Option<impl AsRef<Path>>) -> eyre::Result<Metadata> {
+pub fn metadata(
+    features: &clap_cargo::Features,
+    manifest_path: Option<impl AsRef<Path>>,
+) -> eyre::Result<Metadata> {
     let mut metadata_command = MetadataCommand::new();
     if let Some(manifest_path) = manifest_path {
         metadata_command.manifest_path(manifest_path.as_ref().to_owned());

--- a/cargo-pgx/src/metadata.rs
+++ b/cargo-pgx/src/metadata.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use cargo_metadata::{Metadata, MetadataCommand};
 use eyre::eyre;
 use semver::{Version, VersionReq};

--- a/cargo-pgx/src/metadata.rs
+++ b/cargo-pgx/src/metadata.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use cargo_metadata::{Metadata, MetadataCommand};
 use eyre::eyre;
 use semver::{Version, VersionReq};

--- a/nix/templates/default/src/lib.rs
+++ b/nix/templates/default/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 
 pg_module_magic!();

--- a/nix/templates/default/src/lib.rs
+++ b/nix/templates/default/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 
 pg_module_magic!();

--- a/nix/templates/default/src/lib.rs
+++ b/nix/templates/default/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 
 pg_module_magic!();

--- a/pgx-examples/aggregate/src/lib.rs
+++ b/pgx-examples/aggregate/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::cstr_core::CStr;
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/aggregate/src/lib.rs
+++ b/pgx-examples/aggregate/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::cstr_core::CStr;
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/aggregate/src/lib.rs
+++ b/pgx-examples/aggregate/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::cstr_core::CStr;
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/arrays/src/lib.rs
+++ b/pgx-examples/arrays/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 use serde::*;

--- a/pgx-examples/arrays/src/lib.rs
+++ b/pgx-examples/arrays/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 use serde::*;

--- a/pgx-examples/arrays/src/lib.rs
+++ b/pgx-examples/arrays/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 use serde::*;

--- a/pgx-examples/bad_ideas/src/lib.rs
+++ b/pgx-examples/bad_ideas/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 use std::fs::File;
 use std::io::Write;

--- a/pgx-examples/bad_ideas/src/lib.rs
+++ b/pgx-examples/bad_ideas/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 use std::fs::File;
 use std::io::Write;

--- a/pgx-examples/bad_ideas/src/lib.rs
+++ b/pgx-examples/bad_ideas/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 use std::fs::File;
 use std::io::Write;

--- a/pgx-examples/bgworker/src/lib.rs
+++ b/pgx-examples/bgworker/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::bgworkers::*;
 use pgx::*;
 use std::time::Duration;

--- a/pgx-examples/bgworker/src/lib.rs
+++ b/pgx-examples/bgworker/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::bgworkers::*;
 use pgx::*;
 use std::time::Duration;

--- a/pgx-examples/bgworker/src/lib.rs
+++ b/pgx-examples/bgworker/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::bgworkers::*;
 use pgx::*;
 use std::time::Duration;

--- a/pgx-examples/bytea/src/lib.rs
+++ b/pgx-examples/bytea/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use libflate::gzip::{Decoder, Encoder};
 use pgx::*;

--- a/pgx-examples/bytea/src/lib.rs
+++ b/pgx-examples/bytea/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use libflate::gzip::{Decoder, Encoder};
 use pgx::*;

--- a/pgx-examples/bytea/src/lib.rs
+++ b/pgx-examples/bytea/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use libflate::gzip::{Decoder, Encoder};
 use pgx::*;

--- a/pgx-examples/custom_sql/sql/finalizer.sql
+++ b/pgx-examples/custom_sql/sql/finalizer.sql
@@ -1,5 +1,9 @@
 /*
-Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
-rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 INSERT INTO extension_sql VALUES ('finalizer');

--- a/pgx-examples/custom_sql/sql/finalizer.sql
+++ b/pgx-examples/custom_sql/sql/finalizer.sql
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
-this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
+rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 INSERT INTO extension_sql VALUES ('finalizer');

--- a/pgx-examples/custom_sql/sql/finalizer.sql
+++ b/pgx-examples/custom_sql/sql/finalizer.sql
@@ -1,1 +1,5 @@
+/*
+Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
+this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 INSERT INTO extension_sql VALUES ('finalizer');

--- a/pgx-examples/custom_sql/sql/multiple.sql
+++ b/pgx-examples/custom_sql/sql/multiple.sql
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
-this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
+rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 INSERT INTO extension_sql VALUES ('multiple');

--- a/pgx-examples/custom_sql/sql/multiple.sql
+++ b/pgx-examples/custom_sql/sql/multiple.sql
@@ -1,5 +1,9 @@
 /*
-Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
-rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 INSERT INTO extension_sql VALUES ('multiple');

--- a/pgx-examples/custom_sql/sql/multiple.sql
+++ b/pgx-examples/custom_sql/sql/multiple.sql
@@ -1,1 +1,5 @@
+/*
+Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
+this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 INSERT INTO extension_sql VALUES ('multiple');

--- a/pgx-examples/custom_sql/sql/single.sql
+++ b/pgx-examples/custom_sql/sql/single.sql
@@ -1,5 +1,9 @@
 /*
-Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
-rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 INSERT INTO extension_sql VALUES ('single');

--- a/pgx-examples/custom_sql/sql/single.sql
+++ b/pgx-examples/custom_sql/sql/single.sql
@@ -1,1 +1,5 @@
+/*
+Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
+this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 INSERT INTO extension_sql VALUES ('single');

--- a/pgx-examples/custom_sql/sql/single.sql
+++ b/pgx-examples/custom_sql/sql/single.sql
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
-this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
+rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 INSERT INTO extension_sql VALUES ('single');

--- a/pgx-examples/custom_sql/src/lib.rs
+++ b/pgx-examples/custom_sql/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/custom_sql/src/lib.rs
+++ b/pgx-examples/custom_sql/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/custom_sql/src/lib.rs
+++ b/pgx-examples/custom_sql/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/custom_types/src/complex.rs
+++ b/pgx-examples/custom_types/src/complex.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use maplit::*;
 use pgx::*;

--- a/pgx-examples/custom_types/src/complex.rs
+++ b/pgx-examples/custom_types/src/complex.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use maplit::*;
 use pgx::*;

--- a/pgx-examples/custom_types/src/complex.rs
+++ b/pgx-examples/custom_types/src/complex.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use maplit::*;
 use pgx::*;

--- a/pgx-examples/custom_types/src/fixed_size.rs
+++ b/pgx-examples/custom_types/src/fixed_size.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::cstr_core::CStr;
 use pgx::*;
 use std::str::FromStr;

--- a/pgx-examples/custom_types/src/fixed_size.rs
+++ b/pgx-examples/custom_types/src/fixed_size.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::cstr_core::CStr;
 use pgx::*;
 use std::str::FromStr;

--- a/pgx-examples/custom_types/src/fixed_size.rs
+++ b/pgx-examples/custom_types/src/fixed_size.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::cstr_core::CStr;
 use pgx::*;
 use std::str::FromStr;

--- a/pgx-examples/custom_types/src/generic_enum.rs
+++ b/pgx-examples/custom_types/src/generic_enum.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 use serde::*;

--- a/pgx-examples/custom_types/src/generic_enum.rs
+++ b/pgx-examples/custom_types/src/generic_enum.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 use serde::*;

--- a/pgx-examples/custom_types/src/generic_enum.rs
+++ b/pgx-examples/custom_types/src/generic_enum.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 use serde::*;

--- a/pgx-examples/custom_types/src/hstore_clone.rs
+++ b/pgx-examples/custom_types/src/hstore_clone.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use maplit::*;
 use pgx::*;

--- a/pgx-examples/custom_types/src/hstore_clone.rs
+++ b/pgx-examples/custom_types/src/hstore_clone.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use maplit::*;
 use pgx::*;

--- a/pgx-examples/custom_types/src/hstore_clone.rs
+++ b/pgx-examples/custom_types/src/hstore_clone.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use maplit::*;
 use pgx::*;

--- a/pgx-examples/custom_types/src/lib.rs
+++ b/pgx-examples/custom_types/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-examples/custom_types/src/lib.rs
+++ b/pgx-examples/custom_types/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-examples/custom_types/src/lib.rs
+++ b/pgx-examples/custom_types/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-examples/errors/src/lib.rs
+++ b/pgx-examples/errors/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-examples/errors/src/lib.rs
+++ b/pgx-examples/errors/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-examples/errors/src/lib.rs
+++ b/pgx-examples/errors/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-examples/nostd/src/lib.rs
+++ b/pgx-examples/nostd/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 //! This exists just to make sure we can compile various things under `#![no_std]`
 
 #![no_std]

--- a/pgx-examples/nostd/src/lib.rs
+++ b/pgx-examples/nostd/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 //! This exists just to make sure we can compile various things under `#![no_std]`
 
 #![no_std]

--- a/pgx-examples/nostd/src/lib.rs
+++ b/pgx-examples/nostd/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 //! This exists just to make sure we can compile various things under `#![no_std]`
 
 #![no_std]

--- a/pgx-examples/operators/src/derived.rs
+++ b/pgx-examples/operators/src/derived.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 use serde::{Deserialize, Serialize};
 

--- a/pgx-examples/operators/src/derived.rs
+++ b/pgx-examples/operators/src/derived.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 use serde::{Deserialize, Serialize};
 

--- a/pgx-examples/operators/src/derived.rs
+++ b/pgx-examples/operators/src/derived.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 use serde::{Deserialize, Serialize};
 

--- a/pgx-examples/operators/src/lib.rs
+++ b/pgx-examples/operators/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/operators/src/lib.rs
+++ b/pgx-examples/operators/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/operators/src/lib.rs
+++ b/pgx-examples/operators/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/schemas/src/lib.rs
+++ b/pgx-examples/schemas/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 /// All top-level pgx objects, **regardless** of the ".rs" file they're defined in, are created
 /// in the schema determined by `CREATE EXTENSION`.  It could be `public` (the default), or a
 /// user-specified schema. We have no idea what that is.

--- a/pgx-examples/schemas/src/lib.rs
+++ b/pgx-examples/schemas/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 /// All top-level pgx objects, **regardless** of the ".rs" file they're defined in, are created
 /// in the schema determined by `CREATE EXTENSION`.  It could be `public` (the default), or a
 /// user-specified schema. We have no idea what that is.

--- a/pgx-examples/schemas/src/lib.rs
+++ b/pgx-examples/schemas/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 /// All top-level pgx objects, **regardless** of the ".rs" file they're defined in, are created
 /// in the schema determined by `CREATE EXTENSION`.  It could be `public` (the default), or a
 /// user-specified schema. We have no idea what that is.

--- a/pgx-examples/shmem/src/lib.rs
+++ b/pgx-examples/shmem/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 use serde::*;
 use std::iter::Iterator;

--- a/pgx-examples/shmem/src/lib.rs
+++ b/pgx-examples/shmem/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 use serde::*;
 use std::iter::Iterator;

--- a/pgx-examples/shmem/src/lib.rs
+++ b/pgx-examples/shmem/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 use serde::*;
 use std::iter::Iterator;

--- a/pgx-examples/spi/src/lib.rs
+++ b/pgx-examples/spi/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 
 pg_module_magic!();

--- a/pgx-examples/spi/src/lib.rs
+++ b/pgx-examples/spi/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 
 pg_module_magic!();

--- a/pgx-examples/spi/src/lib.rs
+++ b/pgx-examples/spi/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 
 pg_module_magic!();

--- a/pgx-examples/srf/src/lib.rs
+++ b/pgx-examples/srf/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-examples/srf/src/lib.rs
+++ b/pgx-examples/srf/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-examples/srf/src/lib.rs
+++ b/pgx-examples/srf/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-examples/strings/src/lib.rs
+++ b/pgx-examples/strings/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-examples/strings/src/lib.rs
+++ b/pgx-examples/strings/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-examples/strings/src/lib.rs
+++ b/pgx-examples/strings/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-examples/triggers/src/lib.rs
+++ b/pgx-examples/triggers/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 
 pg_module_magic!();

--- a/pgx-examples/triggers/src/lib.rs
+++ b/pgx-examples/triggers/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 
 pg_module_magic!();

--- a/pgx-examples/triggers/src/lib.rs
+++ b/pgx-examples/triggers/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 
 pg_module_magic!();

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 extern crate proc_macro;
 

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 extern crate proc_macro;
 

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 extern crate proc_macro;
 

--- a/pgx-macros/src/operators.rs
+++ b/pgx-macros/src/operators.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx_utils::{
     operator_common::*,
     sql_entity_graph::{PostgresHash, PostgresOrd},

--- a/pgx-macros/src/operators.rs
+++ b/pgx-macros/src/operators.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx_utils::{
     operator_common::*,
     sql_entity_graph::{PostgresHash, PostgresOrd},

--- a/pgx-macros/src/operators.rs
+++ b/pgx-macros/src/operators.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx_utils::{
     operator_common::*,
     sql_entity_graph::{PostgresHash, PostgresOrd},

--- a/pgx-macros/src/rewriter.rs
+++ b/pgx-macros/src/rewriter.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 extern crate proc_macro;
 

--- a/pgx-macros/src/rewriter.rs
+++ b/pgx-macros/src/rewriter.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 extern crate proc_macro;
 

--- a/pgx-macros/src/rewriter.rs
+++ b/pgx-macros/src/rewriter.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 extern crate proc_macro;
 

--- a/pgx-macros/static/demo.sql
+++ b/pgx-macros/static/demo.sql
@@ -1,6 +1,10 @@
 /*
-Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
-rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 /*
 Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of

--- a/pgx-macros/static/demo.sql
+++ b/pgx-macros/static/demo.sql
@@ -1,6 +1,6 @@
 /*
-Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
-this source code is governed by the MIT license that can be found in the LICENSE file.
+Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>.  All
+rights reserved.  Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 /*
 Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of

--- a/pgx-macros/static/demo.sql
+++ b/pgx-macros/static/demo.sql
@@ -1,2 +1,9 @@
--- Example for extension_sql_file doctest.
+/*
+Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
+this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+/*
+Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
+this source code is governed by the MIT license that can be found in the LICENSE file.*//*Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc. <support@tcdi.com>. All rights reserved.  Use of
+this source code is governed by the MIT license that can be found in the LICENSE file.*/-- Example for extension_sql_file doctest.
 SELECT true;

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 extern crate build_deps;
 

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 extern crate build_deps;
 

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 extern crate build_deps;
 

--- a/pgx-pg-sys/cshim/Makefile
+++ b/pgx-pg-sys/cshim/Makefile
@@ -1,5 +1,6 @@
-# Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-# governed by the MIT license that can be found in the LICENSE file.
+# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+# by the MIT license that can be found in the LICENSE file.
 
 
 MODULE_big = pgx-cshim-${PG_TARGET_VERSION}

--- a/pgx-pg-sys/cshim/Makefile
+++ b/pgx-pg-sys/cshim/Makefile
@@ -1,7 +1,11 @@
-# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-# source code is governed by the MIT license that can be found in the LICENSE
-# file.
+# Portions Copyright 2019-2021 ZomboDB, LLC.
+# Portions Copyright 2021-2022 Technology Concepts & Design, Inc.
+# <support@tcdi.com>
+#
+# All rights reserved.
+#
+# Use of this source code is governed by the MIT license that can be found in
+# the LICENSE file.
 
 
 MODULE_big = pgx-cshim-${PG_TARGET_VERSION}

--- a/pgx-pg-sys/cshim/Makefile
+++ b/pgx-pg-sys/cshim/Makefile
@@ -1,6 +1,7 @@
-# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-# by the MIT license that can be found in the LICENSE file.
+# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+# source code is governed by the MIT license that can be found in the LICENSE
+# file.
 
 
 MODULE_big = pgx-cshim-${PG_TARGET_VERSION}

--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -1,8 +1,6 @@
-/*
- * Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
- * governed by the MIT license that can be found in the LICENSE file.
- */
-
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #include "postgres.h"
 
 #define IS_PG_10 (PG_VERSION_NUM >= 100000 && PG_VERSION_NUM < 110000)

--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #include "postgres.h"
 
 #define IS_PG_10 (PG_VERSION_NUM >= 100000 && PG_VERSION_NUM < 110000)

--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #include "postgres.h"
 
 #define IS_PG_10 (PG_VERSION_NUM >= 100000 && PG_VERSION_NUM < 110000)

--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #include <stdbool.h>
 #define USE_STDBOOL 1
 

--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #include <stdbool.h>
 #define USE_STDBOOL 1
 

--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #include <stdbool.h>
 #define USE_STDBOOL 1
 

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #include "postgres.h"
 #include "pg_config.h"
 #include "funcapi.h"

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //
 // we allow improper_ctypes just to eliminate these warnings:

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //
 // we allow improper_ctypes just to eliminate these warnings:

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //
 // we allow improper_ctypes just to eliminate these warnings:

--- a/pgx-pg-sys/src/pg10.rs
+++ b/pgx-pg-sys/src/pg10.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg10.rs
+++ b/pgx-pg-sys/src/pg10.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg10.rs
+++ b/pgx-pg-sys/src/pg10.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg10_oids.rs
+++ b/pgx-pg-sys/src/pg10_oids.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg10_oids.rs
+++ b/pgx-pg-sys/src/pg10_oids.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg10_oids.rs
+++ b/pgx-pg-sys/src/pg10_oids.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg11_oids.rs
+++ b/pgx-pg-sys/src/pg11_oids.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg11_oids.rs
+++ b/pgx-pg-sys/src/pg11_oids.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg11_oids.rs
+++ b/pgx-pg-sys/src/pg11_oids.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg12_oids.rs
+++ b/pgx-pg-sys/src/pg12_oids.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     HEAP_TABLE_AM_HANDLER_OID = crate::HEAP_TABLE_AM_HANDLER_OID as isize,

--- a/pgx-pg-sys/src/pg12_oids.rs
+++ b/pgx-pg-sys/src/pg12_oids.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     HEAP_TABLE_AM_HANDLER_OID = crate::HEAP_TABLE_AM_HANDLER_OID as isize,

--- a/pgx-pg-sys/src/pg12_oids.rs
+++ b/pgx-pg-sys/src/pg12_oids.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     HEAP_TABLE_AM_HANDLER_OID = crate::HEAP_TABLE_AM_HANDLER_OID as isize,

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg13_oids.rs
+++ b/pgx-pg-sys/src/pg13_oids.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg13_oids.rs
+++ b/pgx-pg-sys/src/pg13_oids.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg13_oids.rs
+++ b/pgx-pg-sys/src/pg13_oids.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 use crate::PgNode;
 use pgx_macros::*;

--- a/pgx-pg-sys/src/pg14_oids.rs
+++ b/pgx-pg-sys/src/pg14_oids.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg14_oids.rs
+++ b/pgx-pg-sys/src/pg14_oids.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/pg14_oids.rs
+++ b/pgx-pg-sys/src/pg14_oids.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum PgBuiltInOids {
     BOOLOID = crate::BOOLOID as isize,

--- a/pgx-pg-sys/src/submodules/guard.rs
+++ b/pgx-pg-sys/src/submodules/guard.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #![allow(non_snake_case)]
 

--- a/pgx-pg-sys/src/submodules/guard.rs
+++ b/pgx-pg-sys/src/submodules/guard.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #![allow(non_snake_case)]
 

--- a/pgx-pg-sys/src/submodules/guard.rs
+++ b/pgx-pg-sys/src/submodules/guard.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #![allow(non_snake_case)]
 

--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 pub mod guard;
 mod oids;

--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 pub mod guard;
 mod oids;

--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 pub mod guard;
 mod oids;

--- a/pgx-pg-sys/src/submodules/oids.rs
+++ b/pgx-pg-sys/src/submodules/oids.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #![allow(non_camel_case_types)]
 use crate as pg_sys;

--- a/pgx-pg-sys/src/submodules/oids.rs
+++ b/pgx-pg-sys/src/submodules/oids.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #![allow(non_camel_case_types)]
 use crate as pg_sys;

--- a/pgx-pg-sys/src/submodules/oids.rs
+++ b/pgx-pg-sys/src/submodules/oids.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #![allow(non_camel_case_types)]
 use crate as pg_sys;

--- a/pgx-pg-sys/src/submodules/tupdesc.rs
+++ b/pgx-pg-sys/src/submodules/tupdesc.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Provides helper implementations for various `TupleDesc`-related structs
 use crate::{name_data_to_str, PgOid};

--- a/pgx-pg-sys/src/submodules/tupdesc.rs
+++ b/pgx-pg-sys/src/submodules/tupdesc.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Provides helper implementations for various `TupleDesc`-related structs
 use crate::{name_data_to_str, PgOid};

--- a/pgx-pg-sys/src/submodules/tupdesc.rs
+++ b/pgx-pg-sys/src/submodules/tupdesc.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Provides helper implementations for various `TupleDesc`-related structs
 use crate::{name_data_to_str, PgOid};

--- a/pgx-pg-sys/src/submodules/utils.rs
+++ b/pgx-pg-sys/src/submodules/utils.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! General utility functions
 use crate as pg_sys;

--- a/pgx-pg-sys/src/submodules/utils.rs
+++ b/pgx-pg-sys/src/submodules/utils.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! General utility functions
 use crate as pg_sys;

--- a/pgx-pg-sys/src/submodules/utils.rs
+++ b/pgx-pg-sys/src/submodules/utils.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! General utility functions
 use crate as pg_sys;

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use std::process::{Command, Stdio};
 

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use std::process::{Command, Stdio};
 
@@ -260,7 +264,7 @@ fn install_extension() -> eyre::Result<()> {
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .env("CARGO_TARGET_DIR", get_target_dir()?);
-    
+
     if let Ok(manifest_path) = std::env::var("PGX_MANIFEST_PATH") {
         command.arg("--manifest-path");
         command.arg(manifest_path);

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use std::process::{Command, Stdio};
 

--- a/pgx-tests/src/lib.rs
+++ b/pgx-tests/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 mod framework;
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/lib.rs
+++ b/pgx-tests/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 mod framework;
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/lib.rs
+++ b/pgx-tests/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 mod framework;
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/tests/aggregate_tests.rs
+++ b/pgx-tests/src/tests/aggregate_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;

--- a/pgx-tests/src/tests/aggregate_tests.rs
+++ b/pgx-tests/src/tests/aggregate_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;

--- a/pgx-tests/src/tests/aggregate_tests.rs
+++ b/pgx-tests/src/tests/aggregate_tests.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;

--- a/pgx-tests/src/tests/anyarray_tests.rs
+++ b/pgx-tests/src/tests/anyarray_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/anyarray_tests.rs
+++ b/pgx-tests/src/tests/anyarray_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/anyarray_tests.rs
+++ b/pgx-tests/src/tests/anyarray_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 use serde_json::*;

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 use serde_json::*;

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 use serde_json::*;

--- a/pgx-tests/src/tests/bytea_tests.rs
+++ b/pgx-tests/src/tests/bytea_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/bytea_tests.rs
+++ b/pgx-tests/src/tests/bytea_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/bytea_tests.rs
+++ b/pgx-tests/src/tests/bytea_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/cfg_tests.rs
+++ b/pgx-tests/src/tests/cfg_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/tests/cfg_tests.rs
+++ b/pgx-tests/src/tests/cfg_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/tests/cfg_tests.rs
+++ b/pgx-tests/src/tests/cfg_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 use std::convert::TryFrom;

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 use std::convert::TryFrom;

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 use std::convert::TryFrom;

--- a/pgx-tests/src/tests/default_arg_value_tests.rs
+++ b/pgx-tests/src/tests/default_arg_value_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/default_arg_value_tests.rs
+++ b/pgx-tests/src/tests/default_arg_value_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/default_arg_value_tests.rs
+++ b/pgx-tests/src/tests/default_arg_value_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/derive_pgtype_lifetimes.rs
+++ b/pgx-tests/src/tests/derive_pgtype_lifetimes.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #![allow(dead_code)]
 /// the purpose of this test is to just make sure this code compiles!

--- a/pgx-tests/src/tests/derive_pgtype_lifetimes.rs
+++ b/pgx-tests/src/tests/derive_pgtype_lifetimes.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #![allow(dead_code)]
 /// the purpose of this test is to just make sure this code compiles!

--- a/pgx-tests/src/tests/derive_pgtype_lifetimes.rs
+++ b/pgx-tests/src/tests/derive_pgtype_lifetimes.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #![allow(dead_code)]
 /// the purpose of this test is to just make sure this code compiles!

--- a/pgx-tests/src/tests/enum_type_tests.rs
+++ b/pgx-tests/src/tests/enum_type_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/enum_type_tests.rs
+++ b/pgx-tests/src/tests/enum_type_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/enum_type_tests.rs
+++ b/pgx-tests/src/tests/enum_type_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/fcinfo_tests.rs
+++ b/pgx-tests/src/tests/fcinfo_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/fcinfo_tests.rs
+++ b/pgx-tests/src/tests/fcinfo_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/fcinfo_tests.rs
+++ b/pgx-tests/src/tests/fcinfo_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/guc_tests.rs
+++ b/pgx-tests/src/tests/guc_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/guc_tests.rs
+++ b/pgx-tests/src/tests/guc_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/guc_tests.rs
+++ b/pgx-tests/src/tests/guc_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/hooks_tests.rs
+++ b/pgx-tests/src/tests/hooks_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/hooks_tests.rs
+++ b/pgx-tests/src/tests/hooks_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/hooks_tests.rs
+++ b/pgx-tests/src/tests/hooks_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/inet_tests.rs
+++ b/pgx-tests/src/tests/inet_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/inet_tests.rs
+++ b/pgx-tests/src/tests/inet_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/inet_tests.rs
+++ b/pgx-tests/src/tests/inet_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/internal_tests.rs
+++ b/pgx-tests/src/tests/internal_tests.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {

--- a/pgx-tests/src/tests/internal_tests.rs
+++ b/pgx-tests/src/tests/internal_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {

--- a/pgx-tests/src/tests/internal_tests.rs
+++ b/pgx-tests/src/tests/internal_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {

--- a/pgx-tests/src/tests/json_tests.rs
+++ b/pgx-tests/src/tests/json_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/json_tests.rs
+++ b/pgx-tests/src/tests/json_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/json_tests.rs
+++ b/pgx-tests/src/tests/json_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/lifetime_tests.rs
+++ b/pgx-tests/src/tests/lifetime_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 //! This file exists just to ensure the code within compiles
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-tests/src/tests/lifetime_tests.rs
+++ b/pgx-tests/src/tests/lifetime_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 //! This file exists just to ensure the code within compiles
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-tests/src/tests/lifetime_tests.rs
+++ b/pgx-tests/src/tests/lifetime_tests.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 //! This file exists just to ensure the code within compiles
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-tests/src/tests/log_tests.rs
+++ b/pgx-tests/src/tests/log_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/log_tests.rs
+++ b/pgx-tests/src/tests/log_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/log_tests.rs
+++ b/pgx-tests/src/tests/log_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 mod aggregate_tests;
 mod anyarray_tests;

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 mod aggregate_tests;
 mod anyarray_tests;

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 mod aggregate_tests;
 mod anyarray_tests;

--- a/pgx-tests/src/tests/name_tests.rs
+++ b/pgx-tests/src/tests/name_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 
 #[pg_extern(name = "renamed_func")]

--- a/pgx-tests/src/tests/name_tests.rs
+++ b/pgx-tests/src/tests/name_tests.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 
 #[pg_extern(name = "renamed_func")]

--- a/pgx-tests/src/tests/name_tests.rs
+++ b/pgx-tests/src/tests/name_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 
 #[pg_extern(name = "renamed_func")]

--- a/pgx-tests/src/tests/numeric_tests.rs
+++ b/pgx-tests/src/tests/numeric_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/numeric_tests.rs
+++ b/pgx-tests/src/tests/numeric_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/numeric_tests.rs
+++ b/pgx-tests/src/tests/numeric_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/pg_try_tests.rs
+++ b/pgx-tests/src/tests/pg_try_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/pg_try_tests.rs
+++ b/pgx-tests/src/tests/pg_try_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/pg_try_tests.rs
+++ b/pgx-tests/src/tests/pg_try_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/pgbox_tests.rs
+++ b/pgx-tests/src/tests/pgbox_tests.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {

--- a/pgx-tests/src/tests/pgbox_tests.rs
+++ b/pgx-tests/src/tests/pgbox_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {

--- a/pgx-tests/src/tests/pgbox_tests.rs
+++ b/pgx-tests/src/tests/pgbox_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {

--- a/pgx-tests/src/tests/postgres_type_tests.rs
+++ b/pgx-tests/src/tests/postgres_type_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::cstr_core::CStr;
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-tests/src/tests/postgres_type_tests.rs
+++ b/pgx-tests/src/tests/postgres_type_tests.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::cstr_core::CStr;
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-tests/src/tests/postgres_type_tests.rs
+++ b/pgx-tests/src/tests/postgres_type_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::cstr_core::CStr;
 use pgx::*;
 use serde::{Deserialize, Serialize};

--- a/pgx-tests/src/tests/schema_tests.rs
+++ b/pgx-tests/src/tests/schema_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/schema_tests.rs
+++ b/pgx-tests/src/tests/schema_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/schema_tests.rs
+++ b/pgx-tests/src/tests/schema_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::*;
 

--- a/pgx-tests/src/tests/struct_type_tests.rs
+++ b/pgx-tests/src/tests/struct_type_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use pgx::stringinfo::StringInfo;
 use pgx::*;

--- a/pgx-tests/src/tests/struct_type_tests.rs
+++ b/pgx-tests/src/tests/struct_type_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use pgx::stringinfo::StringInfo;
 use pgx::*;

--- a/pgx-tests/src/tests/struct_type_tests.rs
+++ b/pgx-tests/src/tests/struct_type_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use pgx::stringinfo::StringInfo;
 use pgx::*;

--- a/pgx-tests/src/tests/uuid_tests.rs
+++ b/pgx-tests/src/tests/uuid_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use pgx::*;
 
 pub const TEST_UUID_V4: UuidBytes = [

--- a/pgx-tests/src/tests/uuid_tests.rs
+++ b/pgx-tests/src/tests/uuid_tests.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use pgx::*;
 
 pub const TEST_UUID_V4: UuidBytes = [

--- a/pgx-tests/src/tests/uuid_tests.rs
+++ b/pgx-tests/src/tests/uuid_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use pgx::*;
 
 pub const TEST_UUID_V4: UuidBytes = [

--- a/pgx-tests/src/tests/variadic_tests.rs
+++ b/pgx-tests/src/tests/variadic_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[pgx::pg_schema]
 mod test {

--- a/pgx-tests/src/tests/variadic_tests.rs
+++ b/pgx-tests/src/tests/variadic_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[pgx::pg_schema]
 mod test {

--- a/pgx-tests/src/tests/variadic_tests.rs
+++ b/pgx-tests/src/tests/variadic_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[pgx::pg_schema]
 mod test {

--- a/pgx-tests/src/tests/xact_callback_tests.rs
+++ b/pgx-tests/src/tests/xact_callback_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/xact_callback_tests.rs
+++ b/pgx-tests/src/tests/xact_callback_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/xact_callback_tests.rs
+++ b/pgx-tests/src/tests/xact_callback_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/xid64_tests.rs
+++ b/pgx-tests/src/tests/xid64_tests.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/xid64_tests.rs
+++ b/pgx-tests/src/tests/xid64_tests.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-tests/src/tests/xid64_tests.rs
+++ b/pgx-tests/src/tests/xid64_tests.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_config::PgConfig, sql_entity_graph::PositioningRef};
 use eyre::{eyre, WrapErr};

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_config::PgConfig, sql_entity_graph::PositioningRef};
 use eyre::{eyre, WrapErr};

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_config::PgConfig, sql_entity_graph::PositioningRef};
 use eyre::{eyre, WrapErr};

--- a/pgx-utils/src/operator_common.rs
+++ b/pgx-utils/src/operator_common.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use proc_macro2::Ident;
 use quote::quote;
 

--- a/pgx-utils/src/operator_common.rs
+++ b/pgx-utils/src/operator_common.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use proc_macro2::Ident;
 use quote::quote;
 

--- a/pgx-utils/src/operator_common.rs
+++ b/pgx-utils/src/operator_common.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use proc_macro2::Ident;
 use quote::quote;
 

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 //! Wrapper around Postgres' `pg_config` command-line tool
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 //! Wrapper around Postgres' `pg_config` command-line tool
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 //! Wrapper around Postgres' `pg_config` command-line tool
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;

--- a/pgx-utils/src/pgx_pg_sys_stub/mod.rs
+++ b/pgx-utils/src/pgx_pg_sys_stub/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use std::{collections::HashSet, fs::File, io::Write, path::Path};
 use syn::{parse_quote, Ident, Item};
 

--- a/pgx-utils/src/pgx_pg_sys_stub/mod.rs
+++ b/pgx-utils/src/pgx_pg_sys_stub/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use std::{collections::HashSet, fs::File, io::Write, path::Path};
 use syn::{parse_quote, Ident, Item};
 

--- a/pgx-utils/src/pgx_pg_sys_stub/mod.rs
+++ b/pgx-utils/src/pgx_pg_sys_stub/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use std::{collections::HashSet, fs::File, io::Write, path::Path};
 use syn::{parse_quote, Ident, Item};
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/aggregate_type.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/aggregate_type.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use super::get_pgx_attr_macro;
 use crate::sql_entity_graph::NameMacro;
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/aggregate_type.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/aggregate_type.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use super::get_pgx_attr_macro;
 use crate::sql_entity_graph::NameMacro;
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/aggregate_type.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/aggregate_type.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use super::get_pgx_attr_macro;
 use crate::sql_entity_graph::NameMacro;
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{
     aggregate::options::{FinalizeModify, ParallelOption},
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{
     aggregate::options::{FinalizeModify, ParallelOption},
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{
     aggregate::options::{FinalizeModify, ParallelOption},
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/aggregate/maybe_variadic_type.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/maybe_variadic_type.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use super::get_pgx_attr_macro;
 use crate::sql_entity_graph::pg_extern::NameMacro;
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/maybe_variadic_type.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/maybe_variadic_type.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use super::get_pgx_attr_macro;
 use crate::sql_entity_graph::pg_extern::NameMacro;
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/maybe_variadic_type.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/maybe_variadic_type.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use super::get_pgx_attr_macro;
 use crate::sql_entity_graph::pg_extern::NameMacro;
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 mod aggregate_type;
 pub(crate) mod entity;
 mod maybe_variadic_type;

--- a/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 mod aggregate_type;
 pub(crate) mod entity;
 mod maybe_variadic_type;

--- a/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 mod aggregate_type;
 pub(crate) mod entity;
 mod maybe_variadic_type;

--- a/pgx-utils/src/sql_entity_graph/aggregate/options.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/options.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{PgxSql, ToSql};
 
 /// Corresponds to the `PARALLEL` and `MFINALFUNC_MODIFY` in [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html).

--- a/pgx-utils/src/sql_entity_graph/aggregate/options.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/options.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{PgxSql, ToSql};
 
 /// Corresponds to the `PARALLEL` and `MFINALFUNC_MODIFY` in [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html).

--- a/pgx-utils/src/sql_entity_graph/aggregate/options.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/options.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{PgxSql, ToSql};
 
 /// Corresponds to the `PARALLEL` and `MFINALFUNC_MODIFY` in [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html).

--- a/pgx-utils/src/sql_entity_graph/control_file.rs
+++ b/pgx-utils/src/sql_entity_graph/control_file.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
 use core::convert::TryFrom;
 use std::collections::HashMap;

--- a/pgx-utils/src/sql_entity_graph/control_file.rs
+++ b/pgx-utils/src/sql_entity_graph/control_file.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
 use core::convert::TryFrom;
 use std::collections::HashMap;

--- a/pgx-utils/src/sql_entity_graph/control_file.rs
+++ b/pgx-utils/src/sql_entity_graph/control_file.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
 use core::convert::TryFrom;
 use std::collections::HashMap;

--- a/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{
     extension_sql::SqlDeclared, pgx_sql::PgxSql, positioning_ref::PositioningRef, to_sql::ToSql,
     SqlGraphEntity, SqlGraphIdentifier,

--- a/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{
     extension_sql::SqlDeclared, pgx_sql::PgxSql, positioning_ref::PositioningRef, to_sql::ToSql,
     SqlGraphEntity, SqlGraphIdentifier,

--- a/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{
     extension_sql::SqlDeclared, pgx_sql::PgxSql, positioning_ref::PositioningRef, to_sql::ToSql,
     SqlGraphEntity, SqlGraphIdentifier,

--- a/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub mod entity;
 
 use crate::sql_entity_graph::positioning_ref::PositioningRef;

--- a/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub mod entity;
 
 use crate::sql_entity_graph::positioning_ref::PositioningRef;

--- a/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub mod entity;
 
 use crate::sql_entity_graph::positioning_ref::PositioningRef;

--- a/pgx-utils/src/sql_entity_graph/mapping.rs
+++ b/pgx-utils/src/sql_entity_graph/mapping.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use core::any::TypeId;
 
 /// A mapping from a Rust type to a SQL type, with a `TypeId`.

--- a/pgx-utils/src/sql_entity_graph/mapping.rs
+++ b/pgx-utils/src/sql_entity_graph/mapping.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use core::any::TypeId;
 
 /// A mapping from a Rust type to a SQL type, with a `TypeId`.

--- a/pgx-utils/src/sql_entity_graph/mapping.rs
+++ b/pgx-utils/src/sql_entity_graph/mapping.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use core::any::TypeId;
 
 /// A mapping from a Rust type to a SQL type, with a `TypeId`.

--- a/pgx-utils/src/sql_entity_graph/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub(crate) mod aggregate;
 pub(crate) mod control_file;
 pub(crate) mod extension_sql;

--- a/pgx-utils/src/sql_entity_graph/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub(crate) mod aggregate;
 pub(crate) mod control_file;
 pub(crate) mod extension_sql;

--- a/pgx-utils/src/sql_entity_graph/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub(crate) mod aggregate;
 pub(crate) mod control_file;
 pub(crate) mod extension_sql;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use std::ops::Deref;
 
 use crate::anonymonize_lifetimes;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use std::ops::Deref;
 
 use crate::anonymonize_lifetimes;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/argument.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use std::ops::Deref;
 
 use crate::anonymonize_lifetimes;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{positioning_ref::PositioningRef, to_sql::ToSqlConfig};
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{positioning_ref::PositioningRef, to_sql::ToSqlConfig};
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{positioning_ref::PositioningRef, to_sql::ToSqlConfig};
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/argument.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/argument.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::SqlGraphIdentifier;
 
 /// The output of a [`PgExternArgument`](crate::sql_entity_graph::PgExternArgument) from `quote::ToTokens::to_tokens`.

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/argument.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/argument.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::SqlGraphIdentifier;
 
 /// The output of a [`PgExternArgument`](crate::sql_entity_graph::PgExternArgument) from `quote::ToTokens::to_tokens`.

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/argument.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/argument.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::SqlGraphIdentifier;
 
 /// The output of a [`PgExternArgument`](crate::sql_entity_graph::PgExternArgument) from `quote::ToTokens::to_tokens`.

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 mod argument;
 mod operator;
 mod returning;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 mod argument;
 mod operator;
 mod returning;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 mod argument;
 mod operator;
 mod returning;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/operator.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/operator.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use serde::{Deserialize, Serialize};
 
 /// The output of a [`PgOperator`](crate::sql_entity_graph::PgOperator) from `quote::ToTokens::to_tokens`.

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/operator.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/operator.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use serde::{Deserialize, Serialize};
 
 /// The output of a [`PgOperator`](crate::sql_entity_graph::PgOperator) from `quote::ToTokens::to_tokens`.

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/operator.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/operator.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use serde::{Deserialize, Serialize};
 
 /// The output of a [`PgOperator`](crate::sql_entity_graph::PgOperator) from `quote::ToTokens::to_tokens`.

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/returning.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/returning.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use core::any::TypeId;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/returning.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/returning.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use core::any::TypeId;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/returning.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/returning.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use core::any::TypeId;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 mod argument;
 mod attribute;
 pub mod entity;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 mod argument;
 mod attribute;
 pub mod entity;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 mod argument;
 mod attribute;
 pub mod entity;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/operator.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/operator.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseBuffer};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/operator.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/operator.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseBuffer};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/operator.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/operator.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseBuffer};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/returning.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/returning.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::{anonymonize_lifetimes, anonymonize_lifetimes_in_type_path};
 use eyre::eyre;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/returning.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/returning.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::{anonymonize_lifetimes, anonymonize_lifetimes_in_type_path};
 use eyre::eyre;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/returning.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/returning.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::{anonymonize_lifetimes, anonymonize_lifetimes_in_type_path};
 use eyre::eyre;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/pg_extern/search_path.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/search_path.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::{

--- a/pgx-utils/src/sql_entity_graph/pg_extern/search_path.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/search_path.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::{

--- a/pgx-utils/src/sql_entity_graph/pg_extern/search_path.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/search_path.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::{

--- a/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use syn::parse::{Parse, ParseStream};
 use syn::{parenthesized, punctuated::Punctuated};
 use syn::{token, Token};

--- a/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use syn::parse::{Parse, ParseStream};
 use syn::{parenthesized, punctuated::Punctuated};
 use syn::{token, Token};

--- a/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_attribute.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use syn::parse::{Parse, ParseStream};
 use syn::{parenthesized, punctuated::Punctuated};
 use syn::{token, Token};

--- a/pgx-utils/src/sql_entity_graph/pgx_sql.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_sql.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use eyre::{eyre, WrapErr};
 use std::{any::TypeId, collections::HashMap, fmt::Debug, path::Path};
 

--- a/pgx-utils/src/sql_entity_graph/pgx_sql.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_sql.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use eyre::{eyre, WrapErr};
 use std::{any::TypeId, collections::HashMap, fmt::Debug, path::Path};
 

--- a/pgx-utils/src/sql_entity_graph/pgx_sql.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_sql.rs
@@ -1,13 +1,17 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use eyre::{eyre, WrapErr};
 use std::{any::TypeId, collections::HashMap, fmt::Debug, path::Path};
 
+use owo_colors::{OwoColorize, XtermColors};
 use petgraph::{dot::Dot, graph::NodeIndex, stable_graph::StableGraph};
 use tracing::instrument;
-use owo_colors::{OwoColorize, XtermColors};
 
 use crate::sql_entity_graph::{
     aggregate::entity::PgAggregateEntity,
@@ -275,7 +279,11 @@ impl PgxSql {
                         if style.foreground.a == 0x01 {
                             write!(*out, "{}", content)?;
                         } else {
-                            write!(*out, "{}", content.color(XtermColors::from(style.foreground.r)))?;
+                            write!(
+                                *out,
+                                "{}",
+                                content.color(XtermColors::from(style.foreground.r))
+                            )?;
                         }
                     }
                     write!(*out, "\x1b[0m")?;

--- a/pgx-utils/src/sql_entity_graph/positioning_ref.rs
+++ b/pgx-utils/src/sql_entity_graph/positioning_ref.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use quote::{quote, ToTokens};
 use std::fmt::Display;
 use syn::parse::{Parse, ParseStream};

--- a/pgx-utils/src/sql_entity_graph/positioning_ref.rs
+++ b/pgx-utils/src/sql_entity_graph/positioning_ref.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use quote::{quote, ToTokens};
 use std::fmt::Display;
 use syn::parse::{Parse, ParseStream};

--- a/pgx-utils/src/sql_entity_graph/positioning_ref.rs
+++ b/pgx-utils/src/sql_entity_graph/positioning_ref.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use quote::{quote, ToTokens};
 use std::fmt::Display;
 use syn::parse::{Parse, ParseStream};

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{
     mapping::RustSqlMapping,
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{
     mapping::RustSqlMapping,
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{
     mapping::RustSqlMapping,
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub mod entity;
 
 use crate::sql_entity_graph::ToSqlConfig;

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub mod entity;
 
 use crate::sql_entity_graph::ToSqlConfig;

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub mod entity;
 
 use crate::sql_entity_graph::ToSqlConfig;

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{
     pgx_sql::PgxSql,
     to_sql::{entity::ToSqlConfigEntity, ToSql},

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{
     pgx_sql::PgxSql,
     to_sql::{entity::ToSqlConfigEntity, ToSql},

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{
     pgx_sql::PgxSql,
     to_sql::{entity::ToSqlConfigEntity, ToSql},

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{
     pgx_sql::PgxSql,
     to_sql::{entity::ToSqlConfigEntity, ToSql},

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{
     pgx_sql::PgxSql,
     to_sql::{entity::ToSqlConfigEntity, ToSql},

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{
     pgx_sql::PgxSql,
     to_sql::{entity::ToSqlConfigEntity, ToSql},

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{
     mapping::RustSqlMapping,
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{
     mapping::RustSqlMapping,
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{
     mapping::RustSqlMapping,
     pgx_sql::PgxSql,

--- a/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub mod entity;
 
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub mod entity;
 
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub mod entity;
 
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/schema/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{pgx_sql::PgxSql, to_sql::ToSql, SqlGraphEntity, SqlGraphIdentifier};
 
 use std::cmp::Ordering;

--- a/pgx-utils/src/sql_entity_graph/schema/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{pgx_sql::PgxSql, to_sql::ToSql, SqlGraphEntity, SqlGraphIdentifier};
 
 use std::cmp::Ordering;

--- a/pgx-utils/src/sql_entity_graph/schema/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{pgx_sql::PgxSql, to_sql::ToSql, SqlGraphEntity, SqlGraphIdentifier};
 
 use std::cmp::Ordering;

--- a/pgx-utils/src/sql_entity_graph/schema/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/schema/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/schema/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub mod entity;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::sql_entity_graph::{pgx_sql::PgxSql, to_sql::ToSqlFn, SqlGraphEntity};
 
 /// Represents configuration options for tuning the SQL generator.

--- a/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::sql_entity_graph::{pgx_sql::PgxSql, to_sql::ToSqlFn, SqlGraphEntity};
 
 /// Represents configuration options for tuning the SQL generator.

--- a/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::sql_entity_graph::{pgx_sql::PgxSql, to_sql::ToSqlFn, SqlGraphEntity};
 
 /// Represents configuration options for tuning the SQL generator.

--- a/pgx-utils/src/sql_entity_graph/to_sql/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 pub mod entity;
 
 use std::hash::Hash;

--- a/pgx-utils/src/sql_entity_graph/to_sql/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 pub mod entity;
 
 use std::hash::Hash;

--- a/pgx-utils/src/sql_entity_graph/to_sql/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 pub mod entity;
 
 use std::hash::Hash;

--- a/pgx/src/aggregate.rs
+++ b/pgx/src/aggregate.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 /*!
 
 [Aggregate](https://www.postgresql.org/docs/current/xaggr.html) support.

--- a/pgx/src/aggregate.rs
+++ b/pgx/src/aggregate.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 /*!
 
 [Aggregate](https://www.postgresql.org/docs/current/xaggr.html) support.

--- a/pgx/src/aggregate.rs
+++ b/pgx/src/aggregate.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 /*!
 
 [Aggregate](https://www.postgresql.org/docs/current/xaggr.html) support.

--- a/pgx/src/atomics.rs
+++ b/pgx/src/atomics.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use once_cell::sync::OnceCell;
 
 pub struct PgAtomic<T> {

--- a/pgx/src/atomics.rs
+++ b/pgx/src/atomics.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use once_cell::sync::OnceCell;
 
 pub struct PgAtomic<T> {

--- a/pgx/src/atomics.rs
+++ b/pgx/src/atomics.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use once_cell::sync::OnceCell;
 
 pub struct PgAtomic<T> {

--- a/pgx/src/bgworkers.rs
+++ b/pgx/src/bgworkers.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Safely create Postgres Background Workers, including with full SPI support
 //!

--- a/pgx/src/bgworkers.rs
+++ b/pgx/src/bgworkers.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Safely create Postgres Background Workers, including with full SPI support
 //!

--- a/pgx/src/bgworkers.rs
+++ b/pgx/src/bgworkers.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Safely create Postgres Background Workers, including with full SPI support
 //!

--- a/pgx/src/callbacks.rs
+++ b/pgx/src/callbacks.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Provides safe wrappers around Postgres' "Transaction" and "Sub Transaction" hook system
 

--- a/pgx/src/callbacks.rs
+++ b/pgx/src/callbacks.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Provides safe wrappers around Postgres' "Transaction" and "Sub Transaction" hook system
 

--- a/pgx/src/callbacks.rs
+++ b/pgx/src/callbacks.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Provides safe wrappers around Postgres' "Transaction" and "Sub Transaction" hook system
 

--- a/pgx/src/datum/anyarray.rs
+++ b/pgx/src/datum/anyarray.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/anyarray.rs
+++ b/pgx/src/datum/anyarray.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/anyarray.rs
+++ b/pgx/src/datum/anyarray.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_sys, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts};
 use serde::Serializer;

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_sys, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts};
 use serde::Serializer;

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_sys, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts};
 use serde::Serializer;

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! for converting a pg_sys::Datum and a corresponding "is_null" bool into a typed Option
 

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! for converting a pg_sys::Datum and a corresponding "is_null" bool into a typed Option
 

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! for converting a pg_sys::Datum and a corresponding "is_null" bool into a typed Option
 

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, pg_try, void_mut_ptr, FromDatum,

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, pg_try, void_mut_ptr, FromDatum,

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, pg_try, void_mut_ptr, FromDatum,

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! for converting primitive types into Datums
 //!

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! for converting primitive types into Datums
 //!

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! for converting primitive types into Datums
 //!

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     item_pointer_get_both, item_pointer_set_all, pg_sys, FromDatum, IntoDatum, PgMemoryContexts,

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     item_pointer_get_both, item_pointer_set_all, pg_sys, FromDatum, IntoDatum, PgMemoryContexts,

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     item_pointer_get_both, item_pointer_set_all, pg_sys, FromDatum, IntoDatum, PgMemoryContexts,

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, vardata_any, varsize_any_exhdr,

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, vardata_any, varsize_any_exhdr,

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, vardata_any, varsize_any_exhdr,

--- a/pgx/src/datum/mod.rs
+++ b/pgx/src/datum/mod.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Handing for easily converting Postgres Datum types into their corresponding Rust types
 //! and converting Rust types into their corresponding Postgres types

--- a/pgx/src/datum/mod.rs
+++ b/pgx/src/datum/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Handing for easily converting Postgres Datum types into their corresponding Rust types
 //! and converting Rust types into their corresponding Postgres types

--- a/pgx/src/datum/mod.rs
+++ b/pgx/src/datum/mod.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Handing for easily converting Postgres Datum types into their corresponding Rust types
 //! and converting Rust types into their corresponding Postgres types

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, void_mut_ptr, FromDatum, IntoDatum,

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, void_mut_ptr, FromDatum, IntoDatum,

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{
     direct_function_call, direct_function_call_as_datum, pg_sys, void_mut_ptr, FromDatum, IntoDatum,

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum, TimestampWithTimeZone};

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum, TimestampWithTimeZone};

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum, TimestampWithTimeZone};

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::datum::time::Time;
 use crate::{pg_sys, FromDatum, IntoDatum, PgBox};

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::datum::time::Time;
 use crate::{pg_sys, FromDatum, IntoDatum, PgBox};

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::datum::time::Time;
 use crate::{pg_sys, FromDatum, IntoDatum, PgBox};

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::{pg_sys, FromDatum, IntoDatum};
 

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 use core::fmt::Write;
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 use core::fmt::Write;
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 use core::fmt::Write;
 use std::ops::{Deref, DerefMut};

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
 use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
 use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
 use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{

--- a/pgx/src/enum_helper.rs
+++ b/pgx/src/enum_helper.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Helper functions for working with Postgres `enum` types
 

--- a/pgx/src/enum_helper.rs
+++ b/pgx/src/enum_helper.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Helper functions for working with Postgres `enum` types
 

--- a/pgx/src/enum_helper.rs
+++ b/pgx/src/enum_helper.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Helper functions for working with Postgres `enum` types
 

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Helper macros and functions for creating Postgres UDFs.
 //!

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Helper macros and functions for creating Postgres UDFs.
 //!

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Helper macros and functions for creating Postgres UDFs.
 //!

--- a/pgx/src/guc.rs
+++ b/pgx/src/guc.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Provides a safe interface into Postgres' Configuration System (GUC)
 use crate::{pg_sys, PgMemoryContexts};

--- a/pgx/src/guc.rs
+++ b/pgx/src/guc.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Provides a safe interface into Postgres' Configuration System (GUC)
 use crate::{pg_sys, PgMemoryContexts};

--- a/pgx/src/guc.rs
+++ b/pgx/src/guc.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Provides a safe interface into Postgres' Configuration System (GUC)
 use crate::{pg_sys, PgMemoryContexts};

--- a/pgx/src/hooks.rs
+++ b/pgx/src/hooks.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! A trait and registration system for hooking Postgres internal operations such as its planner and executor
 use crate::{pg_guard, pg_sys, void_mut_ptr, PgBox, PgList};

--- a/pgx/src/hooks.rs
+++ b/pgx/src/hooks.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! A trait and registration system for hooking Postgres internal operations such as its planner and executor
 use crate::{pg_guard, pg_sys, void_mut_ptr, PgBox, PgList};

--- a/pgx/src/hooks.rs
+++ b/pgx/src/hooks.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! A trait and registration system for hooking Postgres internal operations such as its planner and executor
 use crate::{pg_guard, pg_sys, void_mut_ptr, PgBox, PgList};

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Utility functions for working with `pg_sys::HeapTuple` and `pg_sys::HeapTupleHeader` structs
 use crate::*;

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Utility functions for working with `pg_sys::HeapTuple` and `pg_sys::HeapTupleHeader` structs
 use crate::*;

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Utility functions for working with `pg_sys::HeapTuple` and `pg_sys::HeapTupleHeader` structs
 use crate::*;

--- a/pgx/src/inoutfuncs.rs
+++ b/pgx/src/inoutfuncs.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Helper trait for the `#[derive(PostgresType)]` proc macro for overriding custom Postgres type
 //! input/output functions.

--- a/pgx/src/inoutfuncs.rs
+++ b/pgx/src/inoutfuncs.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Helper trait for the `#[derive(PostgresType)]` proc macro for overriding custom Postgres type
 //! input/output functions.

--- a/pgx/src/inoutfuncs.rs
+++ b/pgx/src/inoutfuncs.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Helper trait for the `#[derive(PostgresType)]` proc macro for overriding custom Postgres type
 //! input/output functions.

--- a/pgx/src/itemptr.rs
+++ b/pgx/src/itemptr.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Helper functions for working with Postgres `ItemPointerData` (`tid`) type
 

--- a/pgx/src/itemptr.rs
+++ b/pgx/src/itemptr.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Helper functions for working with Postgres `ItemPointerData` (`tid`) type
 

--- a/pgx/src/itemptr.rs
+++ b/pgx/src/itemptr.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Helper functions for working with Postgres `ItemPointerData` (`tid`) type
 

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! `pgx` is a framework for creating Postgres extensions in 100% Rust
 //!

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! `pgx` is a framework for creating Postgres extensions in 100% Rust
 //!

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! `pgx` is a framework for creating Postgres extensions in 100% Rust
 //!

--- a/pgx/src/list.rs
+++ b/pgx/src/list.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! A safe wrapper around Postgres' internal `List` structure.
 //!

--- a/pgx/src/list.rs
+++ b/pgx/src/list.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! A safe wrapper around Postgres' internal `List` structure.
 //!

--- a/pgx/src/list.rs
+++ b/pgx/src/list.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! A safe wrapper around Postgres' internal `List` structure.
 //!

--- a/pgx/src/log.rs
+++ b/pgx/src/log.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Access to Postgres' logging system
 

--- a/pgx/src/log.rs
+++ b/pgx/src/log.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Access to Postgres' logging system
 

--- a/pgx/src/log.rs
+++ b/pgx/src/log.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Access to Postgres' logging system
 

--- a/pgx/src/lwlock.rs
+++ b/pgx/src/lwlock.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::pg_sys;
 use core::ops::{Deref, DerefMut};
 use once_cell::sync::OnceCell;

--- a/pgx/src/lwlock.rs
+++ b/pgx/src/lwlock.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::pg_sys;
 use core::ops::{Deref, DerefMut};
 use once_cell::sync::OnceCell;

--- a/pgx/src/lwlock.rs
+++ b/pgx/src/lwlock.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::pg_sys;
 use core::ops::{Deref, DerefMut};
 use once_cell::sync::OnceCell;

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //!
 //! Provides interfacing into Postgres' `MemoryContext` system.

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //!
 //! Provides interfacing into Postgres' `MemoryContext` system.

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //!
 //! Provides interfacing into Postgres' `MemoryContext` system.

--- a/pgx/src/misc.rs
+++ b/pgx/src/misc.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use std::hash::{Hash, Hasher};
 
 /// wrapper around `SeaHasher` from [Seahash](https://crates.io/crates/seahash)

--- a/pgx/src/misc.rs
+++ b/pgx/src/misc.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use std::hash::{Hash, Hasher};
 
 /// wrapper around `SeaHasher` from [Seahash](https://crates.io/crates/seahash)

--- a/pgx/src/misc.rs
+++ b/pgx/src/misc.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use std::hash::{Hash, Hasher};
 
 /// wrapper around `SeaHasher` from [Seahash](https://crates.io/crates/seahash)

--- a/pgx/src/namespace.rs
+++ b/pgx/src/namespace.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! A helper struct for creating a Postgres `List` of `String`s to qualify an object name
 

--- a/pgx/src/namespace.rs
+++ b/pgx/src/namespace.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! A helper struct for creating a Postgres `List` of `String`s to qualify an object name
 

--- a/pgx/src/namespace.rs
+++ b/pgx/src/namespace.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! A helper struct for creating a Postgres `List` of `String`s to qualify an object name
 

--- a/pgx/src/nodes.rs
+++ b/pgx/src/nodes.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Helper functions and such for Postgres' various query tree `Node`s
 

--- a/pgx/src/nodes.rs
+++ b/pgx/src/nodes.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Helper functions and such for Postgres' various query tree `Node`s
 

--- a/pgx/src/nodes.rs
+++ b/pgx/src/nodes.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Helper functions and such for Postgres' various query tree `Node`s
 

--- a/pgx/src/pgbox.rs
+++ b/pgx/src/pgbox.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 /// Similar to Rust's `Box<T>` type, `PgBox<T>` also represents heap-allocated memory.
 use crate::{pg_sys, PgMemoryContexts};

--- a/pgx/src/pgbox.rs
+++ b/pgx/src/pgbox.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 /// Similar to Rust's `Box<T>` type, `PgBox<T>` also represents heap-allocated memory.
 use crate::{pg_sys, PgMemoryContexts};

--- a/pgx/src/pgbox.rs
+++ b/pgx/src/pgbox.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 /// Similar to Rust's `Box<T>` type, `PgBox<T>` also represents heap-allocated memory.
 use crate::{pg_sys, PgMemoryContexts};

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Provides a safe wrapper around Postgres' `pg_sys::RelationData` struct
 use crate::{

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Provides a safe wrapper around Postgres' `pg_sys::RelationData` struct
 use crate::{

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Provides a safe wrapper around Postgres' `pg_sys::RelationData` struct
 use crate::{

--- a/pgx/src/shmem.rs
+++ b/pgx/src/shmem.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 use crate::lwlock::*;
 use crate::{pg_sys, PgAtomic};
 use uuid::Uuid;

--- a/pgx/src/shmem.rs
+++ b/pgx/src/shmem.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 use crate::lwlock::*;
 use crate::{pg_sys, PgAtomic};
 use uuid::Uuid;

--- a/pgx/src/shmem.rs
+++ b/pgx/src/shmem.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 use crate::lwlock::*;
 use crate::{pg_sys, PgAtomic};
 use uuid::Uuid;

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Safe access to Postgres' *Server Programming Interface* (SPI).
 

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Safe access to Postgres' *Server Programming Interface* (SPI).
 

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Safe access to Postgres' *Server Programming Interface* (SPI).
 

--- a/pgx/src/stringinfo.rs
+++ b/pgx/src/stringinfo.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! A safe wrapper around Postgres `StringInfo` structure
 #![allow(dead_code, non_snake_case)]

--- a/pgx/src/stringinfo.rs
+++ b/pgx/src/stringinfo.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! A safe wrapper around Postgres `StringInfo` structure
 #![allow(dead_code, non_snake_case)]

--- a/pgx/src/stringinfo.rs
+++ b/pgx/src/stringinfo.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! A safe wrapper around Postgres `StringInfo` structure
 #![allow(dead_code, non_snake_case)]

--- a/pgx/src/trigger_support.rs
+++ b/pgx/src/trigger_support.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Helper functions for working with custom Rust trigger functions
 

--- a/pgx/src/trigger_support.rs
+++ b/pgx/src/trigger_support.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Helper functions for working with custom Rust trigger functions
 

--- a/pgx/src/trigger_support.rs
+++ b/pgx/src/trigger_support.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Helper functions for working with custom Rust trigger functions
 

--- a/pgx/src/tupdesc.rs
+++ b/pgx/src/tupdesc.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Provides a safe wrapper around Postgres' `pg_sys::TupleDescData` struct
 use crate::{pg_sys, void_mut_ptr, AllocatedByRust, FromDatum, PgBox, PgRelation};

--- a/pgx/src/tupdesc.rs
+++ b/pgx/src/tupdesc.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Provides a safe wrapper around Postgres' `pg_sys::TupleDescData` struct
 use crate::{pg_sys, void_mut_ptr, AllocatedByRust, FromDatum, PgBox, PgRelation};

--- a/pgx/src/tupdesc.rs
+++ b/pgx/src/tupdesc.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Provides a safe wrapper around Postgres' `pg_sys::TupleDescData` struct
 use crate::{pg_sys, void_mut_ptr, AllocatedByRust, FromDatum, PgBox, PgRelation};

--- a/pgx/src/varlena.rs
+++ b/pgx/src/varlena.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 //! Helper functions to work with Postgres `varlena *` structures
 

--- a/pgx/src/varlena.rs
+++ b/pgx/src/varlena.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 //! Helper functions to work with Postgres `varlena *` structures
 

--- a/pgx/src/varlena.rs
+++ b/pgx/src/varlena.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 //! Helper functions to work with Postgres `varlena *` structures
 

--- a/pgx/src/wrappers.rs
+++ b/pgx/src/wrappers.rs
@@ -1,3 +1,6 @@
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 //! Provides safe wrapper functions around some of Postgres' useful functions.
 use crate::{direct_function_call, pg_sys, IntoDatum};
 

--- a/pgx/src/wrappers.rs
+++ b/pgx/src/wrappers.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 //! Provides safe wrapper functions around some of Postgres' useful functions.
 use crate::{direct_function_call, pg_sys, IntoDatum};
 

--- a/pgx/src/wrappers.rs
+++ b/pgx/src/wrappers.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 //! Provides safe wrapper functions around some of Postgres' useful functions.
 use crate::{direct_function_call, pg_sys, IntoDatum};
 

--- a/pgx/src/xid.rs
+++ b/pgx/src/xid.rs
@@ -1,5 +1,6 @@
-// Copyright 2020 ZomboDB, LLC <zombodb@gmail.com>. All rights reserved. Use of this source code is
-// governed by the MIT license that can be found in the LICENSE file.
+// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+// by the MIT license that can be found in the LICENSE file.
 
 use crate::pg_sys;
 

--- a/pgx/src/xid.rs
+++ b/pgx/src/xid.rs
@@ -1,6 +1,7 @@
-// Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-// <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-// by the MIT license that can be found in the LICENSE file.
+// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+// source code is governed by the MIT license that can be found in the LICENSE
+// file.
 
 use crate::pg_sys;
 

--- a/pgx/src/xid.rs
+++ b/pgx/src/xid.rs
@@ -1,7 +1,11 @@
-// Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-// Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-// source code is governed by the MIT license that can be found in the LICENSE
-// file.
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
 
 use crate::pg_sys;
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,8 +1,12 @@
 #! /bin/sh
-# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-# source code is governed by the MIT license that can be found in the LICENSE
-# file.
+# Portions Copyright 2019-2021 ZomboDB, LLC.
+# Portions Copyright 2021-2022 Technology Concepts & Design, Inc.
+# <support@tcdi.com>
+#
+# All rights reserved.
+#
+# Use of this source code is governed by the MIT license that can be found in
+# the LICENSE file.
 
 DIR=`pwd`
 set -x

--- a/publish.sh
+++ b/publish.sh
@@ -1,7 +1,8 @@
-# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-# by the MIT license that can be found in the LICENSE file.
 #! /bin/sh
+# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+# source code is governed by the MIT license that can be found in the LICENSE
+# file.
 
 DIR=`pwd`
 set -x

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,6 @@
+# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+# by the MIT license that can be found in the LICENSE file.
 #! /bin/sh
 
 DIR=`pwd`

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -1,7 +1,8 @@
-# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-# by the MIT license that can be found in the LICENSE file.
 #! /usr/bin/env bash
+# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+# source code is governed by the MIT license that can be found in the LICENSE
+# file.
 
 # requires:
 # * ripgrep

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -1,3 +1,6 @@
+# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+# by the MIT license that can be found in the LICENSE file.
 #! /usr/bin/env bash
 
 # requires:

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -1,8 +1,12 @@
 #! /usr/bin/env bash
-# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-# source code is governed by the MIT license that can be found in the LICENSE
-# file.
+# Portions Copyright 2019-2021 ZomboDB, LLC.
+# Portions Copyright 2021-2022 Technology Concepts & Design, Inc.
+# <support@tcdi.com>
+#
+# All rights reserved.
+#
+# Use of this source code is governed by the MIT license that can be found in
+# the LICENSE file.
 
 # requires:
 # * ripgrep

--- a/upgrade-deps.sh
+++ b/upgrade-deps.sh
@@ -1,3 +1,6 @@
+# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
+# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
+# by the MIT license that can be found in the LICENSE file.
 #! /usr/bin/env bash
 
 # requires:  "cargo install cargo-edit" from https://github.com/killercup/cargo-edit

--- a/upgrade-deps.sh
+++ b/upgrade-deps.sh
@@ -1,7 +1,8 @@
-# Copyright 2019-2022 ZomboDB, LLC and Technology Concepts & Design, Inc.
-# <support@tcdi.com>. All rights reserved.  Use of this source code is governed
-# by the MIT license that can be found in the LICENSE file.
 #! /usr/bin/env bash
+# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
+# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
+# source code is governed by the MIT license that can be found in the LICENSE
+# file.
 
 # requires:  "cargo install cargo-edit" from https://github.com/killercup/cargo-edit
 cargo update

--- a/upgrade-deps.sh
+++ b/upgrade-deps.sh
@@ -1,8 +1,12 @@
 #! /usr/bin/env bash
-# Portions Copyright 2019-2021 ZomboDB, LLC.  Portions Copyright 2021-2022
-# Technology Concepts & Design, Inc. <support@tcdi.com>.  All rights reserved.  Use of this
-# source code is governed by the MIT license that can be found in the LICENSE
-# file.
+# Portions Copyright 2019-2021 ZomboDB, LLC.
+# Portions Copyright 2021-2022 Technology Concepts & Design, Inc.
+# <support@tcdi.com>
+#
+# All rights reserved.
+#
+# Use of this source code is governed by the MIT license that can be found in
+# the LICENSE file.
 
 # requires:  "cargo install cargo-edit" from https://github.com/killercup/cargo-edit
 cargo update


### PR DESCRIPTION
I put this against `develop` but I think we should also merge it into `master`.  No need for a new release, of course.