### PR TITLE
#[pg_guard] cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,6 @@ name = "pgx-macros"
 version = "0.4.2"
 dependencies = [
  "pgx-utils",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "serde",
@@ -1643,16 +1642,6 @@ checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
 dependencies = [
  "proc-macro2",
  "syn",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror",
- "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ members = [
     "pgx-examples/strings",
     "pgx-examples/triggers",
 ]
+
+[profile.dev.build-override]
+opt-level = 3

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -23,7 +23,6 @@ proc-macro2 = "1.0.36"
 quote = "1.0.17"
 syn = { version = "1.0.90", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
-proc-macro-crate = "1.1.3"
 
 [dev-dependencies]
 serde = { version = "1.0.136", features = ["derive"] }

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -10,9 +10,9 @@ Use of this source code is governed by the MIT license that can be found in the 
 extern crate proc_macro;
 
 mod operators;
-mod rewriter;
 use operators::{impl_postgres_eq, impl_postgres_hash, impl_postgres_ord};
 
+use pgx_utils::rewriter::*;
 use pgx_utils::{
     sql_entity_graph::{
         ExtensionSql, ExtensionSqlFile, PgAggregate, PgExtern, PostgresEnum, PostgresType, Schema,
@@ -22,7 +22,6 @@ use pgx_utils::{
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::{quote, quote_spanned, ToTokens};
-use rewriter::*;
 use std::collections::HashSet;
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, Attribute, Data, DeriveInput, Item, ItemFn, ItemImpl};

--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -9,6 +9,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 pub mod guard;
 mod oids;
+pub mod setjmp;
 mod tupdesc;
 mod utils;
 

--- a/pgx-pg-sys/src/submodules/setjmp.rs
+++ b/pgx-pg-sys/src/submodules/setjmp.rs
@@ -1,0 +1,37 @@
+#[inline(always)]
+pub unsafe fn postgres_function_guard<T, F: FnOnce() -> T>(f: F) -> T {
+    use crate as pg_sys;
+
+    // as the panic message says, we can't call Postgres functions from threads
+    // the value of IS_MAIN_THREAD gets set through the pg_module_magic!() macro
+    #[cfg(debug_assertions)]
+    if crate::submodules::guard::IS_MAIN_THREAD.with(|v| v.get().is_none()) {
+        panic!("functions under #[pg_guard] cannot be called from threads");
+    };
+
+    let prev_exception_stack = pg_sys::PG_exception_stack;
+    let prev_error_context_stack = pg_sys::error_context_stack;
+    let mut jump_buffer = std::mem::MaybeUninit::uninit();
+    let jump_value = crate::sigsetjmp(jump_buffer.as_mut_ptr(), 0);
+
+    let result = if jump_value == 0 {
+        // first time through, not as the result of a longjmp
+        pg_sys::PG_exception_stack = jump_buffer.as_mut_ptr();
+
+        // execute the closure, which will be a wrapped internal Postgres function
+        f()
+    } else {
+        // we're back here b/c of a longjmp originating in Postgres
+        // as such, we need to put Postgres' understanding of its exception/error state back together
+        pg_sys::PG_exception_stack = prev_exception_stack;
+        pg_sys::error_context_stack = prev_error_context_stack;
+
+        // and ultimately we panic
+        std::panic::panic_any(pg_sys::JumpContext {});
+    };
+
+    pg_sys::PG_exception_stack = prev_exception_stack;
+    pg_sys::error_context_stack = prev_error_context_stack;
+
+    result
+}

--- a/pgx-pg-sys/src/submodules/setjmp.rs
+++ b/pgx-pg-sys/src/submodules/setjmp.rs
@@ -1,5 +1,14 @@
+/// Given a closure that is assumed to be a wrapped Postgres `extern "C"` function, [pg_guard_ffi_boundary]
+/// will setup intermediate `sigsetjmp` barrier to enable Rust to catch any `elog(ERROR)` Postgres
+/// might raise while running the supplied closure.  
+///
+/// This caught error is then converted into a Rust `panic!()` and propagated up the stack, ultimately
+/// being converted into a transaction-aborting Postgres `ERROR` by pgx.
+///
+/// Currently, this function is only used by pgx' generated Postgres bindings.  It is not (yet)
+/// intended (or even necessary) for normal user code.
 #[inline(always)]
-pub unsafe fn postgres_function_guard<T, F: FnOnce() -> T>(f: F) -> T {
+pub(crate) unsafe fn pg_guard_ffi_boundary<T, F: FnOnce() -> T>(f: F) -> T {
     use crate as pg_sys;
 
     // as the panic message says, we can't call Postgres functions from threads

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -21,10 +21,13 @@ use std::{
 };
 use syn::{GenericArgument, ItemFn, PathArguments, ReturnType, Type, TypeParamBound};
 
+mod pgx_pg_sys_stub;
+
 pub mod operator_common;
 pub mod pg_config;
-mod pgx_pg_sys_stub;
+pub mod rewriter;
 pub mod sql_entity_graph;
+
 pub use pgx_pg_sys_stub::PgxPgSysStub;
 
 #[doc(hidden)]

--- a/pgx-utils/src/rewriter.rs
+++ b/pgx-utils/src/rewriter.rs
@@ -526,13 +526,13 @@ impl PgGuardRewriter {
                     return quote! { extern "C" { #func } };
                 }
 
-                self.foreign_item_fn(func)
+                self.foreign_item_fn(&func)
             }
             _ => quote! { extern "C" { #item } },
         }
     }
 
-    pub fn foreign_item_fn(&self, func: ForeignItemFn) -> proc_macro2::TokenStream {
+    pub fn foreign_item_fn(&self, func: &ForeignItemFn) -> proc_macro2::TokenStream {
         let func_name = PgGuardRewriter::build_func_name(&func.sig);
         let arg_list = PgGuardRewriter::rename_arg_list(&func.sig);
         let arg_list_with_types = PgGuardRewriter::rename_arg_list_with_types(&func.sig);

--- a/pgx-utils/src/rewriter.rs
+++ b/pgx-utils/src/rewriter.rs
@@ -540,7 +540,7 @@ impl PgGuardRewriter {
 
         quote! {
             pub unsafe fn #func_name ( #arg_list_with_types ) #return_type {
-                crate::submodules::setjmp::postgres_function_guard(move || {
+                crate::submodules::setjmp::pg_guard_ffi_boundary(move || {
                     extern "C" {
                         fn #func_name( #arg_list_with_types ) #return_type ;
                     }


### PR DESCRIPTION
This centralizes all the code `#[pg_guard]` otherwise generates into a common function, which takes a closure that is a wrapper around the desired internal Postgres function call.