### PR TITLE
Get TimestampWithTimeZone from OffsetDateTime

### DIFF
--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -24,6 +24,12 @@ impl From<pg_sys::TimestampTz> for TimestampWithTimeZone {
     }
 }
 
+impl From<time::OffsetDateTime> for TimestampWithTimeZone {
+    fn from(time: time::OffsetDateTime) -> Self {
+        TimestampWithTimeZone(time)
+    }
+}
+
 
 impl FromDatum for TimestampWithTimeZone {
     #[inline]


### PR DESCRIPTION
Doing this currently means splitting an OffsetDateTime into Date, Time and UtcOffset, which is a little silly when it just gets converted back into an OffsetDateTime.