### PR TITLE
Remove dubious thread assertion

### DIFF
--- a/pgx-pg-sys/src/submodules/guard.rs
+++ b/pgx-pg-sys/src/submodules/guard.rs
@@ -76,17 +76,6 @@ fn take_panic_location() -> PanicLocation {
 thread_local! { pub(crate) static IS_MAIN_THREAD: once_cell::sync::OnceCell<()> = once_cell::sync::OnceCell::new() }
 
 pub fn register_pg_guard_panic_handler() {
-    // first, lets ensure we're not calling ourselves twice
-    #[cfg(debug_assertions)]
-    {
-        if IS_MAIN_THREAD.with(|v| v.get().is_some()) {
-            panic!("IS_MAIN_THREAD has already been set")
-        }
-
-        // it's expected that this function will only ever be called by `pg_module_magic!()` by the main thread
-        IS_MAIN_THREAD.with(|v| v.set(()).expect("failed to set main thread sentinel"));
-    }
-
     std::panic::set_hook(Box::new(|info| {
         #[cfg(debug_assertions)]
         {

--- a/pgx-pg-sys/src/submodules/guard.rs
+++ b/pgx-pg-sys/src/submodules/guard.rs
@@ -70,28 +70,8 @@ fn take_panic_location() -> PanicLocation {
     })
 }
 
-// via pg_module_magic!() this gets set to Some(()) for the "main" thread, and remains at None
-// for all other threads.
-#[cfg(debug_assertions)]
-thread_local! { pub(crate) static IS_MAIN_THREAD: once_cell::sync::OnceCell<()> = once_cell::sync::OnceCell::new() }
-
 pub fn register_pg_guard_panic_handler() {
     std::panic::set_hook(Box::new(|info| {
-        #[cfg(debug_assertions)]
-        {
-            if IS_MAIN_THREAD.with(|v| v.get().is_none()) {
-                // a thread that isn't the main thread panic!()d
-                // we make a best effort to push a message to stderr, which hopefully
-                // Postgres is logging somewhere
-                eprintln!(
-                    "thread={:?}, id={:?}, {}",
-                    std::thread::current().name(),
-                    std::thread::current().id(),
-                    info
-                );
-            }
-        }
-
         PANIC_LOCATION.with(|p| {
             let existing = p.take();
 

--- a/pgx-pg-sys/src/submodules/setjmp.rs
+++ b/pgx-pg-sys/src/submodules/setjmp.rs
@@ -13,7 +13,7 @@
 pub(crate) unsafe fn pg_guard_ffi_boundary<T, F: FnOnce() -> T>(f: F) -> T {
     use crate as pg_sys;
 
-    // This should really, really not be done if IS_MAIN_THREAD is None.
+    // This should really, really not be done in a multithreaded context
     let prev_exception_stack = pg_sys::PG_exception_stack;
     let prev_error_context_stack = pg_sys::error_context_stack;
     let mut jump_buffer = std::mem::MaybeUninit::uninit();

--- a/pgx-pg-sys/src/submodules/setjmp.rs
+++ b/pgx-pg-sys/src/submodules/setjmp.rs
@@ -7,17 +7,13 @@
 ///
 /// Currently, this function is only used by pgx' generated Postgres bindings.  It is not (yet)
 /// intended (or even necessary) for normal user code.
+///
+/// Calling this function from anything but the main thread can result in unpredictable behavior.
 #[inline(always)]
 pub(crate) unsafe fn pg_guard_ffi_boundary<T, F: FnOnce() -> T>(f: F) -> T {
     use crate as pg_sys;
 
-    // as the panic message says, we can't call Postgres functions from threads
-    // the value of IS_MAIN_THREAD gets set through the pg_module_magic!() macro
-    #[cfg(debug_assertions)]
-    if crate::submodules::guard::IS_MAIN_THREAD.with(|v| v.get().is_none()) {
-        panic!("functions under #[pg_guard] cannot be called from threads");
-    };
-
+    // This should really, really not be done if IS_MAIN_THREAD is None.
     let prev_exception_stack = pg_sys::PG_exception_stack;
     let prev_error_context_stack = pg_sys::error_context_stack;
     let mut jump_buffer = std::mem::MaybeUninit::uninit();


### PR DESCRIPTION
This assertion is misleading: if the Rust runtime becomes nested,
it creates a "new" thread, without actually spawning a second thread.
This `debug_assert!` then yields erroneous assertions.