### PR TITLE
Adding a flag that forces `CREATE OR REPLACE FUNCTION` statements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,6 +181,8 @@ jobs:
       run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
 
     - name: Run versioned_so example tests
+      env: 
+        PGX_FORCE_CREATE_OR_REPLACE: true
       run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
 
     # Attempt to make the cache payload slightly smaller.

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -38,6 +38,9 @@ pub(crate) struct Install {
     /// Build in test mode (for `cargo pgx test`)
     #[clap(long)]
     test: bool,
+    /// Force generation of CREATE OR REPLACE statements instead of plain CREATE.
+    #[clap(long)]
+    force_create_or_replace: bool,
     /// The `pg_config` path (default is first in $PATH)
     #[clap(long, short = 'c')]
     pg_config: Option<String>,
@@ -75,6 +78,7 @@ impl CommandExecute for Install {
             &pg_config,
             self.release,
             self.test,
+            self.force_create_or_replace,
             None,
             &features,
         )
@@ -95,6 +99,7 @@ pub(crate) fn install_extension(
     pg_config: &PgConfig,
     is_release: bool,
     is_test: bool,
+    force_create_or_replace: bool,
     base_directory: Option<PathBuf>,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
@@ -192,6 +197,7 @@ pub(crate) fn install_extension(
         &extdir,
         &base_directory,
         true,
+        force_create_or_replace,
     )?;
 
     println!("{} installing {}", "    Finished".bold().green(), extname);
@@ -327,6 +333,7 @@ fn copy_sql_files(
     extdir: &PathBuf,
     base_directory: &PathBuf,
     skip_build: bool,
+    force_create_or_replace: bool,
 ) -> eyre::Result<()> {
     let dest = get_target_sql_file(&package_manifest_path, extdir, base_directory)?;
     let (_, extname) = find_control_file(&package_manifest_path)?;
@@ -343,6 +350,7 @@ fn copy_sql_files(
         Option::<String>::None,
         None,
         skip_build,
+        force_create_or_replace,
     )?;
 
     // now copy all the version upgrade files too

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -32,6 +32,9 @@ pub(crate) struct Package {
     /// Build in test mode (for `cargo pgx test`)
     #[clap(long)]
     test: bool,
+    /// Force generation of CREATE OR REPLACE statements instead of plain CREATE.
+    #[clap(long)]
+    force_create_or_replace: bool,
     /// The `pg_config` path (default is first in $PATH)
     #[clap(long, short = 'c', parse(from_os_str))]
     pg_config: Option<PathBuf>,
@@ -78,6 +81,7 @@ impl CommandExecute for Package {
             out_dir,
             self.debug,
             self.test,
+            self.force_create_or_replace,
             &features,
         )
     }
@@ -96,6 +100,7 @@ pub(crate) fn package_extension(
     out_dir: PathBuf,
     is_debug: bool,
     is_test: bool,
+    force_create_or_replace: bool,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
     if !out_dir.exists() {
@@ -109,6 +114,7 @@ pub(crate) fn package_extension(
         pg_config,
         !is_debug,
         is_test,
+        force_create_or_replace,
         Some(out_dir),
         features,
     )

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -135,6 +135,7 @@ pub(crate) fn run(
         pg_config,
         is_release,
         false,
+        false,
         None,
         features,
     )?;

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -66,6 +66,9 @@ pub(crate) struct Schema {
     /// Skip building a fresh extension shared object.
     #[clap(long)]
     skip_build: bool,
+    /// Force generation of CREATE OR REPLACE statements instead of plain CREATE.
+    #[clap(long)]
+    force_create_or_replace: bool,
 }
 
 impl CommandExecute for Schema {
@@ -125,6 +128,7 @@ impl CommandExecute for Schema {
             self.dot,
             log_level,
             self.skip_build,
+            self.force_create_or_replace,
         )
     }
 }
@@ -149,6 +153,7 @@ pub(crate) fn generate_schema(
     dot: Option<impl AsRef<std::path::Path>>,
     log_level: Option<String>,
     skip_build: bool,
+    force_create_or_replace: bool,
 ) -> eyre::Result<()> {
     let manifest = Manifest::from_path(&package_manifest_path)?;
     let (control_file, _extname) = find_control_file(&package_manifest_path)?;
@@ -405,6 +410,7 @@ pub(crate) fn generate_schema(
         entities.into_iter(),
         package_name.to_string(),
         versioned_so,
+        force_create_or_replace,
     )
     .wrap_err("SQL generation error")?;
 

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -38,6 +38,9 @@ pub(crate) struct Test {
     /// compile for release mode (default is debug)
     #[clap(env = "PROFILE", long, short)]
     release: bool,
+    /// Force generation of CREATE OR REPLACE statements instead of plain CREATE.
+    #[clap(long)]
+    force_create_or_replace: bool,
     /// Don't regenerate the schema
     #[clap(long, short)]
     no_schema: bool,
@@ -98,6 +101,7 @@ impl CommandExecute for Test {
                 self.package.as_ref(),
                 self.release,
                 self.no_schema,
+                self.force_create_or_replace,
                 &features,
                 testname.clone(),
             )?
@@ -118,6 +122,7 @@ pub fn test_extension(
     user_package: Option<&String>,
     is_release: bool,
     no_schema: bool,
+    force_create_or_replace: bool,
     features: &clap_cargo::Features,
     testname: Option<impl AsRef<str>>,
 ) -> eyre::Result<()> {
@@ -160,7 +165,15 @@ pub fn test_extension(
             "PGX_BUILD_PROFILE",
             if is_release { "release" } else { "debug" },
         )
-        .env("PGX_NO_SCHEMA", if no_schema { "true" } else { "false" });
+        .env("PGX_NO_SCHEMA", if no_schema { "true" } else { "false" })
+        .env(
+            "PGX_FORCE_CREATE_OR_REPLACE",
+            if force_create_or_replace {
+                "true"
+            } else {
+                "false"
+            },
+        );
 
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
         command.env("RUST_LOG", rust_log);

--- a/pgx-examples/versioned_so/src/lib.rs
+++ b/pgx-examples/versioned_so/src/lib.rs
@@ -2,6 +2,25 @@ use pgx::*;
 
 pg_module_magic!();
 
+// This example works better in the test environment,
+// more relealistically though, when using versioned .so 
+// you'll end up with an older definition like:
+//
+// CREATE OR REPLACE FUNCTION hello_versioned_so() RETURNS text
+// IMMUTABLE PARALLEL SAFE STRICT
+// LANGUAGE C
+// AS '$libdir/versioned_so-0.0.1', 'hello_versioned_so_wrapper';
+extension_sql!(
+    "\n\
+    CREATE FUNCTION hello_versioned_so() RETURNS text \
+    AS 'old definition' \
+    LANGUAGE SQL \
+    IMMUTABLE; \
+    ",
+    name = "boostrap",
+    bootstrap,
+);
+
 #[pg_extern]
 fn hello_versioned_so() -> &'static str {
     "Hello, versioned_so"

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -238,6 +238,7 @@ fn install_extension() -> eyre::Result<()> {
     eprintln!("installing extension");
     let is_release = std::env::var("PGX_BUILD_PROFILE").unwrap_or("debug".into()) == "release";
     let no_schema = std::env::var("PGX_NO_SCHEMA").unwrap_or("false".into()) == "true";
+    let force_create_or_replace = std::env::var("PGX_FORCE_CREATE_OR_REPLACE").unwrap_or("false".into()) == "true";
     let mut features = std::env::var("PGX_FEATURES").unwrap_or("".to_string());
     if !features.contains("pg_test") {
         features += " pg_test";
@@ -288,6 +289,9 @@ fn install_extension() -> eyre::Result<()> {
     }
     if no_schema {
         command.arg("--no-schema");
+    }
+    if force_create_or_replace {
+        command.arg("--force-create-or-replace");
     }
 
     let mut child = command.spawn().unwrap();

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -107,8 +107,14 @@ impl ToSql for PgExternEntity {
 
         let module_pathname = &context.get_module_pathname();
 
+        let create = if context.force_create_or_replace {
+            "CREATE OR REPLACE"
+        } else {
+            "CREATE"
+        };
+
         let fn_sql = format!("\
-                                CREATE FUNCTION {schema}\"{name}\"({arguments}) {returns}\n\
+                                {create} FUNCTION {schema}\"{name}\"({arguments}) {returns}\n\
                                 {extern_attrs}\
                                 {search_path}\
                                 LANGUAGE c /* Rust */\n\

--- a/pgx-utils/src/sql_entity_graph/pgx_sql.rs
+++ b/pgx-utils/src/sql_entity_graph/pgx_sql.rs
@@ -67,6 +67,7 @@ pub struct PgxSql {
     pub aggregates: HashMap<PgAggregateEntity, NodeIndex>,
     pub extension_name: String,
     pub versioned_so: bool,
+    pub force_create_or_replace: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
@@ -84,6 +85,7 @@ impl PgxSql {
         entities: impl Iterator<Item = SqlGraphEntity>,
         extension_name: String,
         versioned_so: bool,
+        force_create_or_replace: bool,
     ) -> eyre::Result<Self> {
         let mut graph = StableGraph::new();
 
@@ -236,6 +238,7 @@ impl PgxSql {
             graph_finalize: finalize,
             extension_name: extension_name,
             versioned_so,
+            force_create_or_replace,
         };
         this.register_types();
         Ok(this)


### PR DESCRIPTION
Adding a flag that forces `CREATE OR REPLACE FUNCTION` statements  instead of plain `CREATE FUNCTION` statements pgx now produces by default.

The new default (#554) is potentially less destructive to pre-existing objects and more secure. Unfortunately, it complicates the upgrade path when using versioned shared objects.