### PR TITLE
Optionally emit versioned .so

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,9 @@ jobs:
     - name: Run triggers example tests
       run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
 
+    - name: Run versioned_so example tests
+      run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
+
     # Attempt to make the cache payload slightly smaller.
     - name: Clean up built PGX files
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "versioned_so"
+version = "0.0.0"
+dependencies = [
+ "pgx",
+ "pgx-tests",
+]
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "pgx-examples/srf",
     "pgx-examples/strings",
     "pgx-examples/triggers",
+    "pgx-examples/versioned_so",
 ]
 
 [profile.dev.build-override]

--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -686,3 +686,94 @@ OPTIONS:
     -V, --version
             Print version information
 ```
+
+## EXPERIMENTAL: Versioned shared-object support
+
+`pgx` experimentally supports the option to produce a versioned shared library. This allows multiple versions of the
+extension to be installed side-by-side, and can enable the deprecation (and removal) of functions between extension
+versions. There are some caveats which must be observed when using this functionality. For this reason it is currently
+experimental.
+
+### Activation
+
+Versioned shared-object support is enabled by removing the `module_pathname` configuration value in the extension's
+`.control` file.
+
+### Concepts
+
+Postgres has the implicit requirement that C extensions maintain ABI compatibility between versions. The idea behind
+this feature is to allow interoperability between two versions of an extension when the new version is not ABI
+compatible with the old version.
+
+The mechanism of operation is to version the name of the shared library file, and to hard-code function definitions to
+point to the versioned shared library file. Without versioned shared-object support, the SQL definition of a C function
+would look as follows:
+
+```SQL
+CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'hello_extension_wrapper';
+```
+
+`MODULE_PATHNAME` is replaced by Postgres with the configured value in the `.control` file. For pgx-based extensions,
+this is  usually set to `$libdir/<extension-name>`.
+
+When using versioned shared-object support, the same SQL would look as follows:
+
+```SQL
+CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
+STRICT
+LANGUAGE c /* Rust */
+AS '$libdir/extension-0.0.0', 'hello_extension_wrapper';
+```
+
+Note that the versioned shared library is hard-coded in the function definition. This corresponds to the
+`extension-0.0.0.so` file which `pgx` generates.
+
+It is important to note that the emitted SQL is version-dependent. This means that all previously-defined C functions
+must be redefined to point to the current versioned-so in the version upgrade script. As an example, when updating the
+extension version to 0.1.0, the shared object will be named `<extension-name>-0.1.0.so`, and `cargo pgx schema` will
+produce the following SQL for the above function:
+
+```SQL
+CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
+STRICT
+LANGUAGE c /* Rust */
+AS '$libdir/extension-0.1.0', 'hello_extension_wrapper';
+```
+
+This SQL must be used in the upgrade script from `0.0.0` to `0.1.0` in order to point the `hello_extension` function to
+the new shared object. `pgx` _does not_ do any magic to determine in which version a function was introduced or modified
+and only place it in the corresponding versioned so file. By extension, you can always expect that the shared library
+will contain _all_ functions which are still defined in the extension's source code.
+
+This feature is not designed to assist in the backwards compatibility of data types.
+
+### `@MODULE_PATHNAME@` Templating
+
+In case you are already providing custom SQL definitions for Rust functions, you can use the `@MODULE_PATHNAME@`
+template in your custom SQL. This value will be replaced with the path to the actual shared object. 
+
+The following example illustrates how this works:
+
+```rust
+#[pg_extern(sql = r#"
+    CREATE OR REPLACE FUNCTION tests."overridden_sql_with_fn_name"() RETURNS void
+    STRICT
+    LANGUAGE c /* Rust */
+    AS '@MODULE_PATHNAME@', '@FUNCTION_NAME@';
+"#)]
+fn overridden_sql_with_fn_name() -> bool {
+    true
+}
+```
+
+### Caveats
+
+There are some scenarios which are entirely incompatible with this feature, because they rely on some global state in
+Postgres, so loading two versions of the shared library will cause trouble.
+
+These scenarios are:
+- when using shared memory
+- when using query planner hooks

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -165,6 +165,8 @@ pub(crate) fn generate_schema(
         ));
     }
 
+    let versioned_so = get_property(&package_manifest_path, "module_pathname")?.is_none();
+
     let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
 
     let mut target_dir_with_profile = pgx_utils::get_target_dir()?;
@@ -401,6 +403,8 @@ pub(crate) fn generate_schema(
         typeid_sql_mapping.clone().into_iter(),
         source_only_sql_mapping.clone().into_iter(),
         entities.into_iter(),
+        package_name.to_string(),
+        versioned_so,
     )
     .wrap_err("SQL generation error")?;
 

--- a/pgx-examples/versioned_so/.cargo/config
+++ b/pgx-examples/versioned_so/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+# Postgres symbols won't be available until runtime
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/pgx-examples/versioned_so/.gitignore
+++ b/pgx-examples/versioned_so/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock

--- a/pgx-examples/versioned_so/Cargo.toml
+++ b/pgx-examples/versioned_so/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "versioned_so"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg10 = ["pgx/pg10", "pgx-tests/pg10" ]
+pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
+pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
+pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
+pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
+pg_test = []
+
+[dependencies]
+pgx = { path = "../../pgx/", default-features = false }
+
+[dev-dependencies]
+pgx-tests = { path = "../../pgx-tests" }
+
+# uncomment these if compiling outside of 'pgx'
+#[profile.dev]
+#panic = "unwind"
+# lto = "thin"
+
+#[profile.release]
+#panic = "unwind"
+#opt-level = 3
+#lto = "fat"
+#codegen-units = 1

--- a/pgx-examples/versioned_so/src/lib.rs
+++ b/pgx-examples/versioned_so/src/lib.rs
@@ -1,0 +1,32 @@
+use pgx::*;
+
+pg_module_magic!();
+
+#[pg_extern]
+fn hello_versioned_so() -> &'static str {
+    "Hello, versioned_so"
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_hello_versioned_so() {
+        assert_eq!("Hello, versioned_so", crate::hello_versioned_so());
+    }
+
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}

--- a/pgx-examples/versioned_so/versioned_so.control
+++ b/pgx-examples/versioned_so/versioned_so.control
@@ -1,0 +1,6 @@
+comment = 'versioned_so:  Created by pgx'
+default_version = '@CARGO_VERSION@'
+# commenting-out module_pathname results in this extension being built/run/tested in "versioned shared-object mode"
+# module_pathname = '$libdir/versioned_so'
+relocatable = false
+superuser = false

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -34,12 +34,12 @@ mod tests {
         assert!(result)
     }
 
-    // Ensures `@FUNCTION_NAME@` is handled.
+    // Ensures `@MODULE_PATHNAME@` and `@FUNCTION_NAME@` are handled.
     #[pg_extern(sql = r#"
         CREATE OR REPLACE FUNCTION tests."overridden_sql_with_fn_name"() RETURNS void
         STRICT
         LANGUAGE c /* Rust */
-        AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
+        AS '@MODULE_PATHNAME@', '@FUNCTION_NAME@';
     "#)]
     fn overridden_sql_with_fn_name() -> bool {
         true

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -563,6 +563,10 @@ pub fn anonymonize_lifetimes(value: &mut syn::Type) {
     }
 }
 
+pub fn versioned_so_name(extension_name: &str, extension_version: &str) -> String {
+    format!("{}-{}", extension_name, extension_version)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{parse_extern_attributes, ExternArgs};

--- a/pgx-utils/src/sql_entity_graph/control_file.rs
+++ b/pgx-utils/src/sql_entity_graph/control_file.rs
@@ -26,7 +26,7 @@ use tracing_error::SpanTrace;
 pub struct ControlFile {
     pub comment: String,
     pub default_version: String,
-    pub module_pathname: String,
+    pub module_pathname: Option<String>,
     pub relocatable: bool,
     pub superuser: bool,
     pub schema: Option<String>,
@@ -75,13 +75,7 @@ impl ControlFile {
                     context: SpanTrace::capture(),
                 })?
                 .to_string(),
-            module_pathname: temp
-                .get("module_pathname")
-                .ok_or(ControlFileError::MissingField {
-                    field: "module_pathname",
-                    context: SpanTrace::capture(),
-                })?
-                .to_string(),
+            module_pathname: temp.get("module_pathname").map(|v| v.to_string()),
             relocatable: temp
                 .get("relocatable")
                 .ok_or(ControlFileError::MissingField {

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -105,16 +105,19 @@ impl ToSql for PgExternEntity {
             extern_attrs.push(ExternArgs::Strict);
         }
 
+        let module_pathname = &context.get_module_pathname();
+
         let fn_sql = format!("\
                                 CREATE OR REPLACE FUNCTION {schema}\"{name}\"({arguments}) {returns}\n\
                                 {extern_attrs}\
                                 {search_path}\
                                 LANGUAGE c /* Rust */\n\
-                                AS 'MODULE_PATHNAME', '{unaliased_name}_wrapper';\
+                                AS '{module_pathname}', '{unaliased_name}_wrapper';\
                             ",
                              schema = self.schema.map(|schema| format!("{}.", schema)).unwrap_or_else(|| context.schema_prefix_for(&self_index)),
                              name = self.name,
                              unaliased_name = self.unaliased_name,
+                             module_pathname = module_pathname,
                              arguments = if !self.fn_args.is_empty() {
                                  let mut args = Vec::new();
                                  for (idx, arg) in self.fn_args.iter().enumerate() {

--- a/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
@@ -55,6 +55,10 @@ impl ToSqlConfigEntity {
         }
 
         if let Some(content) = self.content {
+            let module_pathname = context.get_module_pathname();
+
+            let content = content.replace("@MODULE_PATHNAME@", &module_pathname);
+
             return Some(Ok(format!(
                 "\n\
                 {sql_anchor_comment}\n\
@@ -70,14 +74,20 @@ impl ToSqlConfigEntity {
                 .map_err(|e| eyre!(e))
                 .wrap_err("Failed to run specified `#[pgx(sql = path)] function`");
             return match content {
-                Ok(content) => Some(Ok(format!(
-                    "\n\
+                Ok(content) => {
+                    let module_pathname = &context.get_module_pathname();
+
+                    let content = content.replace("@MODULE_PATHNAME@", &module_pathname);
+
+                    Some(Ok(format!(
+                        "\n\
                         {sql_anchor_comment}\n\
                         {content}\
                     ",
-                    content = content,
-                    sql_anchor_comment = entity.sql_anchor_comment(),
-                ))),
+                        content = content,
+                        sql_anchor_comment = entity.sql_anchor_comment(),
+                    )))
+                }
                 Err(e) => Some(Err(e)),
             };
         }


### PR DESCRIPTION
`pgx` now experimentally supports the option to produce a versioned
shared library. This option is activated by removing the
`module_pathname` parameter in the extension's `.control` file.

When activated, it does the following:

- appends current package version to shared library name
- points generated function SQL to the versioned shared library (instead
  of `MODULE_PATHNAME`)
- replaces `@MODULE_PATHNAME@` placeholder with the path to the versioned
  shared library

Background:

There is an implicit requirement that C extensions maintain ABI
compatibility between versions. Emitting a versioned .so allows for ABI
breaks between versions.

This functionality is experimental and that care must be taken in the
following scenarios:

- when using shared memory
- when using query planner hooks
- when producing SQL schema migrations