### PR TITLE
Add support for Spi cursors

### DIFF
--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -221,7 +221,7 @@ mod tests {
             );
             let mut cursor = client.open_cursor("SELECT * FROM tests.cursor_table", None);
             assert_eq!(sum_all(cursor.fetch(3)), 1 + 2 + 3);
-            Ok(Some(cursor.into_name()))
+            Ok(Some(cursor.detach_into_name()))
         })
         .unwrap();
 
@@ -232,6 +232,7 @@ mod tests {
             let mut cursor = client.find_cursor(&cursor_name);
             assert_eq!(sum_all(cursor.fetch(3)), 4 + 5 + 6);
             assert_eq!(sum_all(cursor.fetch(3)), 7 + 8 + 9);
+            cursor.detach_into_name();
             Ok(None::<()>)
         });
 
@@ -246,15 +247,6 @@ mod tests {
     fn test_cursor_failure() {
         Spi::execute(|mut client| {
             client.open_cursor("THIS IS NOT SQL", None);
-        });
-    }
-
-    #[pg_test]
-    fn test_cursor_close() {
-        Spi::connect(|mut client| {
-            let cursor = client.open_cursor("SELECT 1", None);
-            cursor.close();
-            Ok(None::<()>)
         });
     }
 

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -188,6 +188,75 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_cursor() {
+        Spi::execute(|mut client| {
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
+            client.update("INSERT INTO tests.cursor_table (id) \
+            SELECT i FROM generate_series(1, 10) AS t(i)", None, None);
+            let mut portal = client.open_cursor("SELECT * FROM tests.cursor_table", None);
+
+            fn sum_all(table: SpiTupleTable) -> i32 {
+                table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
+            }
+            assert_eq!(sum_all(portal.fetch(3)), 1+2+3);
+            assert_eq!(sum_all(portal.fetch(3)), 4+5+6);
+            assert_eq!(sum_all(portal.fetch(3)), 7+8+9);
+            assert_eq!(sum_all(portal.fetch(3)), 10);
+        });
+    }
+
+    fn test_cursor_by_name() {
+        let cursor_name = Spi::connect(|mut client| {
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
+            client.update("INSERT INTO tests.cursor_table (id) \
+            SELECT i FROM generate_series(1, 10) AS t(i)", None, None);
+            let mut cursor = client.open_cursor("SELECT * FROM tests.cursor_table", None);
+            assert_eq!(sum_all(cursor.fetch(3)), 1+2+3);
+            Ok(Some(cursor.into_name()))
+        }).unwrap();
+
+        fn sum_all(table: SpiTupleTable) -> i32 {
+            table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
+        }
+        Spi::connect(|mut client| {
+            let mut cursor = client.find_cursor(cursor_name.clone());
+            assert_eq!(sum_all(cursor.fetch(3)), 4+5+6);
+            assert_eq!(sum_all(cursor.fetch(3)), 7+8+9);
+            Ok(None::<()>)
+        });
+
+        Spi::connect(|mut client| {
+            let mut cursor = client.find_cursor(cursor_name);
+            assert_eq!(sum_all(cursor.fetch(3)), 10);
+            Ok(None::<()>)
+        });
+    }
+
+    #[pg_test(error = "syntax error at or near \"THIS\"")]
+    fn test_cursor_failure() {
+        Spi::execute(|mut client| {
+            client.open_cursor("THIS IS NOT SQL", None);
+        });
+    }
+
+    #[pg_test]
+    fn test_cursor_close() {
+        Spi::connect(|mut client| {
+            let cursor = client.open_cursor("SELECT 1", None);
+            cursor.close();
+            Ok(None::<()>)
+        });
+    }
+
+    #[pg_test(error="cursor named \"NOT A CURSOR\" not found")]
+    fn test_cursor_not_found() {
+        Spi::connect(|mut client| {
+            client.find_cursor("NOT A CURSOR".to_string());
+            Ok(None::<()>)
+        });
+    }
+
+    #[pg_test]
     fn test_columns() {
         use pgx::{PgBuiltInOids, PgOid};
         Spi::execute(|client| {

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -191,16 +191,20 @@ mod tests {
     fn test_cursor() {
         Spi::execute(|mut client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
-            client.update("INSERT INTO tests.cursor_table (id) \
-            SELECT i FROM generate_series(1, 10) AS t(i)", None, None);
+            client.update(
+                "INSERT INTO tests.cursor_table (id) \
+            SELECT i FROM generate_series(1, 10) AS t(i)",
+                None,
+                None,
+            );
             let mut portal = client.open_cursor("SELECT * FROM tests.cursor_table", None);
 
             fn sum_all(table: SpiTupleTable) -> i32 {
                 table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
             }
-            assert_eq!(sum_all(portal.fetch(3)), 1+2+3);
-            assert_eq!(sum_all(portal.fetch(3)), 4+5+6);
-            assert_eq!(sum_all(portal.fetch(3)), 7+8+9);
+            assert_eq!(sum_all(portal.fetch(3)), 1 + 2 + 3);
+            assert_eq!(sum_all(portal.fetch(3)), 4 + 5 + 6);
+            assert_eq!(sum_all(portal.fetch(3)), 7 + 8 + 9);
             assert_eq!(sum_all(portal.fetch(3)), 10);
         });
     }
@@ -208,20 +212,25 @@ mod tests {
     fn test_cursor_by_name() {
         let cursor_name = Spi::connect(|mut client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
-            client.update("INSERT INTO tests.cursor_table (id) \
-            SELECT i FROM generate_series(1, 10) AS t(i)", None, None);
+            client.update(
+                "INSERT INTO tests.cursor_table (id) \
+            SELECT i FROM generate_series(1, 10) AS t(i)",
+                None,
+                None,
+            );
             let mut cursor = client.open_cursor("SELECT * FROM tests.cursor_table", None);
-            assert_eq!(sum_all(cursor.fetch(3)), 1+2+3);
+            assert_eq!(sum_all(cursor.fetch(3)), 1 + 2 + 3);
             Ok(Some(cursor.into_name()))
-        }).unwrap();
+        })
+        .unwrap();
 
         fn sum_all(table: SpiTupleTable) -> i32 {
             table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
         }
         Spi::connect(|mut client| {
             let mut cursor = client.find_cursor(cursor_name.clone());
-            assert_eq!(sum_all(cursor.fetch(3)), 4+5+6);
-            assert_eq!(sum_all(cursor.fetch(3)), 7+8+9);
+            assert_eq!(sum_all(cursor.fetch(3)), 4 + 5 + 6);
+            assert_eq!(sum_all(cursor.fetch(3)), 7 + 8 + 9);
             Ok(None::<()>)
         });
 
@@ -248,7 +257,7 @@ mod tests {
         });
     }
 
-    #[pg_test(error="cursor named \"NOT A CURSOR\" not found")]
+    #[pg_test(error = "cursor named \"NOT A CURSOR\" not found")]
     fn test_cursor_not_found() {
         Spi::connect(|mut client| {
             client.find_cursor("NOT A CURSOR".to_string());

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -517,7 +517,7 @@ impl<'a> SpiClient<'a> {
 /// ```
 pub struct SpiCursor<'client> {
     ptr: pg_sys::Portal,
-    _phantom: PhantomData<&'client SpiClient>
+    _phantom: PhantomData<&'client SpiClient>,
 }
 
 impl SpiCursor<'_> {

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -445,7 +445,7 @@ impl<'a> SpiClient<'a> {
                 0,
             )
         };
-        SpiCursor { ptr }
+        SpiCursor { ptr, _phantom: PhantomData }
     }
 
     /// Find a cursor in transaction by name
@@ -461,7 +461,7 @@ impl<'a> SpiClient<'a> {
         if ptr.is_null() {
             panic!("cursor named \"{}\" not found", name);
         }
-        SpiCursor { ptr }
+        SpiCursor { ptr, _phantom: PhantomData }
     }
 }
 
@@ -515,11 +515,12 @@ impl<'a> SpiClient<'a> {
 ///     // <--- second SpiTupleTable gets freed by Spi::connect at this point
 /// });
 /// ```
-pub struct SpiCursor {
+pub struct SpiCursor<'client> {
     ptr: pg_sys::Portal,
+    _phantom: PhantomData<&'client SpiClient>
 }
 
-impl SpiCursor {
+impl SpiCursor<'_> {
     /// Fetch up to `count` rows from the cursor, moving forward
     ///
     /// If `fetch` runs off the end of the available rows, an empty [`SpiTupleTable`] is returned.

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -455,15 +455,10 @@ impl<'a> SpiClient<'a> {
     /// Cursor name can be retrieved via [`SpiCursor::into_name`].
     ///
     /// See [`SpiCursor`] docs for usage details.
-    pub fn find_cursor(
-        &mut self,
-        name: String,
-    ) -> SpiCursor {
+    pub fn find_cursor(&mut self, name: String) -> SpiCursor {
         use pgx_pg_sys::AsPgCStr;
 
-        let ptr = unsafe {
-            pg_sys::SPI_cursor_find(name.as_pg_cstr())
-        };
+        let ptr = unsafe { pg_sys::SPI_cursor_find(name.as_pg_cstr()) };
         if ptr.is_null() {
             error!("cursor named \"{}\" not found", name);
         }
@@ -529,20 +524,11 @@ impl SpiCursor {
     /// Fetch up to `count` rows from the cursor, moving forward
     ///
     /// If `fetch` runs off the end of the available rows, an empty [`SpiTupleTable`] is returned.
-    pub fn fetch(
-        &mut self,
-        count: i64
-    ) -> SpiTupleTable {
+    pub fn fetch(&mut self, count: i64) -> SpiTupleTable {
         unsafe {
             pg_sys::SPI_tuptable = std::ptr::null_mut();
         }
-        unsafe {
-            pg_sys::SPI_cursor_fetch(
-                self.ptr,
-                true,
-                count,
-            )
-        }
+        unsafe { pg_sys::SPI_cursor_fetch(self.ptr, true, count) }
         SpiTupleTable {
             status_code: SpiOk::Fetch,
             table: unsafe { pg_sys::SPI_tuptable },
@@ -563,7 +549,9 @@ impl SpiCursor {
     /// using [`SpiClient::find_cursor()`]
     pub fn into_name(self) -> String {
         unsafe { std::ffi::CStr::from_ptr((*self.ptr).name) }
-            .to_str().expect("non-utf8 cursor name").to_string()
+            .to_str()
+            .expect("non-utf8 cursor name")
+            .to_string()
     }
 
     /// Close the cursor, releasing its resources
@@ -573,12 +561,9 @@ impl SpiCursor {
     /// transaction using [`SpiClient::find_cursor()`].
     pub fn close(mut self) {
         let ptr = std::mem::replace(&mut self.ptr, std::ptr::null_mut());
-        unsafe {
-            pg_sys::SPI_cursor_close(ptr)
-        }
+        unsafe { pg_sys::SPI_cursor_close(ptr) }
     }
 }
-
 
 impl SpiTupleTable {
     /// `SpiTupleTable`s are positioned before the start, for iteration purposes.

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -485,7 +485,7 @@ impl<'a> SpiClient<'a> {
 ///
 /// # Examples
 /// ## Simple cursor
-/// ```ignore // FIXME doctests compilation failing on m1
+/// ```rust,no_run
 /// use pgx::Spi;
 /// Spi::connect(|mut client| {
 ///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);
@@ -498,7 +498,7 @@ impl<'a> SpiClient<'a> {
 /// ```
 ///
 /// ## Cursor by name
-/// ```ignore // FIXME doctests compilation failing on m1
+/// ```rust,no_run
 /// use pgx::Spi;
 /// let cursor_name = Spi::connect(|mut client| {
 ///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -517,7 +517,7 @@ impl<'a> SpiClient<'a> {
 /// ```
 pub struct SpiCursor<'client> {
     ptr: pg_sys::Portal,
-    _phantom: PhantomData<&'client SpiClient>,
+    _phantom: PhantomData<&'client SpiClient<'client>>,
 }
 
 impl SpiCursor<'_> {

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -428,7 +428,7 @@ impl<'a> SpiClient<'a> {
 
                 None => {
                     // 'n' here means that the datum is null
-                    datums.push(0);
+                    datums.push(pg_sys::Datum::from(0usize));
                     nulls.push('n' as std::os::raw::c_char);
                 }
             }

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -16,7 +16,6 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Index, IndexMut};
-use tracing::error;
 
 /// These match the Postgres `#define`d constants prefixed `SPI_OK_*` that you can find in `pg_sys`.
 #[derive(Debug, PartialEq)]
@@ -455,12 +454,12 @@ impl<'a> SpiClient<'a> {
     /// Cursor name can be retrieved via [`SpiCursor::into_name`].
     ///
     /// See [`SpiCursor`] docs for usage details.
-    pub fn find_cursor(&mut self, name: String) -> SpiCursor {
+    pub fn find_cursor(&mut self, name: &str) -> SpiCursor {
         use pgx_pg_sys::AsPgCStr;
 
         let ptr = unsafe { pg_sys::SPI_cursor_find(name.as_pg_cstr()) };
         if ptr.is_null() {
-            error!("cursor named \"{}\" not found", name);
+            panic!("cursor named \"{}\" not found", name);
         }
         SpiCursor { ptr }
     }
@@ -508,7 +507,7 @@ impl<'a> SpiClient<'a> {
 ///     // <--- first SpiTupleTable gets freed by Spi::connect at this point
 /// }).unwrap();
 /// Spi::connect(|mut client| {
-///     let mut cursor = client.find_cursor(cursor_name);
+///     let mut cursor = client.find_cursor(&cursor_name);
 ///     assert_eq!(Some(2u32), cursor.fetch(1).get_one());
 ///     drop(cursor); // <-- cursor gets dropped here
 ///     // ... more code ...


### PR DESCRIPTION
This extends the `SpiClient` interface to expose methods to open a cursor based on a query, returning a `SpiCursor` that can be used to fetch results incrementally. Opened cursors can be closed early, or left open and turned into their (portal) name, to be later retrieved in a different Spi session in the same transaction.