### PR TITLE
Add pg_operator.h

### DIFF
--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -25,6 +25,7 @@
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_enum.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -22,6 +22,7 @@
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_enum.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -24,6 +24,7 @@
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_enum.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -24,6 +24,7 @@
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_enum.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -24,6 +24,7 @@
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_enum.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgx-pg-sys/src/pg10.rs
+++ b/pgx-pg-sys/src/pg10.rs
@@ -331,7 +331,7 @@ pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"10\0";
 pub const PG_VERSION: &[u8; 6usize] = b"10.20\0";
 pub const PG_VERSION_NUM: u32 = 100020;
-pub const PG_VERSION_STR : & [u8 ; 97usize] = b"PostgreSQL 10.20 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION_STR : & [u8 ; 102usize] = b"PostgreSQL 10.20 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_LONG: u32 = 8;
 pub const SIZEOF_OFF_T: u32 = 8;
@@ -383,10 +383,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -398,26 +394,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -444,6 +442,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -460,18 +471,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -499,6 +498,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -978,9 +978,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1039,7 +1036,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1075,7 +1071,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1180,7 +1175,6 @@ pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1470,7 +1464,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1835,6 +1832,7 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -1846,34 +1844,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -1885,7 +1882,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2237,6 +2234,71 @@ pub const Natts_pg_enum: u32 = 3;
 pub const Anum_pg_enum_enumtypid: u32 = 1;
 pub const Anum_pg_enum_enumsortorder: u32 = 2;
 pub const Anum_pg_enum_enumlabel: u32 = 3;
+pub const OperatorRelationId: u32 = 2617;
+pub const Natts_pg_operator: u32 = 14;
+pub const Anum_pg_operator_oprname: u32 = 1;
+pub const Anum_pg_operator_oprnamespace: u32 = 2;
+pub const Anum_pg_operator_oprowner: u32 = 3;
+pub const Anum_pg_operator_oprkind: u32 = 4;
+pub const Anum_pg_operator_oprcanmerge: u32 = 5;
+pub const Anum_pg_operator_oprcanhash: u32 = 6;
+pub const Anum_pg_operator_oprleft: u32 = 7;
+pub const Anum_pg_operator_oprright: u32 = 8;
+pub const Anum_pg_operator_oprresult: u32 = 9;
+pub const Anum_pg_operator_oprcom: u32 = 10;
+pub const Anum_pg_operator_oprnegate: u32 = 11;
+pub const Anum_pg_operator_oprcode: u32 = 12;
+pub const Anum_pg_operator_oprrest: u32 = 13;
+pub const Anum_pg_operator_oprjoin: u32 = 14;
+pub const BooleanNotEqualOperator: u32 = 85;
+pub const BooleanEqualOperator: u32 = 91;
+pub const Int4EqualOperator: u32 = 96;
+pub const Int4LessOperator: u32 = 97;
+pub const TextEqualOperator: u32 = 98;
+pub const TIDEqualOperator: u32 = 387;
+pub const TIDLessOperator: u32 = 2799;
+pub const Int8LessOperator: u32 = 412;
+pub const OID_NAME_REGEXEQ_OP: u32 = 639;
+pub const OID_TEXT_REGEXEQ_OP: u32 = 641;
+pub const Float8LessOperator: u32 = 672;
+pub const OID_BPCHAR_REGEXEQ_OP: u32 = 1055;
+pub const ARRAY_EQ_OP: u32 = 1070;
+pub const ARRAY_LT_OP: u32 = 1072;
+pub const ARRAY_GT_OP: u32 = 1073;
+pub const OID_NAME_LIKE_OP: u32 = 1207;
+pub const OID_TEXT_LIKE_OP: u32 = 1209;
+pub const OID_BPCHAR_LIKE_OP: u32 = 1211;
+pub const OID_NAME_ICREGEXEQ_OP: u32 = 1226;
+pub const OID_TEXT_ICREGEXEQ_OP: u32 = 1228;
+pub const OID_BPCHAR_ICREGEXEQ_OP: u32 = 1234;
+pub const OID_INET_SUB_OP: u32 = 931;
+pub const OID_INET_SUBEQ_OP: u32 = 932;
+pub const OID_INET_SUP_OP: u32 = 933;
+pub const OID_INET_SUPEQ_OP: u32 = 934;
+pub const OID_INET_OVERLAP_OP: u32 = 3552;
+pub const OID_NAME_ICLIKE_OP: u32 = 1625;
+pub const OID_TEXT_ICLIKE_OP: u32 = 1627;
+pub const OID_BPCHAR_ICLIKE_OP: u32 = 1629;
+pub const OID_BYTEA_LIKE_OP: u32 = 2016;
+pub const OID_ARRAY_OVERLAP_OP: u32 = 2750;
+pub const OID_ARRAY_CONTAINS_OP: u32 = 2751;
+pub const OID_ARRAY_CONTAINED_OP: u32 = 2752;
+pub const RECORD_EQ_OP: u32 = 2988;
+pub const RECORD_LT_OP: u32 = 2990;
+pub const RECORD_GT_OP: u32 = 2991;
+pub const OID_RANGE_LESS_OP: u32 = 3884;
+pub const OID_RANGE_LESS_EQUAL_OP: u32 = 3885;
+pub const OID_RANGE_GREATER_EQUAL_OP: u32 = 3886;
+pub const OID_RANGE_GREATER_OP: u32 = 3887;
+pub const OID_RANGE_OVERLAP_OP: u32 = 3888;
+pub const OID_RANGE_CONTAINS_ELEM_OP: u32 = 3889;
+pub const OID_RANGE_CONTAINS_OP: u32 = 3890;
+pub const OID_RANGE_ELEM_CONTAINED_OP: u32 = 3891;
+pub const OID_RANGE_CONTAINED_OP: u32 = 3892;
+pub const OID_RANGE_LEFT_OP: u32 = 3893;
+pub const OID_RANGE_RIGHT_OP: u32 = 3894;
+pub const OID_RANGE_OVERLAPS_LEFT_OP: u32 = 3895;
+pub const OID_RANGE_OVERLAPS_RIGHT_OP: u32 = 3896;
 pub const ProcedureRelationId: u32 = 1255;
 pub const ProcedureRelation_Rowtype_Id: u32 = 81;
 pub const Natts_pg_proc: u32 = 29;
@@ -2844,7 +2906,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3023,15 +3084,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3043,6 +3100,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3205,10 +3266,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3486,6 +3543,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3494,14 +3559,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3528,6 +3593,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -3854,13 +3927,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4211,15 +4277,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4239,10 +4305,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5409,7 +5472,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5649,10 +5711,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -23638,8 +23698,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -23880,6 +23938,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -30064,6 +30130,34 @@ extern "C" {
         newVal: *const ::std::os::raw::c_char,
     );
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_operator {
+    pub oprname: NameData,
+    pub oprnamespace: Oid,
+    pub oprowner: Oid,
+    pub oprkind: ::std::os::raw::c_char,
+    pub oprcanmerge: bool,
+    pub oprcanhash: bool,
+    pub oprleft: Oid,
+    pub oprright: Oid,
+    pub oprresult: Oid,
+    pub oprcom: Oid,
+    pub oprnegate: Oid,
+    pub oprcode: regproc,
+    pub oprrest: regproc,
+    pub oprjoin: regproc,
+}
+impl Default for FormData_pg_operator {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_operator = *mut FormData_pg_operator;
 #[repr(C)]
 #[derive(Debug)]
 pub struct FormData_pg_proc {

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -327,7 +327,7 @@ pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"11\0";
 pub const PG_VERSION: &[u8; 6usize] = b"11.15\0";
 pub const PG_VERSION_NUM: u32 = 110015;
-pub const PG_VERSION_STR : & [u8 ; 97usize] = b"PostgreSQL 11.15 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION_STR : & [u8 ; 102usize] = b"PostgreSQL 11.15 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -380,10 +380,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -395,26 +391,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -441,6 +439,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -457,18 +468,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -496,6 +495,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -977,9 +977,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1038,7 +1035,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1074,7 +1070,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1204,7 +1199,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1505,7 +1499,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1754,6 +1751,7 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -1765,34 +1763,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -1804,7 +1801,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2311,6 +2308,71 @@ pub const Anum_pg_enum_enumtypid: u32 = 1;
 pub const Anum_pg_enum_enumsortorder: u32 = 2;
 pub const Anum_pg_enum_enumlabel: u32 = 3;
 pub const Natts_pg_enum: u32 = 3;
+pub const OperatorRelationId: u32 = 2617;
+pub const Anum_pg_operator_oprname: u32 = 1;
+pub const Anum_pg_operator_oprnamespace: u32 = 2;
+pub const Anum_pg_operator_oprowner: u32 = 3;
+pub const Anum_pg_operator_oprkind: u32 = 4;
+pub const Anum_pg_operator_oprcanmerge: u32 = 5;
+pub const Anum_pg_operator_oprcanhash: u32 = 6;
+pub const Anum_pg_operator_oprleft: u32 = 7;
+pub const Anum_pg_operator_oprright: u32 = 8;
+pub const Anum_pg_operator_oprresult: u32 = 9;
+pub const Anum_pg_operator_oprcom: u32 = 10;
+pub const Anum_pg_operator_oprnegate: u32 = 11;
+pub const Anum_pg_operator_oprcode: u32 = 12;
+pub const Anum_pg_operator_oprrest: u32 = 13;
+pub const Anum_pg_operator_oprjoin: u32 = 14;
+pub const Natts_pg_operator: u32 = 14;
+pub const BooleanNotEqualOperator: u32 = 85;
+pub const BooleanEqualOperator: u32 = 91;
+pub const Int4EqualOperator: u32 = 96;
+pub const Int4LessOperator: u32 = 97;
+pub const TextEqualOperator: u32 = 98;
+pub const TIDEqualOperator: u32 = 387;
+pub const TIDLessOperator: u32 = 2799;
+pub const Int8LessOperator: u32 = 412;
+pub const OID_NAME_REGEXEQ_OP: u32 = 639;
+pub const OID_TEXT_REGEXEQ_OP: u32 = 641;
+pub const Float8LessOperator: u32 = 672;
+pub const OID_BPCHAR_REGEXEQ_OP: u32 = 1055;
+pub const ARRAY_EQ_OP: u32 = 1070;
+pub const ARRAY_LT_OP: u32 = 1072;
+pub const ARRAY_GT_OP: u32 = 1073;
+pub const OID_NAME_LIKE_OP: u32 = 1207;
+pub const OID_TEXT_LIKE_OP: u32 = 1209;
+pub const OID_BPCHAR_LIKE_OP: u32 = 1211;
+pub const OID_NAME_ICREGEXEQ_OP: u32 = 1226;
+pub const OID_TEXT_ICREGEXEQ_OP: u32 = 1228;
+pub const OID_BPCHAR_ICREGEXEQ_OP: u32 = 1234;
+pub const OID_INET_SUB_OP: u32 = 931;
+pub const OID_INET_SUBEQ_OP: u32 = 932;
+pub const OID_INET_SUP_OP: u32 = 933;
+pub const OID_INET_SUPEQ_OP: u32 = 934;
+pub const OID_INET_OVERLAP_OP: u32 = 3552;
+pub const OID_NAME_ICLIKE_OP: u32 = 1625;
+pub const OID_TEXT_ICLIKE_OP: u32 = 1627;
+pub const OID_BPCHAR_ICLIKE_OP: u32 = 1629;
+pub const OID_BYTEA_LIKE_OP: u32 = 2016;
+pub const OID_ARRAY_OVERLAP_OP: u32 = 2750;
+pub const OID_ARRAY_CONTAINS_OP: u32 = 2751;
+pub const OID_ARRAY_CONTAINED_OP: u32 = 2752;
+pub const RECORD_EQ_OP: u32 = 2988;
+pub const RECORD_LT_OP: u32 = 2990;
+pub const RECORD_GT_OP: u32 = 2991;
+pub const OID_RANGE_LESS_OP: u32 = 3884;
+pub const OID_RANGE_LESS_EQUAL_OP: u32 = 3885;
+pub const OID_RANGE_GREATER_EQUAL_OP: u32 = 3886;
+pub const OID_RANGE_GREATER_OP: u32 = 3887;
+pub const OID_RANGE_OVERLAP_OP: u32 = 3888;
+pub const OID_RANGE_CONTAINS_ELEM_OP: u32 = 3889;
+pub const OID_RANGE_CONTAINS_OP: u32 = 3890;
+pub const OID_RANGE_ELEM_CONTAINED_OP: u32 = 3891;
+pub const OID_RANGE_CONTAINED_OP: u32 = 3892;
+pub const OID_RANGE_LEFT_OP: u32 = 3893;
+pub const OID_RANGE_RIGHT_OP: u32 = 3894;
+pub const OID_RANGE_OVERLAPS_LEFT_OP: u32 = 3895;
+pub const OID_RANGE_OVERLAPS_RIGHT_OP: u32 = 3896;
 pub const ProcedureRelationId: u32 = 1255;
 pub const ProcedureRelation_Rowtype_Id: u32 = 81;
 pub const Anum_pg_proc_proname: u32 = 1;
@@ -3006,7 +3068,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3185,15 +3246,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3205,6 +3262,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3367,10 +3428,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3648,6 +3705,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3656,14 +3721,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3690,6 +3755,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4016,13 +4089,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4373,15 +4439,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4401,10 +4467,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5579,7 +5642,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5819,10 +5881,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -25321,8 +25381,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -25563,6 +25621,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -34182,6 +34248,58 @@ extern "C" {
         oldVal: *const ::std::os::raw::c_char,
         newVal: *const ::std::os::raw::c_char,
     );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_operator {
+    pub oprname: NameData,
+    pub oprnamespace: Oid,
+    pub oprowner: Oid,
+    pub oprkind: ::std::os::raw::c_char,
+    pub oprcanmerge: bool,
+    pub oprcanhash: bool,
+    pub oprleft: Oid,
+    pub oprright: Oid,
+    pub oprresult: Oid,
+    pub oprcom: Oid,
+    pub oprnegate: Oid,
+    pub oprcode: regproc,
+    pub oprrest: regproc,
+    pub oprjoin: regproc,
+}
+impl Default for FormData_pg_operator {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_operator = *mut FormData_pg_operator;
+#[pg_guard]
+extern "C" {
+    pub fn OperatorCreate(
+        operatorName: *const ::std::os::raw::c_char,
+        operatorNamespace: Oid,
+        leftTypeId: Oid,
+        rightTypeId: Oid,
+        procedureId: Oid,
+        commutatorName: *mut List,
+        negatorName: *mut List,
+        restrictionId: Oid,
+        joinId: Oid,
+        canMerge: bool,
+        canHash: bool,
+    ) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn makeOperatorDependencies(tuple: HeapTuple, isUpdate: bool) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn OperatorUpd(baseId: Oid, commId: Oid, negId: Oid, isDelete: bool);
 }
 #[repr(C)]
 #[derive(Debug)]

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -333,7 +333,7 @@ pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"12\0";
 pub const PG_VERSION: &[u8; 6usize] = b"12.10\0";
 pub const PG_VERSION_NUM: u32 = 120010;
-pub const PG_VERSION_STR : & [u8 ; 97usize] = b"PostgreSQL 12.10 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION_STR : & [u8 ; 102usize] = b"PostgreSQL 12.10 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -386,10 +386,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -401,26 +397,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -447,6 +445,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -463,18 +474,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -502,6 +501,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -983,9 +983,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1044,7 +1041,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1080,7 +1076,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1212,7 +1207,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1375,7 +1369,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1791,6 +1788,7 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -1802,34 +1800,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -1841,7 +1838,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2400,6 +2397,72 @@ pub const Anum_pg_enum_enumtypid: u32 = 2;
 pub const Anum_pg_enum_enumsortorder: u32 = 3;
 pub const Anum_pg_enum_enumlabel: u32 = 4;
 pub const Natts_pg_enum: u32 = 4;
+pub const OperatorRelationId: u32 = 2617;
+pub const Anum_pg_operator_oid: u32 = 1;
+pub const Anum_pg_operator_oprname: u32 = 2;
+pub const Anum_pg_operator_oprnamespace: u32 = 3;
+pub const Anum_pg_operator_oprowner: u32 = 4;
+pub const Anum_pg_operator_oprkind: u32 = 5;
+pub const Anum_pg_operator_oprcanmerge: u32 = 6;
+pub const Anum_pg_operator_oprcanhash: u32 = 7;
+pub const Anum_pg_operator_oprleft: u32 = 8;
+pub const Anum_pg_operator_oprright: u32 = 9;
+pub const Anum_pg_operator_oprresult: u32 = 10;
+pub const Anum_pg_operator_oprcom: u32 = 11;
+pub const Anum_pg_operator_oprnegate: u32 = 12;
+pub const Anum_pg_operator_oprcode: u32 = 13;
+pub const Anum_pg_operator_oprrest: u32 = 14;
+pub const Anum_pg_operator_oprjoin: u32 = 15;
+pub const Natts_pg_operator: u32 = 15;
+pub const BooleanNotEqualOperator: u32 = 85;
+pub const BooleanEqualOperator: u32 = 91;
+pub const Int4EqualOperator: u32 = 96;
+pub const Int4LessOperator: u32 = 97;
+pub const TextEqualOperator: u32 = 98;
+pub const TIDEqualOperator: u32 = 387;
+pub const TIDLessOperator: u32 = 2799;
+pub const Int8LessOperator: u32 = 412;
+pub const OID_NAME_REGEXEQ_OP: u32 = 639;
+pub const OID_TEXT_REGEXEQ_OP: u32 = 641;
+pub const Float8LessOperator: u32 = 672;
+pub const OID_BPCHAR_REGEXEQ_OP: u32 = 1055;
+pub const ARRAY_EQ_OP: u32 = 1070;
+pub const ARRAY_LT_OP: u32 = 1072;
+pub const ARRAY_GT_OP: u32 = 1073;
+pub const OID_NAME_LIKE_OP: u32 = 1207;
+pub const OID_TEXT_LIKE_OP: u32 = 1209;
+pub const OID_BPCHAR_LIKE_OP: u32 = 1211;
+pub const OID_NAME_ICREGEXEQ_OP: u32 = 1226;
+pub const OID_TEXT_ICREGEXEQ_OP: u32 = 1228;
+pub const OID_BPCHAR_ICREGEXEQ_OP: u32 = 1234;
+pub const OID_INET_SUB_OP: u32 = 931;
+pub const OID_INET_SUBEQ_OP: u32 = 932;
+pub const OID_INET_SUP_OP: u32 = 933;
+pub const OID_INET_SUPEQ_OP: u32 = 934;
+pub const OID_INET_OVERLAP_OP: u32 = 3552;
+pub const OID_NAME_ICLIKE_OP: u32 = 1625;
+pub const OID_TEXT_ICLIKE_OP: u32 = 1627;
+pub const OID_BPCHAR_ICLIKE_OP: u32 = 1629;
+pub const OID_BYTEA_LIKE_OP: u32 = 2016;
+pub const OID_ARRAY_OVERLAP_OP: u32 = 2750;
+pub const OID_ARRAY_CONTAINS_OP: u32 = 2751;
+pub const OID_ARRAY_CONTAINED_OP: u32 = 2752;
+pub const RECORD_EQ_OP: u32 = 2988;
+pub const RECORD_LT_OP: u32 = 2990;
+pub const RECORD_GT_OP: u32 = 2991;
+pub const OID_RANGE_LESS_OP: u32 = 3884;
+pub const OID_RANGE_LESS_EQUAL_OP: u32 = 3885;
+pub const OID_RANGE_GREATER_EQUAL_OP: u32 = 3886;
+pub const OID_RANGE_GREATER_OP: u32 = 3887;
+pub const OID_RANGE_OVERLAP_OP: u32 = 3888;
+pub const OID_RANGE_CONTAINS_ELEM_OP: u32 = 3889;
+pub const OID_RANGE_CONTAINS_OP: u32 = 3890;
+pub const OID_RANGE_ELEM_CONTAINED_OP: u32 = 3891;
+pub const OID_RANGE_CONTAINED_OP: u32 = 3892;
+pub const OID_RANGE_LEFT_OP: u32 = 3893;
+pub const OID_RANGE_RIGHT_OP: u32 = 3894;
+pub const OID_RANGE_OVERLAPS_LEFT_OP: u32 = 3895;
+pub const OID_RANGE_OVERLAPS_RIGHT_OP: u32 = 3896;
 pub const ProcedureRelationId: u32 = 1255;
 pub const ProcedureRelation_Rowtype_Id: u32 = 81;
 pub const Anum_pg_proc_oid: u32 = 1;
@@ -3060,7 +3123,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3239,15 +3301,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3259,6 +3317,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3421,10 +3483,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3702,6 +3760,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3710,14 +3776,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3744,6 +3810,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4070,13 +4144,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4427,15 +4494,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4455,10 +4522,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5633,7 +5697,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5873,10 +5936,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -23834,8 +23895,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -24076,6 +24135,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -34714,6 +34781,59 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn AtEOXact_Enum();
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_operator {
+    pub oid: Oid,
+    pub oprname: NameData,
+    pub oprnamespace: Oid,
+    pub oprowner: Oid,
+    pub oprkind: ::std::os::raw::c_char,
+    pub oprcanmerge: bool,
+    pub oprcanhash: bool,
+    pub oprleft: Oid,
+    pub oprright: Oid,
+    pub oprresult: Oid,
+    pub oprcom: Oid,
+    pub oprnegate: Oid,
+    pub oprcode: regproc,
+    pub oprrest: regproc,
+    pub oprjoin: regproc,
+}
+impl Default for FormData_pg_operator {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_operator = *mut FormData_pg_operator;
+#[pg_guard]
+extern "C" {
+    pub fn OperatorCreate(
+        operatorName: *const ::std::os::raw::c_char,
+        operatorNamespace: Oid,
+        leftTypeId: Oid,
+        rightTypeId: Oid,
+        procedureId: Oid,
+        commutatorName: *mut List,
+        negatorName: *mut List,
+        restrictionId: Oid,
+        joinId: Oid,
+        canMerge: bool,
+        canHash: bool,
+    ) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn makeOperatorDependencies(tuple: HeapTuple, isUpdate: bool) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn OperatorUpd(baseId: Oid, commId: Oid, negId: Oid, isDelete: bool);
 }
 #[repr(C)]
 #[derive(Debug)]

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -178,7 +178,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 102usize] = b" '--prefix=/home/ana/.pgx/13.6/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 104usize] = b" '--prefix=/home/einar/.pgx/13.6/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -328,7 +328,7 @@ pub const PG_MINORVERSION_NUM: u32 = 6;
 pub const PG_USE_STDBOOL: u32 = 1;
 pub const PG_VERSION: &[u8; 5usize] = b"13.6\0";
 pub const PG_VERSION_NUM: u32 = 130006;
-pub const PG_VERSION_STR : & [u8 ; 96usize] = b"PostgreSQL 13.6 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION_STR : & [u8 ; 101usize] = b"PostgreSQL 13.6 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -380,10 +380,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -395,26 +391,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -441,6 +439,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -457,18 +468,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -496,6 +495,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -977,9 +977,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1038,7 +1035,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1074,7 +1070,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1206,7 +1201,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1354,7 +1348,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -2017,6 +2014,7 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -2028,34 +2026,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -2067,7 +2064,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2599,6 +2596,87 @@ pub const Anum_pg_enum_enumtypid: u32 = 2;
 pub const Anum_pg_enum_enumsortorder: u32 = 3;
 pub const Anum_pg_enum_enumlabel: u32 = 4;
 pub const Natts_pg_enum: u32 = 4;
+pub const OperatorRelationId: u32 = 2617;
+pub const Anum_pg_operator_oid: u32 = 1;
+pub const Anum_pg_operator_oprname: u32 = 2;
+pub const Anum_pg_operator_oprnamespace: u32 = 3;
+pub const Anum_pg_operator_oprowner: u32 = 4;
+pub const Anum_pg_operator_oprkind: u32 = 5;
+pub const Anum_pg_operator_oprcanmerge: u32 = 6;
+pub const Anum_pg_operator_oprcanhash: u32 = 7;
+pub const Anum_pg_operator_oprleft: u32 = 8;
+pub const Anum_pg_operator_oprright: u32 = 9;
+pub const Anum_pg_operator_oprresult: u32 = 10;
+pub const Anum_pg_operator_oprcom: u32 = 11;
+pub const Anum_pg_operator_oprnegate: u32 = 12;
+pub const Anum_pg_operator_oprcode: u32 = 13;
+pub const Anum_pg_operator_oprrest: u32 = 14;
+pub const Anum_pg_operator_oprjoin: u32 = 15;
+pub const Natts_pg_operator: u32 = 15;
+pub const BooleanNotEqualOperator: u32 = 85;
+pub const BooleanEqualOperator: u32 = 91;
+pub const Int4EqualOperator: u32 = 96;
+pub const Int4LessOperator: u32 = 97;
+pub const TextEqualOperator: u32 = 98;
+pub const NameEqualTextOperator: u32 = 254;
+pub const NameLessTextOperator: u32 = 255;
+pub const NameGreaterEqualTextOperator: u32 = 257;
+pub const TIDEqualOperator: u32 = 387;
+pub const TIDLessOperator: u32 = 2799;
+pub const Int8LessOperator: u32 = 412;
+pub const OID_NAME_REGEXEQ_OP: u32 = 639;
+pub const OID_TEXT_REGEXEQ_OP: u32 = 641;
+pub const TextLessOperator: u32 = 664;
+pub const TextGreaterEqualOperator: u32 = 667;
+pub const Float8LessOperator: u32 = 672;
+pub const BpcharEqualOperator: u32 = 1054;
+pub const OID_BPCHAR_REGEXEQ_OP: u32 = 1055;
+pub const BpcharLessOperator: u32 = 1058;
+pub const BpcharGreaterEqualOperator: u32 = 1061;
+pub const ARRAY_EQ_OP: u32 = 1070;
+pub const ARRAY_LT_OP: u32 = 1072;
+pub const ARRAY_GT_OP: u32 = 1073;
+pub const OID_NAME_LIKE_OP: u32 = 1207;
+pub const OID_TEXT_LIKE_OP: u32 = 1209;
+pub const OID_BPCHAR_LIKE_OP: u32 = 1211;
+pub const OID_NAME_ICREGEXEQ_OP: u32 = 1226;
+pub const OID_TEXT_ICREGEXEQ_OP: u32 = 1228;
+pub const OID_BPCHAR_ICREGEXEQ_OP: u32 = 1234;
+pub const OID_INET_SUB_OP: u32 = 931;
+pub const OID_INET_SUBEQ_OP: u32 = 932;
+pub const OID_INET_SUP_OP: u32 = 933;
+pub const OID_INET_SUPEQ_OP: u32 = 934;
+pub const OID_INET_OVERLAP_OP: u32 = 3552;
+pub const OID_NAME_ICLIKE_OP: u32 = 1625;
+pub const OID_TEXT_ICLIKE_OP: u32 = 1627;
+pub const OID_BPCHAR_ICLIKE_OP: u32 = 1629;
+pub const ByteaEqualOperator: u32 = 1955;
+pub const ByteaLessOperator: u32 = 1957;
+pub const ByteaGreaterEqualOperator: u32 = 1960;
+pub const OID_BYTEA_LIKE_OP: u32 = 2016;
+pub const TextPatternLessOperator: u32 = 2314;
+pub const TextPatternGreaterEqualOperator: u32 = 2317;
+pub const BpcharPatternLessOperator: u32 = 2326;
+pub const BpcharPatternGreaterEqualOperator: u32 = 2329;
+pub const OID_ARRAY_OVERLAP_OP: u32 = 2750;
+pub const OID_ARRAY_CONTAINS_OP: u32 = 2751;
+pub const OID_ARRAY_CONTAINED_OP: u32 = 2752;
+pub const RECORD_EQ_OP: u32 = 2988;
+pub const RECORD_LT_OP: u32 = 2990;
+pub const RECORD_GT_OP: u32 = 2991;
+pub const OID_RANGE_LESS_OP: u32 = 3884;
+pub const OID_RANGE_LESS_EQUAL_OP: u32 = 3885;
+pub const OID_RANGE_GREATER_EQUAL_OP: u32 = 3886;
+pub const OID_RANGE_GREATER_OP: u32 = 3887;
+pub const OID_RANGE_OVERLAP_OP: u32 = 3888;
+pub const OID_RANGE_CONTAINS_ELEM_OP: u32 = 3889;
+pub const OID_RANGE_CONTAINS_OP: u32 = 3890;
+pub const OID_RANGE_ELEM_CONTAINED_OP: u32 = 3891;
+pub const OID_RANGE_CONTAINED_OP: u32 = 3892;
+pub const OID_RANGE_LEFT_OP: u32 = 3893;
+pub const OID_RANGE_RIGHT_OP: u32 = 3894;
+pub const OID_RANGE_OVERLAPS_LEFT_OP: u32 = 3895;
+pub const OID_RANGE_OVERLAPS_RIGHT_OP: u32 = 3896;
 pub const ProcedureRelationId: u32 = 1255;
 pub const ProcedureRelation_Rowtype_Id: u32 = 81;
 pub const Anum_pg_proc_oid: u32 = 1;
@@ -3060,7 +3138,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3239,15 +3316,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3259,6 +3332,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3421,10 +3498,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3702,6 +3775,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3710,14 +3791,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3744,6 +3825,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4070,13 +4159,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4427,15 +4509,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4455,10 +4537,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5633,7 +5712,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5873,10 +5951,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -24575,8 +24651,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -24817,6 +24891,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -35393,6 +35475,63 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn AtEOXact_Enum();
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_operator {
+    pub oid: Oid,
+    pub oprname: NameData,
+    pub oprnamespace: Oid,
+    pub oprowner: Oid,
+    pub oprkind: ::std::os::raw::c_char,
+    pub oprcanmerge: bool,
+    pub oprcanhash: bool,
+    pub oprleft: Oid,
+    pub oprright: Oid,
+    pub oprresult: Oid,
+    pub oprcom: Oid,
+    pub oprnegate: Oid,
+    pub oprcode: regproc,
+    pub oprrest: regproc,
+    pub oprjoin: regproc,
+}
+impl Default for FormData_pg_operator {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_operator = *mut FormData_pg_operator;
+#[pg_guard]
+extern "C" {
+    pub fn OperatorCreate(
+        operatorName: *const ::std::os::raw::c_char,
+        operatorNamespace: Oid,
+        leftTypeId: Oid,
+        rightTypeId: Oid,
+        procedureId: Oid,
+        commutatorName: *mut List,
+        negatorName: *mut List,
+        restrictionId: Oid,
+        joinId: Oid,
+        canMerge: bool,
+        canHash: bool,
+    ) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn makeOperatorDependencies(
+        tuple: HeapTuple,
+        makeExtensionDep: bool,
+        isUpdate: bool,
+    ) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn OperatorUpd(baseId: Oid, commId: Oid, negId: Oid, isDelete: bool);
 }
 #[repr(C)]
 #[derive(Debug)]

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -178,7 +178,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 102usize] = b" '--prefix=/home/ana/.pgx/14.2/pgx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 104usize] = b" '--prefix=/home/einar/.pgx/14.2/pgx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28814;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28814\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -335,7 +335,7 @@ pub const PG_MINORVERSION_NUM: u32 = 2;
 pub const PG_USE_STDBOOL: u32 = 1;
 pub const PG_VERSION: &[u8; 5usize] = b"14.2\0";
 pub const PG_VERSION_NUM: u32 = 140002;
-pub const PG_VERSION_STR : & [u8 ; 96usize] = b"PostgreSQL 14.2 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0, 64-bit\0" ;
+pub const PG_VERSION_STR : & [u8 ; 101usize] = b"PostgreSQL 14.2 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -386,10 +386,6 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
@@ -401,26 +397,28 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 34;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _____fpos_t_defined: u32 = 1;
@@ -447,6 +445,19 @@ pub const TMP_MAX: u32 = 238328;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
+pub const _STDLIB_H: u32 = 1;
+pub const WNOHANG: u32 = 1;
+pub const WUNTRACED: u32 = 2;
+pub const WSTOPPED: u32 = 2;
+pub const WEXITED: u32 = 4;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __ENUM_IDTYPE_T: u32 = 1;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
 pub const __HAVE_FLOAT128: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
 pub const __HAVE_FLOAT64X: u32 = 1;
@@ -463,18 +474,6 @@ pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
 pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
 pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
-pub const _STDLIB_H: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WSTOPPED: u32 = 2;
-pub const WEXITED: u32 = 4;
-pub const WCONTINUED: u32 = 8;
-pub const WNOWAIT: u32 = 16777216;
-pub const __WNOTHREAD: u32 = 536870912;
-pub const __WALL: u32 = 1073741824;
-pub const __WCLONE: u32 = 2147483648;
-pub const __W_CONTINUED: u32 = 65535;
-pub const __WCOREFLAG: u32 = 128;
 pub const __ldiv_t_defined: u32 = 1;
 pub const __lldiv_t_defined: u32 = 1;
 pub const RAND_MAX: u32 = 2147483647;
@@ -502,6 +501,7 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
+pub const __FD_ZERO_STOS: &[u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -981,9 +981,6 @@ pub const SO_TIMESTAMPING_NEW: u32 = 65;
 pub const SO_RCVTIMEO_NEW: u32 = 66;
 pub const SO_SNDTIMEO_NEW: u32 = 67;
 pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
-pub const SO_PREFER_BUSY_POLL: u32 = 69;
-pub const SO_BUSY_POLL_BUDGET: u32 = 70;
-pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1042,7 +1039,6 @@ pub const IP_NODEFRAG: u32 = 22;
 pub const IP_CHECKSUM: u32 = 23;
 pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
 pub const IP_RECVFRAGSIZE: u32 = 25;
-pub const IP_RECVERR_RFC4884: u32 = 26;
 pub const IP_PMTUDISC_DONT: u32 = 0;
 pub const IP_PMTUDISC_WANT: u32 = 1;
 pub const IP_PMTUDISC_DO: u32 = 2;
@@ -1078,7 +1074,6 @@ pub const IPV6_JOIN_ANYCAST: u32 = 27;
 pub const IPV6_LEAVE_ANYCAST: u32 = 28;
 pub const IPV6_MULTICAST_ALL: u32 = 29;
 pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
-pub const IPV6_RECVERR_RFC4884: u32 = 31;
 pub const IPV6_IPSEC_POLICY: u32 = 34;
 pub const IPV6_XFRM_POLICY: u32 = 35;
 pub const IPV6_HDRINCL: u32 = 36;
@@ -1210,7 +1205,6 @@ pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
 pub const _SETJMP_H: u32 = 1;
 pub const _BITS_SETJMP_H: u32 = 1;
-pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1366,7 +1360,10 @@ pub const AT_REMOVEDIR: u32 = 512;
 pub const AT_SYMLINK_FOLLOW: u32 = 1024;
 pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
-pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const _STAT_VER_KERNEL: u32 = 0;
+pub const _STAT_VER_LINUX: u32 = 1;
+pub const _MKNOD_VER_LINUX: u32 = 0;
+pub const _STAT_VER: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -2053,6 +2050,7 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_H: u32 = 1;
 pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGILL: u32 = 4;
@@ -2064,34 +2062,33 @@ pub const SIGHUP: u32 = 1;
 pub const SIGQUIT: u32 = 3;
 pub const SIGTRAP: u32 = 5;
 pub const SIGKILL: u32 = 9;
+pub const SIGBUS: u32 = 10;
+pub const SIGSYS: u32 = 12;
 pub const SIGPIPE: u32 = 13;
 pub const SIGALRM: u32 = 14;
-pub const SIGIOT: u32 = 6;
-pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
-pub const SIGSTKFLT: u32 = 16;
-pub const SIGPWR: u32 = 30;
-pub const SIGBUS: u32 = 7;
-pub const SIGSYS: u32 = 31;
-pub const SIGURG: u32 = 23;
-pub const SIGSTOP: u32 = 19;
-pub const SIGTSTP: u32 = 20;
-pub const SIGCONT: u32 = 18;
-pub const SIGCHLD: u32 = 17;
+pub const SIGURG: u32 = 16;
+pub const SIGSTOP: u32 = 17;
+pub const SIGTSTP: u32 = 18;
+pub const SIGCONT: u32 = 19;
+pub const SIGCHLD: u32 = 20;
 pub const SIGTTIN: u32 = 21;
 pub const SIGTTOU: u32 = 22;
-pub const SIGPOLL: u32 = 29;
-pub const SIGXFSZ: u32 = 25;
+pub const SIGPOLL: u32 = 23;
 pub const SIGXCPU: u32 = 24;
+pub const SIGXFSZ: u32 = 25;
 pub const SIGVTALRM: u32 = 26;
 pub const SIGPROF: u32 = 27;
-pub const SIGUSR1: u32 = 10;
-pub const SIGUSR2: u32 = 12;
+pub const SIGUSR1: u32 = 30;
+pub const SIGUSR2: u32 = 31;
 pub const SIGWINCH: u32 = 28;
-pub const SIGIO: u32 = 29;
-pub const SIGCLD: u32 = 17;
+pub const SIGIO: u32 = 23;
+pub const SIGIOT: u32 = 6;
+pub const SIGCLD: u32 = 20;
 pub const __SIGRTMIN: u32 = 32;
-pub const __SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 65;
+pub const __SIGRTMAX: u32 = 32;
+pub const _NSIG: u32 = 33;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
 pub const __sig_atomic_t_defined: u32 = 1;
 pub const __siginfo_t_defined: u32 = 1;
 pub const __SI_MAX_SIZE: u32 = 128;
@@ -2103,7 +2100,7 @@ pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
 pub const __sigevent_t_defined: u32 = 1;
 pub const __SIGEV_MAX_SIZE: u32 = 64;
 pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
-pub const NSIG: u32 = 65;
+pub const NSIG: u32 = 33;
 pub const _BITS_SIGACTION_H: u32 = 1;
 pub const SA_NOCLDSTOP: u32 = 1;
 pub const SA_NOCLDWAIT: u32 = 2;
@@ -2515,6 +2512,122 @@ pub const Natts_pg_enum: u32 = 4;
 pub const EnumOidIndexId: u32 = 3502;
 pub const EnumTypIdLabelIndexId: u32 = 3503;
 pub const EnumTypIdSortOrderIndexId: u32 = 3534;
+pub const OperatorRelationId: u32 = 2617;
+pub const Anum_pg_operator_oid: u32 = 1;
+pub const Anum_pg_operator_oprname: u32 = 2;
+pub const Anum_pg_operator_oprnamespace: u32 = 3;
+pub const Anum_pg_operator_oprowner: u32 = 4;
+pub const Anum_pg_operator_oprkind: u32 = 5;
+pub const Anum_pg_operator_oprcanmerge: u32 = 6;
+pub const Anum_pg_operator_oprcanhash: u32 = 7;
+pub const Anum_pg_operator_oprleft: u32 = 8;
+pub const Anum_pg_operator_oprright: u32 = 9;
+pub const Anum_pg_operator_oprresult: u32 = 10;
+pub const Anum_pg_operator_oprcom: u32 = 11;
+pub const Anum_pg_operator_oprnegate: u32 = 12;
+pub const Anum_pg_operator_oprcode: u32 = 13;
+pub const Anum_pg_operator_oprrest: u32 = 14;
+pub const Anum_pg_operator_oprjoin: u32 = 15;
+pub const Natts_pg_operator: u32 = 15;
+pub const BooleanNotEqualOperator: u32 = 85;
+pub const BooleanEqualOperator: u32 = 91;
+pub const Int4EqualOperator: u32 = 96;
+pub const Int4LessOperator: u32 = 97;
+pub const TextEqualOperator: u32 = 98;
+pub const NameEqualTextOperator: u32 = 254;
+pub const NameLessTextOperator: u32 = 255;
+pub const NameGreaterEqualTextOperator: u32 = 257;
+pub const TIDEqualOperator: u32 = 387;
+pub const TIDLessOperator: u32 = 2799;
+pub const TIDGreaterOperator: u32 = 2800;
+pub const TIDLessEqOperator: u32 = 2801;
+pub const TIDGreaterEqOperator: u32 = 2802;
+pub const Int8LessOperator: u32 = 412;
+pub const OID_NAME_REGEXEQ_OP: u32 = 639;
+pub const OID_TEXT_REGEXEQ_OP: u32 = 641;
+pub const TextLessOperator: u32 = 664;
+pub const TextGreaterEqualOperator: u32 = 667;
+pub const Float8LessOperator: u32 = 672;
+pub const BpcharEqualOperator: u32 = 1054;
+pub const OID_BPCHAR_REGEXEQ_OP: u32 = 1055;
+pub const BpcharLessOperator: u32 = 1058;
+pub const BpcharGreaterEqualOperator: u32 = 1061;
+pub const ARRAY_EQ_OP: u32 = 1070;
+pub const ARRAY_LT_OP: u32 = 1072;
+pub const ARRAY_GT_OP: u32 = 1073;
+pub const OID_NAME_LIKE_OP: u32 = 1207;
+pub const OID_TEXT_LIKE_OP: u32 = 1209;
+pub const OID_BPCHAR_LIKE_OP: u32 = 1211;
+pub const OID_NAME_ICREGEXEQ_OP: u32 = 1226;
+pub const OID_TEXT_ICREGEXEQ_OP: u32 = 1228;
+pub const OID_BPCHAR_ICREGEXEQ_OP: u32 = 1234;
+pub const OID_INET_SUB_OP: u32 = 931;
+pub const OID_INET_SUBEQ_OP: u32 = 932;
+pub const OID_INET_SUP_OP: u32 = 933;
+pub const OID_INET_SUPEQ_OP: u32 = 934;
+pub const OID_INET_OVERLAP_OP: u32 = 3552;
+pub const OID_NAME_ICLIKE_OP: u32 = 1625;
+pub const OID_TEXT_ICLIKE_OP: u32 = 1627;
+pub const OID_BPCHAR_ICLIKE_OP: u32 = 1629;
+pub const ByteaEqualOperator: u32 = 1955;
+pub const ByteaLessOperator: u32 = 1957;
+pub const ByteaGreaterEqualOperator: u32 = 1960;
+pub const OID_BYTEA_LIKE_OP: u32 = 2016;
+pub const TextPatternLessOperator: u32 = 2314;
+pub const TextPatternGreaterEqualOperator: u32 = 2317;
+pub const BpcharPatternLessOperator: u32 = 2326;
+pub const BpcharPatternGreaterEqualOperator: u32 = 2329;
+pub const OID_ARRAY_OVERLAP_OP: u32 = 2750;
+pub const OID_ARRAY_CONTAINS_OP: u32 = 2751;
+pub const OID_ARRAY_CONTAINED_OP: u32 = 2752;
+pub const RECORD_EQ_OP: u32 = 2988;
+pub const RECORD_LT_OP: u32 = 2990;
+pub const RECORD_GT_OP: u32 = 2991;
+pub const OID_RANGE_LESS_OP: u32 = 3884;
+pub const OID_RANGE_LESS_EQUAL_OP: u32 = 3885;
+pub const OID_RANGE_GREATER_EQUAL_OP: u32 = 3886;
+pub const OID_RANGE_GREATER_OP: u32 = 3887;
+pub const OID_RANGE_OVERLAP_OP: u32 = 3888;
+pub const OID_RANGE_CONTAINS_ELEM_OP: u32 = 3889;
+pub const OID_RANGE_CONTAINS_OP: u32 = 3890;
+pub const OID_RANGE_ELEM_CONTAINED_OP: u32 = 3891;
+pub const OID_RANGE_CONTAINED_OP: u32 = 3892;
+pub const OID_RANGE_LEFT_OP: u32 = 3893;
+pub const OID_RANGE_RIGHT_OP: u32 = 3894;
+pub const OID_RANGE_OVERLAPS_LEFT_OP: u32 = 3895;
+pub const OID_RANGE_OVERLAPS_RIGHT_OP: u32 = 3896;
+pub const OID_MULTIRANGE_LESS_OP: u32 = 2862;
+pub const OID_MULTIRANGE_LESS_EQUAL_OP: u32 = 2863;
+pub const OID_MULTIRANGE_GREATER_EQUAL_OP: u32 = 2864;
+pub const OID_MULTIRANGE_GREATER_OP: u32 = 2865;
+pub const OID_RANGE_OVERLAPS_MULTIRANGE_OP: u32 = 2866;
+pub const OID_MULTIRANGE_OVERLAPS_RANGE_OP: u32 = 2867;
+pub const OID_MULTIRANGE_OVERLAPS_MULTIRANGE_OP: u32 = 2868;
+pub const OID_MULTIRANGE_CONTAINS_ELEM_OP: u32 = 2869;
+pub const OID_MULTIRANGE_CONTAINS_RANGE_OP: u32 = 2870;
+pub const OID_MULTIRANGE_CONTAINS_MULTIRANGE_OP: u32 = 2871;
+pub const OID_MULTIRANGE_ELEM_CONTAINED_OP: u32 = 2872;
+pub const OID_MULTIRANGE_RANGE_CONTAINED_OP: u32 = 2873;
+pub const OID_MULTIRANGE_MULTIRANGE_CONTAINED_OP: u32 = 2874;
+pub const OID_RANGE_CONTAINS_MULTIRANGE_OP: u32 = 4539;
+pub const OID_RANGE_MULTIRANGE_CONTAINED_OP: u32 = 4540;
+pub const OID_RANGE_OVERLAPS_LEFT_MULTIRANGE_OP: u32 = 2875;
+pub const OID_MULTIRANGE_OVERLAPS_LEFT_RANGE_OP: u32 = 2876;
+pub const OID_MULTIRANGE_OVERLAPS_LEFT_MULTIRANGE_OP: u32 = 2877;
+pub const OID_RANGE_OVERLAPS_RIGHT_MULTIRANGE_OP: u32 = 3585;
+pub const OID_MULTIRANGE_OVERLAPS_RIGHT_RANGE_OP: u32 = 4035;
+pub const OID_MULTIRANGE_OVERLAPS_RIGHT_MULTIRANGE_OP: u32 = 4142;
+pub const OID_RANGE_ADJACENT_MULTIRANGE_OP: u32 = 4179;
+pub const OID_MULTIRANGE_ADJACENT_RANGE_OP: u32 = 4180;
+pub const OID_MULTIRANGE_ADJACENT_MULTIRANGE_OP: u32 = 4198;
+pub const OID_RANGE_LEFT_MULTIRANGE_OP: u32 = 4395;
+pub const OID_MULTIRANGE_LEFT_RANGE_OP: u32 = 4396;
+pub const OID_MULTIRANGE_LEFT_MULTIRANGE_OP: u32 = 4397;
+pub const OID_RANGE_RIGHT_MULTIRANGE_OP: u32 = 4398;
+pub const OID_MULTIRANGE_RIGHT_RANGE_OP: u32 = 4399;
+pub const OID_MULTIRANGE_RIGHT_MULTIRANGE_OP: u32 = 4400;
+pub const OperatorOidIndexId: u32 = 2688;
+pub const OperatorNameNspIndexId: u32 = 2689;
 pub const ProcedureRelationId: u32 = 1255;
 pub const ProcedureRelation_Rowtype_Id: u32 = 81;
 pub const Anum_pg_proc_oid: u32 = 1;
@@ -3127,7 +3240,6 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -3306,15 +3418,11 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 #[pg_guard]
 extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 #[pg_guard]
 extern "C" {
@@ -3326,6 +3434,10 @@ extern "C" {
         __dir: *const ::std::os::raw::c_char,
         __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
+}
+#[pg_guard]
+extern "C" {
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3488,10 +3600,6 @@ extern "C" {
         ...
     ) -> ::std::os::raw::c_int;
 }
-pub type _Float32 = f32;
-pub type _Float64 = f64;
-pub type _Float32x = f64;
-pub type _Float64x = u128;
 #[pg_guard]
 extern "C" {
     #[link_name = "\u{1}__isoc99_fscanf"]
@@ -3769,6 +3877,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
+    pub static mut sys_nerr: ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+}
+#[pg_guard]
+extern "C" {
     pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
@@ -3777,14 +3893,14 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
-}
-#[pg_guard]
-extern "C" {
     pub fn popen(
         __command: *const ::std::os::raw::c_char,
         __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
+}
+#[pg_guard]
+extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 #[pg_guard]
 extern "C" {
@@ -3811,6 +3927,14 @@ extern "C" {
     pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type wchar_t = ::std::os::raw::c_int;
+pub const idtype_t_P_ALL: idtype_t = 0;
+pub const idtype_t_P_PID: idtype_t = 1;
+pub const idtype_t_P_PGID: idtype_t = 2;
+pub type idtype_t = ::std::os::raw::c_uint;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -4137,13 +4261,6 @@ impl Default for __pthread_cond_s {
             s.assume_init()
         }
     }
-}
-pub type __tss_t = ::std::os::raw::c_uint;
-pub type __thrd_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __once_flag {
-    pub __data: ::std::os::raw::c_int,
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]
@@ -4494,15 +4611,15 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn free(__ptr: *mut ::std::os::raw::c_void);
-}
-#[pg_guard]
-extern "C" {
     pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
         __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+#[pg_guard]
+extern "C" {
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[pg_guard]
 extern "C" {
@@ -4522,10 +4639,7 @@ extern "C" {
 }
 #[pg_guard]
 extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 #[pg_guard]
 extern "C" {
@@ -5696,7 +5810,6 @@ pub struct __kernel_fsid_t {
 }
 pub type __kernel_off_t = __kernel_long_t;
 pub type __kernel_loff_t = ::std::os::raw::c_longlong;
-pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_time64_t = ::std::os::raw::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
@@ -5936,10 +6049,8 @@ pub const IPPROTO_COMP: ::std::os::raw::c_uint = 108;
 pub const IPPROTO_SCTP: ::std::os::raw::c_uint = 132;
 pub const IPPROTO_UDPLITE: ::std::os::raw::c_uint = 136;
 pub const IPPROTO_MPLS: ::std::os::raw::c_uint = 137;
-pub const IPPROTO_ETHERNET: ::std::os::raw::c_uint = 143;
 pub const IPPROTO_RAW: ::std::os::raw::c_uint = 255;
-pub const IPPROTO_MPTCP: ::std::os::raw::c_uint = 262;
-pub const IPPROTO_MAX: ::std::os::raw::c_uint = 263;
+pub const IPPROTO_MAX: ::std::os::raw::c_uint = 256;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
 pub const IPPROTO_HOPOPTS: ::std::os::raw::c_uint = 0;
 pub const IPPROTO_ROUTING: ::std::os::raw::c_uint = 43;
@@ -25224,8 +25335,6 @@ pub const SEGV_PKUERR: ::std::os::raw::c_uint = 4;
 pub const SEGV_ACCADI: ::std::os::raw::c_uint = 5;
 pub const SEGV_ADIDERR: ::std::os::raw::c_uint = 6;
 pub const SEGV_ADIPERR: ::std::os::raw::c_uint = 7;
-pub const SEGV_MTEAERR: ::std::os::raw::c_uint = 8;
-pub const SEGV_MTESERR: ::std::os::raw::c_uint = 9;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 pub const BUS_ADRALN: ::std::os::raw::c_uint = 1;
 pub const BUS_ADRERR: ::std::os::raw::c_uint = 2;
@@ -25466,6 +25575,14 @@ extern "C" {
         __sig: ::std::os::raw::c_int,
         __val: sigval,
     ) -> ::std::os::raw::c_int;
+}
+#[pg_guard]
+extern "C" {
+    pub static _sys_siglist: [*const ::std::os::raw::c_char; 65usize];
+}
+#[pg_guard]
+extern "C" {
+    pub static sys_siglist: [*const ::std::os::raw::c_char; 65usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -35575,6 +35692,63 @@ extern "C" {
 #[pg_guard]
 extern "C" {
     pub fn AtEOXact_Enum();
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_operator {
+    pub oid: Oid,
+    pub oprname: NameData,
+    pub oprnamespace: Oid,
+    pub oprowner: Oid,
+    pub oprkind: ::std::os::raw::c_char,
+    pub oprcanmerge: bool,
+    pub oprcanhash: bool,
+    pub oprleft: Oid,
+    pub oprright: Oid,
+    pub oprresult: Oid,
+    pub oprcom: Oid,
+    pub oprnegate: Oid,
+    pub oprcode: regproc,
+    pub oprrest: regproc,
+    pub oprjoin: regproc,
+}
+impl Default for FormData_pg_operator {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_operator = *mut FormData_pg_operator;
+#[pg_guard]
+extern "C" {
+    pub fn OperatorCreate(
+        operatorName: *const ::std::os::raw::c_char,
+        operatorNamespace: Oid,
+        leftTypeId: Oid,
+        rightTypeId: Oid,
+        procedureId: Oid,
+        commutatorName: *mut List,
+        negatorName: *mut List,
+        restrictionId: Oid,
+        joinId: Oid,
+        canMerge: bool,
+        canHash: bool,
+    ) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn makeOperatorDependencies(
+        tuple: HeapTuple,
+        makeExtensionDep: bool,
+        isUpdate: bool,
+    ) -> ObjectAddress;
+}
+#[pg_guard]
+extern "C" {
+    pub fn OperatorUpd(baseId: Oid, commId: Oid, negId: Oid, isDelete: bool);
 }
 #[repr(C)]
 #[derive(Debug)]


### PR DESCRIPTION
Really just the `FormData_pg_operator` struct and a few associated methods, which is useful when looking up operators from queries.

I'm noticing that regenerating bindings has a tendency to make a few OS and even user related changes. Not sure if you care about that.