### PR TITLE
Autodetect rustc version and silence warnings accordingly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,6 +1479,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rayon",
+ "rustversion",
  "sptr",
  "syn",
 ]
@@ -1907,6 +1908,12 @@ checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver 0.11.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -45,3 +45,4 @@ rayon = "1.5.2"
 syn = { version = "1.0.91", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 color-eyre = "0.6.1"
+rustversion = "1.0"

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -26,6 +26,11 @@ use syn::{ForeignItem, Item};
 #[derive(Debug)]
 struct IgnoredMacros(HashSet<String>);
 
+#[rustversion::nightly]
+const IS_NIGHTLY: bool = true;
+#[rustversion::not(nightly)]
+const IS_NIGHTLY: bool = false;
+
 impl IgnoredMacros {
     fn default() -> Self {
         // these cause duplicate definition problems on linux
@@ -70,6 +75,11 @@ fn main() -> color_eyre::Result<()> {
     let is_for_release =
         std::env::var("PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE").unwrap_or("0".to_string()) == "1";
     println!("cargo:rerun-if-env-changed=PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE");
+
+    // Do nightly detection to suppress silly warnings.
+    if IS_NIGHTLY {
+        println!("cargo:rustc-cfg=nightly")
+    };
 
     let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -17,6 +17,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #![allow(non_upper_case_globals)]
 #![allow(improper_ctypes)]
 #![allow(clippy::unneeded_field_pattern)]
+#![cfg_attr(nightly, feature(strict_provenance))]
 
 #[cfg(
     any(

--- a/pgx-pg-sys/src/submodules/datum.rs
+++ b/pgx-pg-sys/src/submodules/datum.rs
@@ -1,4 +1,5 @@
 // Polyfill while #![feature(strict_provenance)] is unstable
+#[cfg(not(nightly))]
 use sptr::Strict;
 use std::ptr::NonNull;
 


### PR DESCRIPTION
These messages started bothering me after upgrading rustc. They mostly appear on nightly (which I have been testing on for Reasons), and so I adjusted things so that the build should not fail to compile going forward and should suppress these warnings without any additional configuration.