### PR TITLE
Fix typo in cargo pgx init "downLoad" option documentation

### DIFF
--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -45,19 +45,19 @@ static PROCESS_ENV_DENYLIST: &'static [&'static str] = &[
 #[derive(clap::Args, Debug)]
 #[clap(author)]
 pub(crate) struct Init {
-    /// If installed locally, the path to PG10's `pgconfig` tool, or `downLoad` to have pgx download/compile/install it
+    /// If installed locally, the path to PG10's `pgconfig` tool, or `download` to have pgx download/compile/install it
     #[clap(env = "PG10_PG_CONFIG", long, help = "")]
     pg10: Option<String>,
-    /// If installed locally, the path to PG11's `pgconfig` tool, or `downLoad` to have pgx download/compile/install it
+    /// If installed locally, the path to PG11's `pgconfig` tool, or `download` to have pgx download/compile/install it
     #[clap(env = "PG11_PG_CONFIG", long)]
     pg11: Option<String>,
-    /// If installed locally, the path to PG12's `pgconfig` tool, or `downLoad` to have pgx download/compile/install it
+    /// If installed locally, the path to PG12's `pgconfig` tool, or `download` to have pgx download/compile/install it
     #[clap(env = "PG12_PG_CONFIG", long)]
     pg12: Option<String>,
-    /// If installed locally, the path to PG13's `pgconfig` tool, or `downLoad` to have pgx download/compile/install it
+    /// If installed locally, the path to PG13's `pgconfig` tool, or `download` to have pgx download/compile/install it
     #[clap(env = "PG13_PG_CONFIG", long)]
     pg13: Option<String>,
-    /// If installed locally, the path to PG14's `pgconfig` tool, or `downLoad` to have pgx download/compile/install it
+    /// If installed locally, the path to PG14's `pgconfig` tool, or `download` to have pgx download/compile/install it
     #[clap(env = "PG14_PG_CONFIG", long)]
     pg14: Option<String>,
     #[clap(from_global, parse(from_occurrences))]


### PR DESCRIPTION
`cargo pgx init --help` reported wrong value `downLoad` (capital `L`) to request download of specific Postgres version.