### PR TITLE
Lockdown semver on pgx deps

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -23,7 +23,7 @@ semver = "1.0.9"
 owo-colors = { version = "3.4.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils", version = "0.4.4" }
+pgx-utils = { path = "../pgx-utils", version = "=0.4.4" }
 proc-macro2 = { version = "1.0.37", features = [ "span-locations" ] }
 quote = "1.0.18"
 rayon = "1.5.2"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.4.4"
+pgx = "=0.4.4"
 
 [dev-dependencies]
-pgx-tests = "0.4.4"
+pgx-tests = "=0.4.4"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,13 +16,13 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.4.4"
-pgx-macros = "0.4.4"
-pgx-utils = "0.4.4"
+pgx = "=0.4.4"
+pgx-macros = "=0.4.4"
+pgx-utils = "=0.4.4"
 
 
 [dev-dependencies]
-pgx-tests = "0.4.4"
+pgx-tests = "=0.4.4"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "0.4.4" }
+pgx-utils = { path = "../pgx-utils", version = "=0.4.4" }
 proc-macro2 = "1.0.37"
 quote = "1.0.18"
 syn = { version = "1.0.92", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -29,14 +29,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.5"
 once_cell = "1.10.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.4.4" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.4.4" }
 
 [build-dependencies]
 bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }
 build-deps = "0.1.4"
 owo-colors = "3.4.0"
 num_cpus = "1.13.1"
-pgx-utils = { path = "../pgx-utils/", version = "0.4.4" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.4.4" }
 proc-macro2 = "1.0.37"
 quote = "1.0.18"
 rayon = "1.5.2"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -34,9 +34,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 owo-colors = "3.4.0"
 once_cell = "1.10.0"
 libc = "0.2.125"
-pgx = { path = "../pgx", default-features = false, version= "0.4.4" }
-pgx-macros = { path = "../pgx-macros", version= "0.4.4" }
-pgx-utils = { path = "../pgx-utils", version= "0.4.4" }
+pgx = { path = "../pgx", default-features = false, version= "=0.4.4" }
+pgx-macros = { path = "../pgx-macros", version= "=0.4.4" }
+pgx-utils = { path = "../pgx-utils", version= "=0.4.4" }
 postgres = "0.19.3"
 regex = "1.5.5"
 serde = "1.0.137"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -34,9 +34,9 @@ cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.15"
 seahash = "4.1.0"
-pgx-macros = { path = "../pgx-macros/", version = "0.4.4" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "0.4.4" }
-pgx-utils = { path = "../pgx-utils/", version = "0.4.4" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.4.4" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.4.4" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.4.4" }
 serde = { version = "1.0.137", features = [ "derive" ] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.80"

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -57,7 +57,7 @@ SEMVER_REGEX="(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*
 
 for cargo_toml in ${CARGO_TOMLS_TO_SED[@]}; do
     for dependency in ${DEPENDENCIES_TO_UPDATE[@]}; do
-        rg --passthru -N "(?P<prefix>^${dependency}.*\")${SEMVER_REGEX}(?P<postfix>\".*$)" -r "\${prefix}${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
+        rg --passthru -N "(?P<prefix>^${dependency}.*\")${SEMVER_REGEX}(?P<postfix>\".*$)" -r "\${prefix}=${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
         mv ${cargo_toml}.tmp ${cargo_toml}
     done
 done


### PR DESCRIPTION
While trying to install an older version of `cargo-pgx-0.4.2`, a user noticed they were getting build failures related to `pgx-utils-0.4.4`, this is because we were not correctly locking the semver.

According to https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#comparison-requirements, we can use `=0.4.2`, for example, to do this.