### PR TITLE
Don't use NullableDatum on pg10,11

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -156,8 +156,9 @@ fn main() -> color_eyre::Result<()> {
                     &bindings_file,
                     quote! {
                         use crate as pg_sys;
-                        use crate::{Datum, NullableDatum};
-                        use crate::PgNode;
+                        #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14"))]
+                        use crate::NullableDatum;
+                        use crate::{PgNode, Datum};
                     },
                 )
                 .wrap_err_with(|| {


### PR DESCRIPTION
I experienced a build error building pgx-tests for pg10 without this.