### PR TITLE
fix namespace.rs

### DIFF
--- a/pgx/src/namespace.rs
+++ b/pgx/src/namespace.rs
@@ -11,6 +11,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::list::PgList;
 use crate::pg_sys;
+use pgx_pg_sys::AsPgCStr;
 
 /// A helper struct for creating a Postgres `List` of `String`s to qualify an object name
 pub struct PgQualifiedNameBuilder {
@@ -33,9 +34,7 @@ impl PgQualifiedNameBuilder {
     pub fn push(mut self, value: &str) -> PgQualifiedNameBuilder {
         unsafe {
             // SAFETY:  the result of pg_sys::makeString is always a valid pointer
-            self.list.push(pg_sys::makeString(
-                std::ffi::CString::new(value).unwrap().into_raw(),
-            ));
+            self.list.push(pg_sys::makeString(value.as_pg_cstr()));
         }
         self
     }


### PR DESCRIPTION
fix a problem with leaking a `std::ffi::CString` along with Postgres' expectation that the argument to `pg_sys::makeString()` is a `palloc()`'d string.