### PR TITLE
FromDatum overhaul

### DIFF
--- a/pgx-examples/bgworker/src/lib.rs
+++ b/pgx-examples/bgworker/src/lib.rs
@@ -40,7 +40,7 @@ pub extern "C" fn _PG_init() {
 #[pg_guard]
 #[no_mangle]
 pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {
-    let arg = unsafe { i32::from_datum(arg, false, pg_sys::INT4OID) };
+    let arg = unsafe { i32::from_datum(arg, false) };
 
     // these are the signals we want to receive.  If we don't attach the SIGTERM handler, then
     // we'll never be able to exit via an external notification

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -642,7 +642,7 @@ fn impl_postgres_enum(ast: DeriveInput) -> proc_macro2::TokenStream {
     stream.extend(quote! {
         impl pgx::FromDatum for #enum_ident {
             #[inline]
-            unsafe fn from_datum(datum: pgx::pg_sys::Datum, is_null: bool, typeoid: pgx::pg_sys::Oid) -> Option<#enum_ident> {
+            unsafe fn from_datum(datum: pgx::pg_sys::Datum, is_null: bool) -> Option<#enum_ident> {
                 if is_null {
                     None
                 } else {

--- a/pgx/src/datum/anyarray.rs
+++ b/pgx/src/datum/anyarray.rs
@@ -12,7 +12,6 @@ use crate::{pg_sys, FromDatum, IntoDatum};
 #[derive(Debug, Clone, Copy)]
 pub struct AnyArray {
     datum: pg_sys::Datum,
-    typoid: pg_sys::Oid,
 }
 
 impl AnyArray {
@@ -20,27 +19,19 @@ impl AnyArray {
         self.datum
     }
 
-    pub fn oid(&self) -> pg_sys::Oid {
-        self.typoid
-    }
-
     #[inline]
     pub fn into<T: FromDatum>(&self) -> Option<T> {
-        unsafe { T::from_datum(self.datum(), false, self.oid()) }
+        unsafe { T::from_datum(self.datum(), false) }
     }
 }
 
 impl FromDatum for AnyArray {
     #[inline]
-    unsafe fn from_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        typoid: pg_sys::Oid,
-    ) -> Option<AnyArray> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<AnyArray> {
         if is_null {
             None
         } else {
-            Some(AnyArray { datum, typoid })
+            Some(AnyArray { datum })
         }
     }
 }

--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -12,7 +12,6 @@ use crate::{pg_sys, FromDatum, IntoDatum};
 #[derive(Debug, Clone, Copy)]
 pub struct AnyElement {
     datum: pg_sys::Datum,
-    typoid: pg_sys::Oid,
 }
 
 impl AnyElement {
@@ -20,27 +19,19 @@ impl AnyElement {
         self.datum
     }
 
-    pub fn oid(&self) -> pg_sys::Oid {
-        self.typoid
-    }
-
     #[inline]
     pub fn into<T: FromDatum>(&self) -> Option<T> {
-        unsafe { T::from_datum(self.datum(), false, self.oid()) }
+        unsafe { T::from_datum(self.datum(), false) }
     }
 }
 
 impl FromDatum for AnyElement {
     #[inline]
-    unsafe fn from_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        typoid: pg_sys::Oid,
-    ) -> Option<AnyElement> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<AnyElement> {
         if is_null {
             None
         } else {
-            Some(AnyElement { datum, typoid })
+            Some(AnyElement { datum })
         }
     }
 }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -389,11 +389,16 @@ where
     fn type_oid() -> u32 {
         unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
+
+    #[inline]
+    fn is_compatible_with(other: pg_sys::Oid) -> bool {
+        Self::type_oid() == other || other == unsafe { pg_sys::get_array_type(T::type_oid()) }
+    }
 }
 
 impl<'a, T> IntoDatum for &'a [T]
 where
-    T: IntoDatum + Copy,
+    T: IntoDatum + Copy + 'a,
 {
     fn into_datum(self) -> Option<pg_sys::Datum> {
         let mut state = unsafe {
@@ -430,5 +435,10 @@ where
 
     fn type_oid() -> u32 {
         unsafe { pg_sys::get_array_type(T::type_oid()) }
+    }
+
+    #[inline]
+    fn is_compatible_with(other: pg_sys::Oid) -> bool {
+        Self::type_oid() == other || other == unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
 }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -276,8 +276,6 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
     unsafe fn from_datum(datum: usize, is_null: bool) -> Option<Array<'a, T>> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("array was flagged not null but datum is zero");
         } else {
             let ptr = datum as *mut pg_sys::varlena;
             let array =
@@ -322,8 +320,6 @@ impl<T: FromDatum> FromDatum for Vec<T> {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Vec<T>> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("array was flagged not null but datum is zero");
         } else {
             let array = Array::<T>::from_datum(datum, is_null).unwrap();
             let mut v = Vec::with_capacity(array.len());
@@ -341,8 +337,6 @@ impl<T: FromDatum> FromDatum for Vec<Option<T>> {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Vec<Option<T>>> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("array was flagged not null but datum is zero");
         } else {
             let array = Array::<T>::from_datum(datum, is_null).unwrap();
             let mut v = Vec::with_capacity(array.len());

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -15,7 +15,7 @@ use time::format_description::FormatItem;
 pub struct Date(time::Date);
 impl FromDatum for Date {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Date> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Date> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -14,7 +14,6 @@ use time::format_description::FormatItem;
 #[derive(Debug)]
 pub struct Date(time::Date);
 impl FromDatum for Date {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Date> {
         if is_null {

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -176,8 +176,6 @@ impl<'a> FromDatum for &'a str {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<&'a str> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a varlena Datum was flagged as non-null but the datum is zero");
         } else {
             let varlena = pg_sys::pg_detoast_datum_packed(datum as *mut pg_sys::varlena);
             Some(text_to_rust_str_unchecked(varlena))
@@ -194,8 +192,6 @@ impl<'a> FromDatum for &'a str {
     {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a varlena Datum was flagged as non-null but the datum is zero");
         } else {
             memory_context.switch_to(|_| {
                 // this gets the varlena Datum copied into this memory context
@@ -242,8 +238,6 @@ impl<'a> FromDatum for &'a std::ffi::CStr {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<&'a CStr> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a cstring Datum was flagged as non-null but the datum is zero");
         } else {
             Some(std::ffi::CStr::from_ptr(
                 datum as *const std::os::raw::c_char,
@@ -260,8 +254,6 @@ impl<'a> FromDatum for &'a crate::cstr_core::CStr {
     ) -> Option<&'a crate::cstr_core::CStr> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a cstring Datum was flagged as non-null but the datum is zero");
         } else {
             Some(crate::cstr_core::CStr::from_ptr(
                 datum as *const std::os::raw::c_char,
@@ -276,8 +268,6 @@ impl<'a> FromDatum for &'a [u8] {
     unsafe fn from_datum(datum: usize, is_null: bool) -> Option<&'a [u8]> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a bytea Datum was flagged as non-null but the datum is zero");
         } else {
             let varlena = pg_sys::pg_detoast_datum_packed(datum as *mut pg_sys::varlena);
             Some(varlena_to_byte_slice(varlena))
@@ -294,8 +284,6 @@ impl<'a> FromDatum for &'a [u8] {
     {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a bytea Datum was flagged as non-null but the datum is zero");
         } else {
             memory_context.switch_to(|_| {
                 // this gets the varlena Datum copied into this memory context
@@ -316,8 +304,6 @@ impl FromDatum for Vec<u8> {
     unsafe fn from_datum(datum: usize, is_null: bool) -> Option<Vec<u8>> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a bytea Datum as flagged as non-null but the datum is zero");
         } else {
             // Vec<u8> conversion is initially the same as for &[u8]
             let bytes: Option<&[u8]> = FromDatum::from_datum(datum, is_null);
@@ -346,11 +332,6 @@ impl<T> FromDatum for PgBox<T, AllocatedByPostgres> {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!(
-                "user type {} Datum was flagged as non-null but the datum is zero",
-                std::any::type_name::<T>()
-            );
         } else {
             Some(PgBox::<T>::from_pg(datum as *mut T))
         }
@@ -367,11 +348,6 @@ impl<T> FromDatum for PgBox<T, AllocatedByPostgres> {
         memory_context.switch_to(|context| {
             if is_null {
                 None
-            } else if datum == 0 {
-                panic!(
-                    "user type {} Datum was flagged as non-null but the datum is zero",
-                    std::any::type_name::<T>()
-                );
             } else {
                 let copied = context.copy_ptr_into(datum as *mut T, std::mem::size_of::<T>());
                 Some(PgBox::<T>::from_pg(copied))

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -22,7 +22,6 @@ use std::ffi::CStr;
 /// If implementing this, also implement `IntoDatum` for the reverse
 /// conversion.
 pub trait FromDatum {
-    const NEEDS_TYPID: bool = true;
     /// ## Safety
     ///
     /// This method is inherently unsafe as the `datum` argument can represent an arbitrary
@@ -66,7 +65,6 @@ pub trait FromDatum {
 
 /// for pg_sys::Datum
 impl FromDatum for pg_sys::Datum {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(
         datum: pg_sys::Datum,
@@ -83,7 +81,6 @@ impl FromDatum for pg_sys::Datum {
 
 /// for bool
 impl FromDatum for bool {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<bool> {
         if is_null {
@@ -96,7 +93,6 @@ impl FromDatum for bool {
 
 /// for `"char"`
 impl FromDatum for i8 {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i8> {
         if is_null {
@@ -109,7 +105,6 @@ impl FromDatum for i8 {
 
 /// for smallint
 impl FromDatum for i16 {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i16> {
         if is_null {
@@ -122,7 +117,6 @@ impl FromDatum for i16 {
 
 /// for integer
 impl FromDatum for i32 {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i32> {
         if is_null {
@@ -135,7 +129,6 @@ impl FromDatum for i32 {
 
 /// for oid
 impl FromDatum for u32 {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<u32> {
         if is_null {
@@ -148,7 +141,6 @@ impl FromDatum for u32 {
 
 /// for bigint
 impl FromDatum for i64 {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i64> {
         if is_null {
@@ -161,7 +153,6 @@ impl FromDatum for i64 {
 
 /// for real
 impl FromDatum for f32 {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f32> {
         if is_null {
@@ -174,7 +165,6 @@ impl FromDatum for f32 {
 
 /// for double precision
 impl FromDatum for f64 {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f64> {
         if is_null {
@@ -187,7 +177,6 @@ impl FromDatum for f64 {
 
 /// for text, varchar
 impl<'a> FromDatum for &'a str {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a str> {
         if is_null {
@@ -232,7 +221,6 @@ impl<'a> FromDatum for &'a str {
 ///
 /// This returns a **copy**, allocated and managed by Rust, of the underlying `varlena` Datum
 impl FromDatum for String {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(
         datum: pg_sys::Datum,
@@ -248,7 +236,6 @@ impl FromDatum for String {
 }
 
 impl FromDatum for char {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<char> {
         let refstr: Option<&str> = FromDatum::from_datum(datum, is_null, typoid);
@@ -261,7 +248,6 @@ impl FromDatum for char {
 
 /// for cstring
 impl<'a> FromDatum for &'a std::ffi::CStr {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a CStr> {
         if is_null {
@@ -277,7 +263,6 @@ impl<'a> FromDatum for &'a std::ffi::CStr {
 }
 
 impl<'a> FromDatum for &'a crate::cstr_core::CStr {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(
         datum: pg_sys::Datum,
@@ -298,7 +283,6 @@ impl<'a> FromDatum for &'a crate::cstr_core::CStr {
 
 /// for bytea
 impl<'a> FromDatum for &'a [u8] {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: usize, is_null: bool, _typoid: u32) -> Option<&'a [u8]> {
         if is_null {
@@ -340,7 +324,6 @@ impl<'a> FromDatum for &'a [u8] {
 }
 
 impl FromDatum for Vec<u8> {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: usize, is_null: bool, typoid: u32) -> Option<Vec<u8>> {
         if is_null {
@@ -363,7 +346,6 @@ impl FromDatum for Vec<u8> {
 
 /// for NULL -- always converts to a `None`, even if the is_null argument is false
 impl FromDatum for () {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(_datum: pg_sys::Datum, _is_null: bool, _: pg_sys::Oid) -> Option<()> {
         None
@@ -372,7 +354,6 @@ impl FromDatum for () {
 
 /// for user types
 impl<T> FromDatum for PgBox<T, AllocatedByPostgres> {
-    const NEEDS_TYPID: bool = false;
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self> {
         if is_null {

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -10,7 +10,6 @@ Use of this source code is governed by the MIT license that can be found in the 
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 
 impl FromDatum for pg_sys::BOX {
-    const NEEDS_TYPID: bool = false;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -16,8 +16,6 @@ impl FromDatum for pg_sys::BOX {
     {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("BOX datum declared not null, but datum is zero")
         } else {
             let the_box = datum as *mut pg_sys::BOX;
             Some(the_box.read())
@@ -48,8 +46,6 @@ impl FromDatum for pg_sys::Point {
     {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("Point datum declared not null, but datum is zero")
         } else {
             let point = datum as *mut pg_sys::Point;
             Some(point.read())

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -10,7 +10,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 
 impl FromDatum for pg_sys::BOX {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
     where
         Self: Sized,
     {
@@ -42,7 +42,7 @@ impl IntoDatum for pg_sys::BOX {
 }
 
 impl FromDatum for pg_sys::Point {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -84,7 +84,7 @@ impl<'de> Deserialize<'de> for Inet {
 }
 
 impl FromDatum for Inet {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Inet> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Inet> {
         if is_null {
             None
         } else if datum == 0 {

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -87,8 +87,6 @@ impl FromDatum for Inet {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Inet> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("inet datum is declared non-null but Datum is zero");
         } else {
             let cstr = direct_function_call::<&CStr>(pg_sys::inet_out, vec![Some(datum)]);
             Some(Inet(

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -157,7 +157,7 @@ impl From<Option<pg_sys::Datum>> for Internal {
 
 impl FromDatum for Internal {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Internal> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Internal> {
         Some(Internal(if is_null { None } else { Some(datum) }))
     }
 }

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -13,11 +13,7 @@ use crate::{
 
 impl FromDatum for pg_sys::ItemPointerData {
     #[inline]
-    unsafe fn from_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        _typoid: u32,
-    ) -> Option<pg_sys::ItemPointerData> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<pg_sys::ItemPointerData> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -26,7 +26,7 @@ pub struct JsonString(pub String);
 /// for json
 impl FromDatum for Json {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Json> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Json> {
         if is_null {
             None
         } else if datum == 0 {
@@ -44,7 +44,7 @@ impl FromDatum for Json {
 
 /// for jsonb
 impl FromDatum for JsonB {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<JsonB> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<JsonB> {
         if is_null {
             None
         } else if datum == 0 {
@@ -84,11 +84,7 @@ impl FromDatum for JsonB {
 /// This returns a **copy**, allocated and managed by Rust, of the underlying `varlena` Datum
 impl FromDatum for JsonString {
     #[inline]
-    unsafe fn from_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        _: pg_sys::Oid,
-    ) -> Option<JsonString> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<JsonString> {
         if is_null {
             None
         } else if datum == 0 {

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -29,8 +29,6 @@ impl FromDatum for Json {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Json> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a json Datum was flagged as non-null but the datum is zero");
         } else {
             let varlena = pg_sys::pg_detoast_datum(datum as *mut pg_sys::varlena);
             let len = varsize_any_exhdr(varlena);
@@ -47,8 +45,6 @@ impl FromDatum for JsonB {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<JsonB> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a jsonb Datum was flagged as non-null but the datum is zero")
         } else {
             let varlena = datum as *mut pg_sys::varlena;
             let detoasted = pg_sys::pg_detoast_datum_packed(varlena);
@@ -87,8 +83,6 @@ impl FromDatum for JsonString {
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<JsonString> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a varlena Datum was flagged as non-null but the datum is zero");
         } else {
             let varlena = datum as *mut pg_sys::varlena;
             let detoasted = pg_sys::pg_detoast_datum_packed(varlena);

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -152,7 +152,7 @@ impl Into<Numeric> for f64 {
 }
 
 impl FromDatum for Numeric {
-    unsafe fn from_datum(datum: usize, is_null: bool, _typoid: u32) -> Option<Self>
+    unsafe fn from_datum(datum: usize, is_null: bool) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -21,7 +21,7 @@ pub(crate) const SEC_PER_MIN: i64 = 60;
 pub struct Time(pub(crate) time::Time);
 impl FromDatum for Time {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Time> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Time> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -17,15 +17,14 @@ pub struct Timestamp(time::PrimitiveDateTime);
 
 impl From<pg_sys::Timestamp> for Timestamp {
     fn from(item: pg_sys::Timestamp) -> Self {
-        unsafe { Timestamp::from_datum(item as usize, false, pg_sys::TIMESTAMPOID).unwrap() }
+        unsafe { Timestamp::from_datum(item as usize, false).unwrap() }
     }
 }
 
 impl FromDatum for Timestamp {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: u32) -> Option<Timestamp> {
-        let ts: Option<TimestampWithTimeZone> =
-            TimestampWithTimeZone::from_datum(datum, is_null, typoid);
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Timestamp> {
+        let ts: Option<TimestampWithTimeZone> = TimestampWithTimeZone::from_datum(datum, is_null);
         match ts {
             None => None,
             Some(ts) => {

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -20,18 +20,13 @@ pub struct TimestampWithTimeZone(time::OffsetDateTime);
 
 impl From<pg_sys::TimestampTz> for TimestampWithTimeZone {
     fn from(item: pg_sys::TimestampTz) -> Self {
-        unsafe { TimestampWithTimeZone::from_datum(item as usize, false, pg_sys::TIMESTAMPTZOID).unwrap() }
+        unsafe { TimestampWithTimeZone::from_datum(item as usize, false).unwrap() }
     }
 }
 
-
 impl FromDatum for TimestampWithTimeZone {
     #[inline]
-    unsafe fn from_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        _typoid: u32,
-    ) -> Option<TimestampWithTimeZone> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<TimestampWithTimeZone> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -16,13 +16,13 @@ use time::format_description::FormatItem;
 pub struct TimeWithTimeZone(Time);
 impl FromDatum for TimeWithTimeZone {
     #[inline]
-    unsafe fn from_datum(datum: usize, is_null: bool, typoid: u32) -> Option<TimeWithTimeZone> {
+    unsafe fn from_datum(datum: usize, is_null: bool) -> Option<TimeWithTimeZone> {
         if is_null {
             None
         } else {
             let timetz = PgBox::from_pg(datum as *mut pg_sys::TimeTzADT);
 
-            let mut time = Time::from_datum(timetz.time as pg_sys::Datum, false, typoid)
+            let mut time = Time::from_datum(timetz.time as pg_sys::Datum, false)
                 .expect("failed to convert TimeWithTimeZone");
             time.0 += time::Duration::seconds(timetz.zone as i64);
 

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -49,7 +49,6 @@ where
     A: FromDatum + IntoDatum,
     B: FromDatum + IntoDatum,
 {
-    const NEEDS_TYPID: bool = A::NEEDS_TYPID || B::NEEDS_TYPID;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
@@ -80,7 +79,6 @@ where
     B: FromDatum + IntoDatum,
     C: FromDatum + IntoDatum,
 {
-    const NEEDS_TYPID: bool = A::NEEDS_TYPID || B::NEEDS_TYPID || C::NEEDS_TYPID;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -49,22 +49,22 @@ where
     A: FromDatum + IntoDatum,
     B: FromDatum + IntoDatum,
 {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
     where
         Self: Sized,
     {
-        let mut vec = Vec::<Option<pg_sys::Datum>>::from_datum(datum, is_null, typoid).unwrap();
+        let mut vec = Vec::<Option<pg_sys::Datum>>::from_datum(datum, is_null).unwrap();
         let b = vec.pop().unwrap();
         let a = vec.pop().unwrap();
 
         let a_datum = if a.is_some() {
-            A::from_datum(a.unwrap(), false, A::type_oid())
+            A::from_datum(a.unwrap(), false)
         } else {
             None
         };
 
         let b_datum = if b.is_some() {
-            B::from_datum(b.unwrap(), false, B::type_oid())
+            B::from_datum(b.unwrap(), false)
         } else {
             None
         };
@@ -79,29 +79,29 @@ where
     B: FromDatum + IntoDatum,
     C: FromDatum + IntoDatum,
 {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
     where
         Self: Sized,
     {
-        let mut vec = Vec::<Option<pg_sys::Datum>>::from_datum(datum, is_null, typoid).unwrap();
+        let mut vec = Vec::<Option<pg_sys::Datum>>::from_datum(datum, is_null).unwrap();
         let c = vec.pop().unwrap();
         let b = vec.pop().unwrap();
         let a = vec.pop().unwrap();
 
         let a_datum = if a.is_some() {
-            A::from_datum(a.unwrap(), false, A::type_oid())
+            A::from_datum(a.unwrap(), false)
         } else {
             None
         };
 
         let b_datum = if b.is_some() {
-            B::from_datum(b.unwrap(), false, B::type_oid())
+            B::from_datum(b.unwrap(), false)
         } else {
             None
         };
 
         let c_datum = if c.is_some() {
-            C::from_datum(c.unwrap(), false, C::type_oid())
+            C::from_datum(c.unwrap(), false)
         } else {
             None
         };

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -38,8 +38,6 @@ impl FromDatum for Uuid {
     unsafe fn from_datum(datum: usize, is_null: bool) -> Option<Uuid> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a uuid Datum as flagged as non-null but the datum is zero");
         } else {
             let bytes = std::slice::from_raw_parts(datum as *const u8, UUID_BYTES_LEN);
             if let Ok(uuid) = Uuid::from_slice(bytes) {

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -35,7 +35,7 @@ impl IntoDatum for Uuid {
 
 impl FromDatum for Uuid {
     #[inline]
-    unsafe fn from_datum(datum: usize, is_null: bool, _typoid: pg_sys::Oid) -> Option<Uuid> {
+    unsafe fn from_datum(datum: usize, is_null: bool) -> Option<Uuid> {
         if is_null {
             None
         } else if datum == 0 {

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -298,7 +298,6 @@ impl<T> FromDatum for PgVarlena<T>
 where
     T: Copy + Sized,
 {
-    const NEEDS_TYPID: bool = false;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
         if is_null {
             None

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -313,8 +313,6 @@ where
     ) -> Option<Self> {
         if is_null {
             None
-        } else if datum == 0 {
-            panic!("a varlena Datum was flagged as non-null but the datum is zero");
         } else {
             memory_context.switch_to(|_| {
                 // this gets the varlena Datum copied into this memory context

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -298,7 +298,7 @@ impl<T> FromDatum for PgVarlena<T>
 where
     T: Copy + Sized,
 {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self> {
         if is_null {
             None
         } else {
@@ -310,7 +310,6 @@ where
         mut memory_context: PgMemoryContexts,
         datum: usize,
         is_null: bool,
-        _typoid: u32,
     ) -> Option<Self> {
         if is_null {
             None
@@ -348,7 +347,7 @@ impl<'de, T> FromDatum for T
 where
     T: PostgresType + Deserialize<'de>,
 {
-    unsafe fn from_datum(datum: usize, is_null: bool, _typoid: u32) -> Option<Self> {
+    unsafe fn from_datum(datum: usize, is_null: bool) -> Option<Self> {
         if is_null {
             None
         } else {
@@ -360,7 +359,6 @@ where
         memory_context: PgMemoryContexts,
         datum: usize,
         is_null: bool,
-        _typoid: u32,
     ) -> Option<Self> {
         if is_null {
             None

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -95,11 +95,7 @@ mod pg_10_11 {
         let datum = unsafe { fcinfo.as_ref() }.unwrap().arg[num];
         let isnull = pg_arg_is_null(fcinfo, num);
         unsafe {
-            let typid = if T::NEEDS_TYPID {
-                crate::get_getarg_type(fcinfo, num)
-            } else {
-                pg_sys::InvalidOid
-            };
+            let typid = pg_sys::InvalidOid;
             T::from_datum(datum, isnull, typid)
         }
     }
@@ -138,11 +134,7 @@ mod pg_12_13_14 {
     pub fn pg_getarg<T: FromDatum>(fcinfo: pg_sys::FunctionCallInfo, num: usize) -> Option<T> {
         let datum = get_nullable_datum(fcinfo, num);
         unsafe {
-            let typid = if T::NEEDS_TYPID {
-                crate::get_getarg_type(fcinfo, num)
-            } else {
-                pg_sys::InvalidOid
-            };
+            let typid = pg_sys::InvalidOid;
             T::from_datum(datum.value, datum.isnull, typid)
         }
     }

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -94,10 +94,7 @@ mod pg_10_11 {
     pub fn pg_getarg<T: FromDatum>(fcinfo: pg_sys::FunctionCallInfo, num: usize) -> Option<T> {
         let datum = unsafe { fcinfo.as_ref() }.unwrap().arg[num];
         let isnull = pg_arg_is_null(fcinfo, num);
-        unsafe {
-            let typid = pg_sys::InvalidOid;
-            T::from_datum(datum, isnull, typid)
-        }
+        unsafe { T::from_datum(datum, isnull) }
     }
 
     #[inline]
@@ -133,10 +130,7 @@ mod pg_12_13_14 {
     #[inline]
     pub fn pg_getarg<T: FromDatum>(fcinfo: pg_sys::FunctionCallInfo, num: usize) -> Option<T> {
         let datum = get_nullable_datum(fcinfo, num);
-        unsafe {
-            let typid = pg_sys::InvalidOid;
-            T::from_datum(datum.value, datum.isnull, typid)
-        }
+        unsafe { T::from_datum(datum.value, datum.isnull) }
     }
 
     #[inline]
@@ -269,7 +263,7 @@ pub unsafe fn direct_function_call<R: FromDatum>(
 ) -> Option<R> {
     let datum = direct_function_call_as_datum(func, args);
     match datum {
-        Some(datum) => R::from_datum(datum, false, pg_sys::InvalidOid),
+        Some(datum) => R::from_datum(datum, false),
         None => None,
     }
 }
@@ -306,7 +300,7 @@ pub unsafe fn direct_pg_extern_function_call<R: FromDatum>(
 ) -> Option<R> {
     let datum = direct_pg_extern_function_call_as_datum(func, args);
     match datum {
-        Some(datum) => R::from_datum(datum, false, pg_sys::InvalidOid),
+        Some(datum) => R::from_datum(datum, false),
         None => None,
     }
 }

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -101,15 +101,11 @@ pub fn heap_getattr<
     attno: usize,
     tupdesc: &PgTupleDesc,
 ) -> Option<T> {
-    let mut is_null = false;
-    let datum =
-        unsafe { pgx_heap_getattr(tuple.as_ptr(), attno as u32, tupdesc.as_ptr(), &mut is_null) };
-    let typoid = tupdesc.get(attno - 1).expect("no attribute").type_oid();
+    unsafe {
+        let mut is_null = false;
+        let datum = pgx_heap_getattr(tuple.as_ptr(), attno as u32, tupdesc.as_ptr(), &mut is_null);
 
-    if is_null {
-        None
-    } else {
-        unsafe { T::from_datum(datum, false, typoid.value()) }
+        T::from_datum(datum, is_null)
     }
 }
 
@@ -156,7 +152,7 @@ pub struct DatumWithTypeInfo {
 impl DatumWithTypeInfo {
     #[inline]
     pub fn into_value<T: FromDatum>(self) -> T {
-        unsafe { T::from_datum(self.datum, self.is_null, self.typoid.value()).unwrap() }
+        unsafe { T::from_datum(self.datum, self.is_null).unwrap() }
     }
 }
 

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -308,7 +308,6 @@ impl Clone for PgRelation {
 }
 
 impl FromDatum for PgRelation {
-    const NEEDS_TYPID: bool = false;
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<PgRelation> {
         if is_null {
             None

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -308,7 +308,7 @@ impl Clone for PgRelation {
 }
 
 impl FromDatum for PgRelation {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<PgRelation> {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<PgRelation> {
         if is_null {
             None
         } else {

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -75,6 +75,7 @@ pub struct SpiTupleTable {
 /// Represents a single `pg_sys::Datum` inside a `SpiHeapTupleData`
 pub struct SpiHeapTupleDataEntry {
     datum: Option<pg_sys::Datum>,
+    #[allow(dead_code)]
     type_oid: pg_sys::Oid,
 }
 
@@ -250,7 +251,6 @@ impl Spi {
                                     outer_memory_context,
                                     as_datum.expect("SPI result datum was NULL"),
                                     false,
-                                    pg_sys::InvalidOid,
                                 )
                             }
                         }
@@ -458,7 +458,7 @@ impl SpiTupleTable {
                         let datum =
                             pg_sys::SPI_getbinval(heap_tuple, tupdesc, ordinal, &mut is_null);
 
-                        T::from_datum(datum, is_null, pg_sys::SPI_gettypeid(tupdesc, ordinal))
+                        T::from_datum(datum, is_null)
                     }
                 },
                 None => panic!("TupDesc is NULL"),
@@ -620,7 +620,7 @@ impl<Datum: IntoDatum + FromDatum> From<Datum> for SpiHeapTupleDataEntry {
 impl SpiHeapTupleDataEntry {
     pub fn value<T: FromDatum>(&self) -> Option<T> {
         match self.datum.as_ref() {
-            Some(datum) => unsafe { T::from_datum(*datum, false, self.type_oid) },
+            Some(datum) => unsafe { T::from_datum(*datum, false) },
             None => None,
         }
     }


### PR DESCRIPTION
This PR overhauls the `FromDatum` trait by making some backwards incompatible API changes.

Primarily, the changes are:

 - Remove the `const NEEDS_TYPID` const field.  All usages of it were `false`
 - Remove the `typid: Oid` argument from the `::from_datum()` function.  This was never used in any meaningful way
 - Add a new `::try_from_datum(datum, is_null, type_oid) -> TryFromDatumResult<Option<Self>, TryFromDatumError)` function that will return an Err if the provided `type_oid` isn't compatible with the desired Rust type
 - Add a new `IntoDatum::is_compatible_with(type_oid)` function to help facilitate the above

Going forward, these changes will be necessary to help implement #502, #499, and to also cleanup our Spi interface.

Once merged, this will definitely require a semver minor version bump.