### PR TITLE
Require rust-version "1.58".

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["database", "postgres", "postgresql", "extension"]
 readme = "README.md"
 exclude = [ "*.png" ]
 edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 atty = "0.2.14"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pgx_demo"
 version = "0.0.1"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aggregate"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/arrays/Cargo.toml
+++ b/pgx-examples/arrays/Cargo.toml
@@ -2,6 +2,7 @@
 name = "arrays"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/bad_ideas/Cargo.toml
+++ b/pgx-examples/bad_ideas/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bad_ideas"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/bgworker/Cargo.toml
+++ b/pgx-examples/bgworker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bgworker"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/bytea/Cargo.toml
+++ b/pgx-examples/bytea/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bytea"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/custom_sql/Cargo.toml
+++ b/pgx-examples/custom_sql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "custom_sql"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -2,6 +2,7 @@
 name = "custom_types"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/errors/Cargo.toml
+++ b/pgx-examples/errors/Cargo.toml
@@ -2,6 +2,7 @@
 name = "errors"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/nostd/Cargo.toml
+++ b/pgx-examples/nostd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nostd"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/operators/Cargo.toml
+++ b/pgx-examples/operators/Cargo.toml
@@ -2,6 +2,7 @@
 name = "operators"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/schemas/Cargo.toml
+++ b/pgx-examples/schemas/Cargo.toml
@@ -2,6 +2,7 @@
 name = "schemas"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/shmem/Cargo.toml
+++ b/pgx-examples/shmem/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shmem"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/spi/Cargo.toml
+++ b/pgx-examples/spi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spi"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/srf/Cargo.toml
+++ b/pgx-examples/srf/Cargo.toml
@@ -2,6 +2,7 @@
 name = "srf"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/strings/Cargo.toml
+++ b/pgx-examples/strings/Cargo.toml
@@ -2,6 +2,7 @@
 name = "strings"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/triggers/Cargo.toml
+++ b/pgx-examples/triggers/Cargo.toml
@@ -2,6 +2,7 @@
 name = "triggers"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/versioned_so/Cargo.toml
+++ b/pgx-examples/versioned_so/Cargo.toml
@@ -2,6 +2,7 @@
 name = "versioned_so"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-macros"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 proc-macro = true

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-pg-sys"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.58"
 
 [features]
 default = [ ]

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-tests"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = [ "cdylib", "lib" ]

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-utils"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 atty = "0.2.14"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 readme = "../README.md"
 edition = "2021"
+rust-version = "1.58"
 
 [lib]
 crate-type = [ "rlib" ]


### PR DESCRIPTION
It would be nice to support older versions, but currently pgx makes use
of captured identifers in format strings:
https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings

At least this way users get a comprehensible error message:

    error: package `pgx-pg-sys v0.4.5` cannot be built
    because it requires rustc 1.58 or newer, while the
    currently active rustc version is 1.57.0