### PR TITLE
Remove dead --workspace flag on cargo pgx test

### DIFF
--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -35,9 +35,6 @@ pub(crate) struct Test {
     /// Path to Cargo.toml
     #[clap(long, parse(from_os_str))]
     manifest_path: Option<PathBuf>,
-    /// Test all packages in the workspace
-    #[clap(long)]
-    workspace: bool,
     /// compile for release mode (default is debug)
     #[clap(env = "PROFILE", long, short)]
     release: bool,


### PR DESCRIPTION
In #475 we accidently slipped in a `cargo pgx test --workspace` flag that does nothing. Note discussion at https://github.com/tcdi/pgx/pull/475#issuecomment-1067335953.