### PR TITLE
Annotate and refactor pgx-tests

### DIFF
--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -399,7 +399,7 @@ fn monitor_pg(mut command: Command, cmd_string: String, loglines: LogLines) -> (
         let pid = child.id();
 
         eprintln!(
-            "{cmd }\npid={p}",
+            "{cmd}\npid={p}",
             cmd = cmd_string.bold().blue(),
             p = pid.to_string().yellow()
         );

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -501,8 +501,8 @@ fn dropdb() {
         )) {
             // got some error we didn't expect
             let stdout = String::from_utf8_lossy(output.stdout.as_slice());
-            eprintln!("completely unexpected error? stdout:\n{stdout}");
-            eprintln!("completely unexpected error? stderr:\n{stderr}");
+            eprintln!("unexpected error (stdout):\n{stdout}");
+            eprintln!("unexpected error (stderr):\n{stderr}");
             panic!("failed to drop test database");
         }
     }

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -99,8 +99,7 @@ pub fn run_test(
                     Ok(())
                 } else {
                     // we weren't expecting an error
-                    //
-                    // wait a second for Postgres to get log messages written to stdoerr
+                    // wait a second for Postgres to get log messages written to stderr
                     std::thread::sleep(std::time::Duration::from_millis(1000));
 
                     let mut pg_location = String::from("Postgres location: ");


### PR DESCRIPTION
I found it was useful to go through and annotate all the different panics with where they arose in the test framework, to get a better idea of what was going on. While I was out and about, I did some minor cleanup based on noticing some seemingly unnecessary potential panic sites.