### PR TITLE
Expose inline table_* APIs

### DIFF
--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -25,6 +25,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tableam.h"
 #include "access/xact.h"
 #include "catalog/dependency.h"
 #include "catalog/index.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -25,6 +25,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tableam.h"
 #include "access/xact.h"
 #include "catalog/dependency.h"
 #include "catalog/index.h"


### PR DESCRIPTION
While functions like table_beginscan* are available the corresponding
end functions like table_endscan are not. Expose these now. They are
not available in PG11 and PG12 already had this header file included.