### PR TITLE
Prepare 0.4.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,9 @@ jobs:
     - name: Run triggers example tests
       run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
 
+    - name: Run versioned_so example tests
+      run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
+
     # Attempt to make the cache payload slightly smaller.
     - name: Clean up built PGX files
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "versioned_so"
+version = "0.0.0"
+dependencies = [
+ "pgx",
+ "pgx-tests",
+]
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "eyre",
  "libc",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "atty",
  "convert_case",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,15 +928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baa98978c170759522ad6ebb567aeb29a62e1867551f39ae2e5b749fbd5cc21"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
 dependencies = [
  "atomic-polyfill",
- "hash32 0.2.1",
+ "hash32",
  "spin",
  "stable_deref_trait",
 ]
@@ -1451,7 +1442,6 @@ dependencies = [
  "cstr_core",
  "enum-primitive-derive",
  "eyre",
- "hash32 0.3.0",
  "heapless",
  "num-traits",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "rayon",
  "regex",
  "rttp_client",
- "semver 1.0.7",
+ "semver 1.0.9",
  "syn",
  "tracing",
  "tracing-error",
@@ -325,7 +325,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.7",
+ "semver 1.0.9",
  "serde",
  "serde_json",
 ]
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.10"
+version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3124f3f75ce09e22d1410043e1e24f2ecc44fad3afe4f08408f1f7663d68da2b"
+checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
 dependencies = [
  "atty",
  "bitflags",
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
 dependencies = [
  "os_str_bytes",
 ]
@@ -928,6 +928,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2baa98978c170759522ad6ebb567aeb29a62e1867551f39ae2e5b749fbd5cc21"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,7 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "spin",
  "stable_deref_trait",
 ]
@@ -1037,9 +1046,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libflate"
@@ -1098,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -1137,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -1267,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -1311,16 +1320,28 @@ checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "28f3916d46d9d813a62d7b7d2724d7b14785ac999fb623d990ee4603f9122742"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1331,9 +1352,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.72"
+version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
 dependencies = [
  "autocfg",
  "cc",
@@ -1360,36 +1381,34 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "owo-colors"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e72e30578e0d0993c8ae20823dd9cff2bc5517d2f586a8aef462a581e8a03eb"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
 dependencies = [
  "supports-color",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1432,7 +1451,7 @@ dependencies = [
  "cstr_core",
  "enum-primitive-derive",
  "eyre",
- "hash32",
+ "hash32 0.3.0",
  "heapless",
  "num-traits",
  "once_cell",
@@ -1551,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1583,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb76d6535496f633fa799bb872ffb4790e9cbdedda9d35564ca0252f930c0dd5"
+checksum = "c8bbcd5f6deb39585a0d9f4ef34c4a41c25b7ad26d23c75d837d78c8e7adc85f"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1597,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ec03bce71f18b4a27c4c64c6ba2ddf74686d69b91d8714fb32ead3adaed713"
+checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -1615,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
+checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1632,9 +1651,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
+checksum = "d9e07e3a46d0771a8a06b5f4441527802830b43e679ba12f44960f48dd4c6803"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2002,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 dependencies = [
  "serde",
 ]
@@ -2026,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
@@ -2057,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2068,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
 dependencies = [
  "itoa",
  "ryu",
@@ -2232,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2294,18 +2313,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2341,9 +2360,9 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2356,14 +2375,15 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
  "mio",
+ "once_cell",
  "pin-project-lite",
  "socket2",
  "winapi",
@@ -2371,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6c8b33df661b548dcd8f9bf87debb8c56c05657ed291122e1188698c2ece95"
+checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2394,16 +2414,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2429,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2460,9 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -2524,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"
@@ -2539,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "url"
@@ -2557,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom 0.2.6",
 ]
@@ -2670,6 +2690,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "pgx-examples/srf",
     "pgx-examples/strings",
     "pgx-examples/triggers",
+    "pgx-examples/versioned_so",
 ]
 
 [profile.dev.build-override]

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ my_extension=# SELECT hello_my_extension();
 
 ### 5. Detailed cargo pgx usage
 
-For more details on how to manage pgx extensions see [Managing pgx extensions](./cargo-pgx/README.md.)
+For more details on how to manage pgx extensions see [Managing pgx extensions](./cargo-pgx/README.md).
 
 ## Upgrading
 

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgx' to make Postgres extension development easy"
@@ -23,7 +23,7 @@ semver = "1.0.9"
 owo-colors = { version = "3.4.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils", version = "0.4.3" }
+pgx-utils = { path = "../pgx-utils", version = "0.4.4" }
 proc-macro2 = { version = "1.0.37", features = [ "span-locations" ] }
 quote = "1.0.18"
 rayon = "1.5.2"

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -17,10 +17,10 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.14.2"
 cargo_toml = "0.11.5"
-clap = { version = "3.1.10", features = [ "env", "suggestions", "cargo", "derive" ] }
+clap = { version = "3.1.15", features = [ "env", "suggestions", "cargo", "derive" ] }
 clap-cargo = { version = "0.8.0", features = [ "cargo_metadata" ] }
-semver = "1.0.7"
-owo-colors = { version = "3.3.0", features = [ "supports-colors" ] }
+semver = "1.0.9"
+owo-colors = { version = "3.4.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
 pgx-utils = { path = "../pgx-utils", version = "0.4.3" }
@@ -29,7 +29,7 @@ quote = "1.0.18"
 rayon = "1.5.2"
 regex = "1.5.5"
 rttp_client = { version = "0.1.0", features = ["tls-native"] }
-syn = { version = "1.0.91", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.92", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 fork = "0.1.19"
 libloading = "0.7.3"

--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -626,7 +626,7 @@ OPTIONS:
             Print version information
 ```
 
-## Inspect you Extension Schema
+## Inspect your Extension Schema
 
 If you just want to look at the full extension schema that pgx will generate, use
 `cargo pgx schema`.

--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -686,3 +686,94 @@ OPTIONS:
     -V, --version
             Print version information
 ```
+
+## EXPERIMENTAL: Versioned shared-object support
+
+`pgx` experimentally supports the option to produce a versioned shared library. This allows multiple versions of the
+extension to be installed side-by-side, and can enable the deprecation (and removal) of functions between extension
+versions. There are some caveats which must be observed when using this functionality. For this reason it is currently
+experimental.
+
+### Activation
+
+Versioned shared-object support is enabled by removing the `module_pathname` configuration value in the extension's
+`.control` file.
+
+### Concepts
+
+Postgres has the implicit requirement that C extensions maintain ABI compatibility between versions. The idea behind
+this feature is to allow interoperability between two versions of an extension when the new version is not ABI
+compatible with the old version.
+
+The mechanism of operation is to version the name of the shared library file, and to hard-code function definitions to
+point to the versioned shared library file. Without versioned shared-object support, the SQL definition of a C function
+would look as follows:
+
+```SQL
+CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'hello_extension_wrapper';
+```
+
+`MODULE_PATHNAME` is replaced by Postgres with the configured value in the `.control` file. For pgx-based extensions,
+this is  usually set to `$libdir/<extension-name>`.
+
+When using versioned shared-object support, the same SQL would look as follows:
+
+```SQL
+CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
+STRICT
+LANGUAGE c /* Rust */
+AS '$libdir/extension-0.0.0', 'hello_extension_wrapper';
+```
+
+Note that the versioned shared library is hard-coded in the function definition. This corresponds to the
+`extension-0.0.0.so` file which `pgx` generates.
+
+It is important to note that the emitted SQL is version-dependent. This means that all previously-defined C functions
+must be redefined to point to the current versioned-so in the version upgrade script. As an example, when updating the
+extension version to 0.1.0, the shared object will be named `<extension-name>-0.1.0.so`, and `cargo pgx schema` will
+produce the following SQL for the above function:
+
+```SQL
+CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
+STRICT
+LANGUAGE c /* Rust */
+AS '$libdir/extension-0.1.0', 'hello_extension_wrapper';
+```
+
+This SQL must be used in the upgrade script from `0.0.0` to `0.1.0` in order to point the `hello_extension` function to
+the new shared object. `pgx` _does not_ do any magic to determine in which version a function was introduced or modified
+and only place it in the corresponding versioned so file. By extension, you can always expect that the shared library
+will contain _all_ functions which are still defined in the extension's source code.
+
+This feature is not designed to assist in the backwards compatibility of data types.
+
+### `@MODULE_PATHNAME@` Templating
+
+In case you are already providing custom SQL definitions for Rust functions, you can use the `@MODULE_PATHNAME@`
+template in your custom SQL. This value will be replaced with the path to the actual shared object. 
+
+The following example illustrates how this works:
+
+```rust
+#[pg_extern(sql = r#"
+    CREATE OR REPLACE FUNCTION tests."overridden_sql_with_fn_name"() RETURNS void
+    STRICT
+    LANGUAGE c /* Rust */
+    AS '@MODULE_PATHNAME@', '@FUNCTION_NAME@';
+"#)]
+fn overridden_sql_with_fn_name() -> bool {
+    true
+}
+```
+
+### Caveats
+
+There are some scenarios which are entirely incompatible with this feature, because they rely on some global state in
+Postgres, so loading two versions of the shared library will cause trouble.
+
+These scenarios are:
+- when using shared memory
+- when using query planner hooks

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -165,6 +165,8 @@ pub(crate) fn generate_schema(
         ));
     }
 
+    let versioned_so = get_property(&package_manifest_path, "module_pathname")?.is_none();
+
     let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
 
     let mut target_dir_with_profile = pgx_utils::get_target_dir()?;
@@ -401,6 +403,8 @@ pub(crate) fn generate_schema(
         typeid_sql_mapping.clone().into_iter(),
         source_only_sql_mapping.clone().into_iter(),
         entities.into_iter(),
+        package_name.to_string(),
+        versioned_so,
     )
     .wrap_err("SQL generation error")?;
 

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.4.3"
+pgx = "0.4.4"
 
 [dev-dependencies]
-pgx-tests = "0.4.3"
+pgx-tests = "0.4.4"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,13 +16,13 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.4.3"
-pgx-macros = "0.4.3"
-pgx-utils = "0.4.3"
+pgx = "0.4.4"
+pgx-macros = "0.4.4"
+pgx-utils = "0.4.4"
 
 
 [dev-dependencies]
-pgx-tests = "0.4.3"
+pgx-tests = "0.4.4"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.136"
+serde = "1.0.137"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/arrays/Cargo.toml
+++ b/pgx-examples/arrays/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.136"
+serde = "1.0.137"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/custom_sql/Cargo.toml
+++ b/pgx-examples/custom_sql/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.136"
+serde = "1.0.137"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
 maplit = "1.0.2"
-serde = "1.0.136"
+serde = "1.0.137"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/nostd/Cargo.toml
+++ b/pgx-examples/nostd/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.136"
+serde = "1.0.137"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/operators/Cargo.toml
+++ b/pgx-examples/operators/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
 maplit = "1.0.2"
-serde = "1.0.136"
+serde = "1.0.137"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/schemas/Cargo.toml
+++ b/pgx-examples/schemas/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.136"
+serde = "1.0.137"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/shmem/Cargo.toml
+++ b/pgx-examples/shmem/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 heapless = "0.7.10"
 pgx = { path = "../../pgx", default-features = false }
-serde = { version = "1.0.136", features = [ "derive" ] }
+serde = { version = "1.0.137", features = [ "derive" ] }
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/versioned_so/.cargo/config
+++ b/pgx-examples/versioned_so/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+# Postgres symbols won't be available until runtime
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/pgx-examples/versioned_so/.cargo/config
+++ b/pgx-examples/versioned_so/.cargo/config
@@ -1,3 +1,0 @@
-[build]
-# Postgres symbols won't be available until runtime
-rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/pgx-examples/versioned_so/.gitignore
+++ b/pgx-examples/versioned_so/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock

--- a/pgx-examples/versioned_so/Cargo.toml
+++ b/pgx-examples/versioned_so/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "versioned_so"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg10 = ["pgx/pg10", "pgx-tests/pg10" ]
+pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
+pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
+pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
+pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
+pg_test = []
+
+[dependencies]
+pgx = { path = "../../pgx/", default-features = false }
+
+[dev-dependencies]
+pgx-tests = { path = "../../pgx-tests" }
+
+# uncomment these if compiling outside of 'pgx'
+#[profile.dev]
+#panic = "unwind"
+# lto = "thin"
+
+#[profile.release]
+#panic = "unwind"
+#opt-level = 3
+#lto = "fat"
+#codegen-units = 1

--- a/pgx-examples/versioned_so/src/lib.rs
+++ b/pgx-examples/versioned_so/src/lib.rs
@@ -1,0 +1,32 @@
+use pgx::*;
+
+pg_module_magic!();
+
+#[pg_extern]
+fn hello_versioned_so() -> &'static str {
+    "Hello, versioned_so"
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_hello_versioned_so() {
+        assert_eq!("Hello, versioned_so", crate::hello_versioned_so());
+    }
+
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}

--- a/pgx-examples/versioned_so/versioned_so.control
+++ b/pgx-examples/versioned_so/versioned_so.control
@@ -1,0 +1,6 @@
+comment = 'versioned_so:  Created by pgx'
+default_version = '@CARGO_VERSION@'
+# commenting-out module_pathname results in this extension being built/run/tested in "versioned shared-object mode"
+# module_pathname = '$libdir/versioned_so'
+relocatable = false
+superuser = false

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -21,8 +21,8 @@ rustc-args = ["--cfg", "docsrs"]
 pgx-utils = { path = "../pgx-utils", version = "0.4.3" }
 proc-macro2 = "1.0.37"
 quote = "1.0.18"
-syn = { version = "1.0.91", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.92", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 
 [dev-dependencies]
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { version = "1.0.137", features = ["derive"] }

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgx'"
@@ -18,7 +18,7 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.4.3" }
+pgx-utils = { path = "../pgx-utils", version = "0.4.4" }
 proc-macro2 = "1.0.37"
 quote = "1.0.18"
 syn = { version = "1.0.92", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgx'"
@@ -29,14 +29,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.5"
 once_cell = "1.10.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.4.3" }
+pgx-macros = { path = "../pgx-macros/", version = "0.4.4" }
 
 [build-dependencies]
 bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }
 build-deps = "0.1.4"
 owo-colors = "3.4.0"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils/", version = "0.4.3" }
+pgx-utils = { path = "../pgx-utils/", version = "0.4.4" }
 proc-macro2 = "1.0.37"
 quote = "1.0.18"
 rayon = "1.5.2"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -34,12 +34,12 @@ pgx-macros = { path = "../pgx-macros/", version = "0.4.3" }
 [build-dependencies]
 bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }
 build-deps = "0.1.4"
-owo-colors = "3.3.0"
+owo-colors = "3.4.0"
 num_cpus = "1.13.1"
 pgx-utils = { path = "../pgx-utils/", version = "0.4.3" }
 proc-macro2 = "1.0.37"
 quote = "1.0.18"
 rayon = "1.5.2"
-syn = { version = "1.0.91", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.92", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 color-eyre = "0.6.1"

--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -74,6 +74,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
 #include "parser/parse_func.h"
+#include "parser/parse_oper.h"
 #include "parser/parse_type.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -72,6 +72,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
 #include "parser/parse_func.h"
+#include "parser/parse_oper.h"
 #include "parser/parse_type.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -72,6 +72,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
 #include "parser/parse_func.h"
+#include "parser/parse_oper.h"
 #include "parser/parse_type.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -72,6 +72,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
 #include "parser/parse_func.h"
+#include "parser/parse_oper.h"
 #include "parser/parse_type.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -72,6 +72,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
 #include "parser/parse_func.h"
+#include "parser/parse_oper.h"
 #include "parser/parse_type.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -31,16 +31,16 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-owo-colors = "3.3.0"
+owo-colors = "3.4.0"
 once_cell = "1.10.0"
-libc = "0.2.124"
+libc = "0.2.125"
 pgx = { path = "../pgx", default-features = false, version= "0.4.3" }
 pgx-macros = { path = "../pgx-macros", version= "0.4.3" }
 pgx-utils = { path = "../pgx-utils", version= "0.4.3" }
-postgres = "0.19.2"
+postgres = "0.19.3"
 regex = "1.5.5"
-serde = "1.0.136"
-serde_json = "1.0.79"
+serde = "1.0.137"
+serde_json = "1.0.80"
 shutdown_hooks = "0.1.0"
 time = "0.3.9"
 eyre = "0.6.8"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgx'-based Postgres extensions"
@@ -34,9 +34,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 owo-colors = "3.4.0"
 once_cell = "1.10.0"
 libc = "0.2.125"
-pgx = { path = "../pgx", default-features = false, version= "0.4.3" }
-pgx-macros = { path = "../pgx-macros", version= "0.4.3" }
-pgx-utils = { path = "../pgx-utils", version= "0.4.3" }
+pgx = { path = "../pgx", default-features = false, version= "0.4.4" }
+pgx-macros = { path = "../pgx-macros", version= "0.4.4" }
+pgx-utils = { path = "../pgx-utils", version= "0.4.4" }
 postgres = "0.19.3"
 regex = "1.5.5"
 serde = "1.0.137"

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -34,12 +34,12 @@ mod tests {
         assert!(result)
     }
 
-    // Ensures `@FUNCTION_NAME@` is handled.
+    // Ensures `@MODULE_PATHNAME@` and `@FUNCTION_NAME@` are handled.
     #[pg_extern(sql = r#"
         CREATE OR REPLACE FUNCTION tests."overridden_sql_with_fn_name"() RETURNS void
         STRICT
         LANGUAGE c /* Rust */
-        AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
+        AS '@MODULE_PATHNAME@', '@FUNCTION_NAME@';
     "#)]
     fn overridden_sql_with_fn_name() -> bool {
         true

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 atty = "0.2.14"
-owo-colors = "3.3.0"
+owo-colors = "3.4.0"
 convert_case = "0.5.0"
 dirs = "4.0.0"
 env_proxy = "0.4.1"
@@ -20,11 +20,11 @@ proc-macro2 = { version = "1.0.37", features = [ "span-locations" ] }
 quote = "1.0.18"
 regex = "1.5.5"
 rttp_client = "0.1.0"
-serde = { version = "1.0.136", features = [ "derive" ] }
-serde_derive = "1.0.136"
+serde = { version = "1.0.137", features = [ "derive" ] }
+serde_derive = "1.0.137"
 serde-xml-rs = "0.5.1"
-serde_json = "1.0.79"
-syn = { version = "1.0.91", features = [ "extra-traits", "full", "fold", "parsing" ] }
+serde_json = "1.0.80"
+syn = { version = "1.0.92", features = [ "extra-traits", "full", "fold", "parsing" ] }
 syntect = { version = "4.6.0", default-features = false, features = ["default-fancy"] }
 toml = "0.5.9"
 unescape = "0.1.0"
@@ -34,4 +34,4 @@ tracing = "0.1.34"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.11", features = [ "env-filter" ] }
 petgraph = "0.6.0"
-prettyplease = "0.1.9"
+prettyplease = "0.1.10"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Utility functions for 'pgx'"

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -563,6 +563,10 @@ pub fn anonymonize_lifetimes(value: &mut syn::Type) {
     }
 }
 
+pub fn versioned_so_name(extension_name: &str, extension_version: &str) -> String {
+    format!("{}-{}", extension_name, extension_version)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{parse_extern_attributes, ExternArgs};

--- a/pgx-utils/src/sql_entity_graph/control_file.rs
+++ b/pgx-utils/src/sql_entity_graph/control_file.rs
@@ -26,7 +26,7 @@ use tracing_error::SpanTrace;
 pub struct ControlFile {
     pub comment: String,
     pub default_version: String,
-    pub module_pathname: String,
+    pub module_pathname: Option<String>,
     pub relocatable: bool,
     pub superuser: bool,
     pub schema: Option<String>,
@@ -75,13 +75,7 @@ impl ControlFile {
                     context: SpanTrace::capture(),
                 })?
                 .to_string(),
-            module_pathname: temp
-                .get("module_pathname")
-                .ok_or(ControlFileError::MissingField {
-                    field: "module_pathname",
-                    context: SpanTrace::capture(),
-                })?
-                .to_string(),
+            module_pathname: temp.get("module_pathname").map(|v| v.to_string()),
             relocatable: temp
                 .get("relocatable")
                 .ok_or(ControlFileError::MissingField {

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -105,16 +105,19 @@ impl ToSql for PgExternEntity {
             extern_attrs.push(ExternArgs::Strict);
         }
 
+        let module_pathname = &context.get_module_pathname();
+
         let fn_sql = format!("\
                                 CREATE OR REPLACE FUNCTION {schema}\"{name}\"({arguments}) {returns}\n\
                                 {extern_attrs}\
                                 {search_path}\
                                 LANGUAGE c /* Rust */\n\
-                                AS 'MODULE_PATHNAME', '{unaliased_name}_wrapper';\
+                                AS '{module_pathname}', '{unaliased_name}_wrapper';\
                             ",
                              schema = self.schema.map(|schema| format!("{}.", schema)).unwrap_or_else(|| context.schema_prefix_for(&self_index)),
                              name = self.name,
                              unaliased_name = self.unaliased_name,
+                             module_pathname = module_pathname,
                              arguments = if !self.fn_args.is_empty() {
                                  let mut args = Vec::new();
                                  for (idx, arg) in self.fn_args.iter().enumerate() {

--- a/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
@@ -55,6 +55,10 @@ impl ToSqlConfigEntity {
         }
 
         if let Some(content) = self.content {
+            let module_pathname = context.get_module_pathname();
+
+            let content = content.replace("@MODULE_PATHNAME@", &module_pathname);
+
             return Some(Ok(format!(
                 "\n\
                 {sql_anchor_comment}\n\
@@ -70,14 +74,20 @@ impl ToSqlConfigEntity {
                 .map_err(|e| eyre!(e))
                 .wrap_err("Failed to run specified `#[pgx(sql = path)] function`");
             return match content {
-                Ok(content) => Some(Ok(format!(
-                    "\n\
+                Ok(content) => {
+                    let module_pathname = &context.get_module_pathname();
+
+                    let content = content.replace("@MODULE_PATHNAME@", &module_pathname);
+
+                    Some(Ok(format!(
+                        "\n\
                         {sql_anchor_comment}\n\
                         {content}\
                     ",
-                    content = content,
-                    sql_anchor_comment = entity.sql_anchor_comment(),
-                ))),
+                        content = content,
+                        sql_anchor_comment = entity.sql_anchor_comment(),
+                    )))
+                }
                 Err(e) => Some(Err(e)),
             };
         }

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -43,8 +43,7 @@ serde_json = "1.0.80"
 time = { version = "0.3.9", features = ["formatting", "parsing", "alloc", "macros"] }
 atomic-traits = "0.3.0"
 heapless = "0.7.10"
-hash32 = "0.3.0"
-uuid = { version = "1.0.0", features = [ "v4" ] } 
+uuid = { version = "1.0.0", features = [ "v4" ] }
 once_cell = "1.10.0"
 bitflags = "1.3.2"
 eyre = "0.6.8"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgx:  A Rust framework for creating Postgres extensions"
@@ -34,9 +34,9 @@ cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.15"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.4.3" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.4.3" }
-pgx-utils = { path = "../pgx-utils/", version = "0.4.3" }
+pgx-macros = { path = "../pgx-macros/", version = "0.4.4" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.4.4" }
+pgx-utils = { path = "../pgx-utils/", version = "0.4.4" }
 serde = { version = "1.0.137", features = [ "derive" ] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.80"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -32,19 +32,19 @@ rustc-args = ["--cfg", "docsrs"]
 [dependencies]
 cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
-num-traits = "0.2.14"
+num-traits = "0.2.15"
 seahash = "4.1.0"
 pgx-macros = { path = "../pgx-macros/", version = "0.4.3" }
 pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.4.3" }
 pgx-utils = { path = "../pgx-utils/", version = "0.4.3" }
-serde = { version = "1.0.136", features = [ "derive" ] }
+serde = { version = "1.0.137", features = [ "derive" ] }
 serde_cbor = "0.11.2"
-serde_json = "1.0.79"
+serde_json = "1.0.80"
 time = { version = "0.3.9", features = ["formatting", "parsing", "alloc", "macros"] }
 atomic-traits = "0.3.0"
 heapless = "0.7.10"
-hash32 = "0.2.1"
-uuid = { version = "0.8.2", features = [ "v4" ] } 
+hash32 = "0.3.0"
+uuid = { version = "1.0.0", features = [ "v4" ] } 
 once_cell = "1.10.0"
 bitflags = "1.3.2"
 eyre = "0.6.8"

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -16,8 +16,14 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 use serde_json::Number;
 use std::fmt;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Numeric(pub String);
+
+impl std::fmt::Display for Numeric {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        fmt.write_fmt(format_args!("{}", self.0))
+    }
+}
 
 impl<'de> Deserialize<'de> for Numeric {
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>

--- a/pgx/src/namespace.rs
+++ b/pgx/src/namespace.rs
@@ -11,6 +11,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::list::PgList;
 use crate::pg_sys;
+use pgx_pg_sys::AsPgCStr;
 
 /// A helper struct for creating a Postgres `List` of `String`s to qualify an object name
 pub struct PgQualifiedNameBuilder {
@@ -33,9 +34,7 @@ impl PgQualifiedNameBuilder {
     pub fn push(mut self, value: &str) -> PgQualifiedNameBuilder {
         unsafe {
             // SAFETY:  the result of pg_sys::makeString is always a valid pointer
-            self.list.push(pg_sys::makeString(
-                std::ffi::CString::new(value).unwrap().into_raw(),
-            ));
+            self.list.push(pg_sys::makeString(value.as_pg_cstr()));
         }
         self
     }

--- a/pgx/src/shmem.rs
+++ b/pgx/src/shmem.rs
@@ -8,6 +8,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 use crate::lwlock::*;
 use crate::{pg_sys, PgAtomic};
+use std::hash::Hash;
 use uuid::Uuid;
 
 /// Custom types that want to participate in shared memory must implement this marker trait
@@ -217,7 +218,7 @@ where
 {
 }
 unsafe impl<T, const N: usize> PGXSharedMemory for heapless::Vec<T, N> {}
-unsafe impl<K: Eq + hash32::Hash, V: Default, S, const N: usize> PGXSharedMemory
+unsafe impl<K: Eq + Hash, V: Default, S, const N: usize> PGXSharedMemory
     for heapless::IndexMap<K, V, S, N>
 {
 }


### PR DESCRIPTION
(proposed release notes)

This is pgx v0.4.4.  A minor release which adds support for "versioned .so" files.

## Notable Changes
* Optionally emit versioned .so by @JamesGuthrie in https://github.com/tcdi/pgx/pull/546
* Add `impl Debug` for `Numeric` by @Hoverbear in https://github.com/tcdi/pgx/pull/551
* Fix `namespace.rs` safety issues by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/553

## Minor Changes
* Fix spelling mistakes by @kiwicopple in https://github.com/tcdi/pgx/pull/548
* Fix url typo on Detailed `cargo pgx` usage section by @msAlcantara in https://github.com/tcdi/pgx/pull/550
* Add aggregate article by @Hoverbear in https://github.com/tcdi/pgx/pull/555

## New Contributors
* @kiwicopple made their first contribution in https://github.com/tcdi/pgx/pull/548
* @msAlcantara made their first contribution in https://github.com/tcdi/pgx/pull/550

**Full Changelog**: https://github.com/tcdi/pgx/compare/v0.4.3...v0.4.4