### PR TITLE
add support for creating an empty composite type

### DIFF
--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -29,7 +29,6 @@ mod tests {
     #[pg_test]
     fn test_missing_type() {
         const NON_EXISTING_ATTRIBUTE: &str = "DEFINITELY_NOT_EXISTING";
-        let attr_string = NON_EXISTING_ATTRIBUTE.to_string();
 
         match PgHeapTuple::new_composite_type(NON_EXISTING_ATTRIBUTE) {
             Err(PgHeapTupleError::NoSuchType(not_found)) if not_found == NON_EXISTING_ATTRIBUTE.to_string() => (),

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -28,7 +28,14 @@ mod tests {
 
     #[pg_test]
     fn test_missing_type() {
-        assert!(PgHeapTuple::new_composite_type("nuthin").is_err());
+        const NON_EXISTING_ATTRIBUTE: &str = "DEFINITELY_NOT_EXISTING";
+        let attr_string = NON_EXISTING_ATTRIBUTE.to_string();
+
+        match PgHeapTuple::new_composite_type(NON_EXISTING_ATTRIBUTE) {
+            Err(PgHeapTupleError::NoSuchType(not_found)) if not_found == NON_EXISTING_ATTRIBUTE.to_string() => (),
+            Err(err) => panic!("{}", err),
+            Ok(_) => panic!("Able to find what should be a not existing composite type"),
+        }
     }
 
     #[pg_test]

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -31,7 +31,11 @@ mod tests {
         const NON_EXISTING_ATTRIBUTE: &str = "DEFINITELY_NOT_EXISTING";
 
         match PgHeapTuple::new_composite_type(NON_EXISTING_ATTRIBUTE) {
-            Err(PgHeapTupleError::NoSuchType(not_found)) if not_found == NON_EXISTING_ATTRIBUTE.to_string() => (),
+            Err(PgHeapTupleError::NoSuchType(not_found))
+                if not_found == NON_EXISTING_ATTRIBUTE.to_string() =>
+            {
+                ()
+            }
             Err(err) => panic!("{}", err),
             Ok(_) => panic!("Able to find what should be a not existing composite type"),
         }
@@ -45,13 +49,16 @@ mod tests {
         const NON_EXISTING_ATTRIBUTE: &str = "DEFINITELY_NOT_EXISTING";
         assert_eq!(
             heap_tuple.get_by_name::<String>(NON_EXISTING_ATTRIBUTE),
-            Err(TryFromDatumError::NoSuchAttributeName(NON_EXISTING_ATTRIBUTE.into())),
+            Err(TryFromDatumError::NoSuchAttributeName(
+                NON_EXISTING_ATTRIBUTE.into()
+            )),
         );
 
         assert_eq!(
-            heap_tuple
-                .set_by_name(NON_EXISTING_ATTRIBUTE, "Brandy".to_string()),
-            Err(TryFromDatumError::NoSuchAttributeName(NON_EXISTING_ATTRIBUTE.into())),
+            heap_tuple.set_by_name(NON_EXISTING_ATTRIBUTE, "Brandy".to_string()),
+            Err(TryFromDatumError::NoSuchAttributeName(
+                NON_EXISTING_ATTRIBUTE.into()
+            )),
         );
     }
 
@@ -63,13 +70,16 @@ mod tests {
         const NON_EXISTING_ATTRIBUTE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(9001) };
         assert_eq!(
             heap_tuple.get_by_index::<String>(NON_EXISTING_ATTRIBUTE),
-            Err(TryFromDatumError::NoSuchAttributeNumber(NON_EXISTING_ATTRIBUTE)),
+            Err(TryFromDatumError::NoSuchAttributeNumber(
+                NON_EXISTING_ATTRIBUTE
+            )),
         );
 
         assert_eq!(
-            heap_tuple
-                .set_by_index(NON_EXISTING_ATTRIBUTE, "Brandy".to_string()),
-            Err(TryFromDatumError::NoSuchAttributeNumber(NON_EXISTING_ATTRIBUTE)),
+            heap_tuple.set_by_index(NON_EXISTING_ATTRIBUTE, "Brandy".to_string()),
+            Err(TryFromDatumError::NoSuchAttributeNumber(
+                NON_EXISTING_ATTRIBUTE
+            )),
         );
     }
 
@@ -90,16 +100,13 @@ mod tests {
 
         // These are **deliberately** the wrong types.
         assert_eq!(
-            heap_tuple
-                .set_by_name("name", 1_i32),
+            heap_tuple.set_by_name("name", 1_i32),
             Err(TryFromDatumError::IncompatibleTypes),
         );
         assert_eq!(
-            heap_tuple
-                .set_by_name("age", "Brandy"),
+            heap_tuple.set_by_name("age", "Brandy"),
             Err(TryFromDatumError::IncompatibleTypes),
         );
-
 
         // Now set them properly, to test that we get errors when they're set...
         heap_tuple

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -1,0 +1,31 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    use crate as pgx_tests;
+    use pgx::*;
+
+    #[pg_test]
+    fn test_new_composite_type() {
+        Spi::run("CREATE TYPE dog AS (name text, age int);");
+        let mut heap_tuple = PgHeapTuple::new_composite_type("dog").unwrap();
+
+        assert_eq!(heap_tuple.get_by_name::<String>("name").unwrap(), None);
+        assert_eq!(heap_tuple.get_by_name::<i32>("age").unwrap(), None);
+
+        heap_tuple
+            .set_by_name("name", "Brandy".to_string())
+            .unwrap();
+        heap_tuple.set_by_name("age", 42).unwrap();
+
+        assert_eq!(
+            heap_tuple.get_by_name("name").unwrap(),
+            Some("Brandy".to_string())
+        );
+        assert_eq!(heap_tuple.get_by_name("age").unwrap(), Some(42i32));
+    }
+
+    #[pg_test]
+    fn test_missing_type() {
+        assert!(PgHeapTuple::new_composite_type("nuthin").is_err());
+    }
+}

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -1,8 +1,10 @@
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {
+    #[cfg(test)]
     use crate as pgx_tests;
     use pgx::*;
+    use std::num::NonZeroUsize;
 
     #[pg_test]
     fn test_new_composite_type() {
@@ -27,5 +29,86 @@ mod tests {
     #[pg_test]
     fn test_missing_type() {
         assert!(PgHeapTuple::new_composite_type("nuthin").is_err());
+    }
+
+    #[pg_test]
+    fn test_missing_field() {
+        Spi::run("CREATE TYPE dog AS (name text, age int);");
+        let mut heap_tuple = PgHeapTuple::new_composite_type("dog").unwrap();
+
+        const NON_EXISTING_ATTRIBUTE: &str = "DEFINITELY_NOT_EXISTING";
+        assert_eq!(
+            heap_tuple.get_by_name::<String>(NON_EXISTING_ATTRIBUTE),
+            Err(TryFromDatumError::NoSuchAttributeName(NON_EXISTING_ATTRIBUTE.into())),
+        );
+
+        assert_eq!(
+            heap_tuple
+                .set_by_name(NON_EXISTING_ATTRIBUTE, "Brandy".to_string()),
+            Err(TryFromDatumError::NoSuchAttributeName(NON_EXISTING_ATTRIBUTE.into())),
+        );
+    }
+
+    #[pg_test]
+    fn test_missing_number() {
+        Spi::run("CREATE TYPE dog AS (name text, age int);");
+        let mut heap_tuple = PgHeapTuple::new_composite_type("dog").unwrap();
+
+        const NON_EXISTING_ATTRIBUTE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(9001) };
+        assert_eq!(
+            heap_tuple.get_by_index::<String>(NON_EXISTING_ATTRIBUTE),
+            Err(TryFromDatumError::NoSuchAttributeNumber(NON_EXISTING_ATTRIBUTE)),
+        );
+
+        assert_eq!(
+            heap_tuple
+                .set_by_index(NON_EXISTING_ATTRIBUTE, "Brandy".to_string()),
+            Err(TryFromDatumError::NoSuchAttributeNumber(NON_EXISTING_ATTRIBUTE)),
+        );
+    }
+
+    #[pg_test]
+    fn test_wrong_type_assumed() {
+        Spi::run("CREATE TYPE dog AS (name text, age int);");
+        let mut heap_tuple = PgHeapTuple::new_composite_type("dog").unwrap();
+
+        // These are **deliberately** the wrong types.
+        assert_eq!(
+            heap_tuple.get_by_name::<i32>("name"),
+            Ok(None), // We don't get an error here, yet...
+        );
+        assert_eq!(
+            heap_tuple.get_by_name::<String>("age"),
+            Ok(None), // We don't get an error here, yet...
+        );
+
+        // These are **deliberately** the wrong types.
+        assert_eq!(
+            heap_tuple
+                .set_by_name("name", 1_i32),
+            Err(TryFromDatumError::IncompatibleTypes),
+        );
+        assert_eq!(
+            heap_tuple
+                .set_by_name("age", "Brandy"),
+            Err(TryFromDatumError::IncompatibleTypes),
+        );
+
+
+        // Now set them properly, to test that we get errors when they're set...
+        heap_tuple
+            .set_by_name("name", "Brandy".to_string())
+            .unwrap();
+        heap_tuple.set_by_name("age", 42).unwrap();
+
+        // These are **deliberately** the wrong types.
+        assert_eq!(
+            heap_tuple.get_by_name::<i32>("name"),
+            Err(TryFromDatumError::IncompatibleTypes),
+        );
+        assert_eq!(
+            heap_tuple.get_by_name::<String>("age"),
+            Err(TryFromDatumError::IncompatibleTypes),
+        );
     }
 }

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -18,6 +18,7 @@ mod derive_pgtype_lifetimes;
 mod enum_type_tests;
 mod fcinfo_tests;
 mod guc_tests;
+mod heap_tuple;
 mod hooks_tests;
 mod inet_tests;
 mod internal_tests;

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -19,33 +19,20 @@ use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
 
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum TryFromDatumError {
-    /// The specified type of the Datum is not compatible with the desired Rust type.
+    #[error("The specified type of the Datum is not compatible with the desired Rust type.")]
     IncompatibleTypes,
 
-    /// We were asked to convert a Datum that is NULL (but flagged as "not null")
+    #[error("We were asked to convert a Datum that is NULL (but flagged as \"not null\")")]
     NullDatumPointer,
 
-    /// The specified attribute number is invalid
+    #[error("The specified attribute number `{0}` is not present")]
     NoSuchAttributeNumber(NonZeroUsize),
 
-    /// The specified attribute name is invalid
+    #[error("The specified attribute name `{0}` is not present")]
     NoSuchAttributeName(String),
 }
-
-impl Display for TryFromDatumError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TryFromDatumError::IncompatibleTypes => f.write_str("Incompatible types"),
-            TryFromDatumError::NullDatumPointer => f.write_str("Null Datum pointer"),
-            TryFromDatumError::NoSuchAttributeNumber(_) => f.write_str("No such attribute number"),
-            TryFromDatumError::NoSuchAttributeName(_) => f.write_str("No such attribute name"),
-        }
-    }
-}
-
-impl Error for TryFromDatumError {}
 
 /// Convert a `(pg_sys::Datum, is_null:bool` pair into a Rust type
 ///

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -13,9 +13,7 @@ use crate::{
     pg_sys, text_to_rust_str_unchecked, varlena_to_byte_slice, AllocatedByPostgres, IntoDatum,
     PgBox, PgMemoryContexts,
 };
-use std::error::Error;
 use std::ffi::CStr;
-use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
 
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -114,12 +114,10 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
             .ok_or_else(|| PgHeapTupleError::NoSuchType(type_name.to_string()))?;
         let natts = tuple_desc.len();
         unsafe {
-            let datums =
-                pg_sys::palloc0(natts * std::mem::size_of::<pg_sys::Datum>()) as *mut pg_sys::Datum;
             let mut is_null = (0..natts).map(|_| true).collect::<Vec<_>>();
 
             let heap_tuple =
-                pg_sys::heap_form_tuple(tuple_desc.as_ptr(), datums, is_null.as_mut_ptr());
+                pg_sys::heap_form_tuple(tuple_desc.as_ptr(), std::ptr::null_mut(), is_null.as_mut_ptr());
 
             Ok(PgHeapTuple {
                 tuple: PgBox::<pg_sys::HeapTupleData, AllocatedByRust>::from_rust(heap_tuple),

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -1,12 +1,12 @@
 //! Provides a safe interface to Postgres `HeapTuple` objects.
 use crate::{
     heap_getattr_raw, pg_sys, AllocatedByPostgres, AllocatedByRust, FromDatum, IntoDatum, PgBox,
-    PgTupleDesc, Spi, TriggerTuple, TryFromDatumError, WhoAllocated,
+    PgTupleDesc, TriggerTuple, TryFromDatumError, WhoAllocated,
 };
 use std::num::NonZeroUsize;
 
 /// Describes errors that can occur when trying to create a new [PgHeapTuple].
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum PgHeapTupleError {
     #[error("Incorrect attribute count, found {0}, descriptor had {1}")]
     IncorrectAttributeCount(usize, usize),
@@ -86,10 +86,31 @@ impl<'a> PgHeapTuple<'a, AllocatedByPostgres> {
 }
 
 impl<'a> PgHeapTuple<'a, AllocatedByRust> {
+    /** Create a new heap tuple in the shape of a defined composite type
+    
+    ```rust,no_run
+    Spi::run("CREATE TYPE dog AS (name text, age int);");
+    let mut heap_tuple = PgHeapTuple::new_composite_type("dog").unwrap();
+
+    assert_eq!(heap_tuple.get_by_name::<String>("name").unwrap(), None);
+    assert_eq!(heap_tuple.get_by_name::<i32>("age").unwrap(), None);
+
+    heap_tuple
+        .set_by_name("name", "Brandy".to_string())
+        .unwrap();
+    heap_tuple.set_by_name("age", 42).unwrap();
+
+    assert_eq!(
+        heap_tuple.get_by_name("name").unwrap(),
+        Some("Brandy".to_string())
+    );
+    assert_eq!(heap_tuple.get_by_name("age").unwrap(), Some(42i32));
+    ```
+    */
     pub fn new_composite_type(
         type_name: &str,
     ) -> Result<PgHeapTuple<'a, AllocatedByRust>, PgHeapTupleError> {
-        let tuple_desc = PgTupleDesc::from_composite_type(type_name)
+        let tuple_desc = PgTupleDesc::for_composite_type(type_name)
             .ok_or_else(|| PgHeapTupleError::NoSuchType(type_name.to_string()))?;
         let natts = tuple_desc.len();
         unsafe {

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -89,6 +89,8 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
     /** Create a new heap tuple in the shape of a defined composite type
 
     ```rust,no_run
+    use pgx::*;
+    
     Spi::run("CREATE TYPE dog AS (name text, age int);");
     let mut heap_tuple = PgHeapTuple::new_composite_type("dog").unwrap();
 

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -87,7 +87,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByPostgres> {
 
 impl<'a> PgHeapTuple<'a, AllocatedByRust> {
     /** Create a new heap tuple in the shape of a defined composite type
-    
+
     ```rust,no_run
     Spi::run("CREATE TYPE dog AS (name text, age int);");
     let mut heap_tuple = PgHeapTuple::new_composite_type("dog").unwrap();

--- a/pgx/src/tupdesc.rs
+++ b/pgx/src/tupdesc.rs
@@ -97,7 +97,7 @@ impl<'a> PgTupleDesc<'a> {
     ///
     /// This method is unsafe as we cannot validate that the provided `pg_sys::TupleDesc` is valid
     /// or requires reference counting.
-    pub unsafe fn from_pg_copy<'b>(ptr: pg_sys::TupleDesc) -> PgTupleDesc<'b> {
+    pub unsafe fn from_rust_copy<'b>(ptr: pg_sys::TupleDesc) -> PgTupleDesc<'b> {
         PgTupleDesc {
             // SAFETY:  pg_sys::CreateTupleDescCopyConstr will be returning a valid pointer
             tupdesc: PgBox::from_pg(pg_sys::CreateTupleDescCopyConstr(ptr)),
@@ -107,7 +107,7 @@ impl<'a> PgTupleDesc<'a> {
         }
     }
 
-    /// Similar to `::from_pg_copy()`, but assumes the provided `TupleDesc` is already a copy.
+    /// Similar to `::from_rust_copy()`, but assumes the provided `TupleDesc` is already a copy.
     ///
     /// When this instance is dropped, the TupleDesc is `pfree()`'d
     ///
@@ -178,7 +178,8 @@ impl<'a> PgTupleDesc<'a> {
             }
 
             let tuple_desc = pg_sys::lookup_rowtype_tupdesc(typoid, typmod);
-            Some(PgTupleDesc::from_rust(tuple_desc))
+            // It's important to make a copy of the tupledesc: https://www.postgresql.org/message-id/flat/24471.1136768659%40sss.pgh.pa.us
+            Some(PgTupleDesc::from_rust_copy(tuple_desc))
         }
     }
 

--- a/pgx/src/tupdesc.rs
+++ b/pgx/src/tupdesc.rs
@@ -150,7 +150,24 @@ impl<'a> PgTupleDesc<'a> {
         }
     }
 
-    pub fn from_composite_type(name: &str) -> Option<PgTupleDesc<'a>> {
+    /** Retrieve the tuple description of the shape of a defined composite type
+    
+    ```rust,no_run
+    Spi::run("CREATE TYPE dog AS (name text, age int);");
+    let tuple_desc = PgTupleDesc::for_composite_type(type_name);
+    
+    let mut is_null = (0..natts).map(|_| true).collect::<Vec<_>>();
+
+    let heap_tuple =
+        pg_sys::heap_form_tuple(tuple_desc.as_ptr(), datums, is_null.as_mut_ptr());
+
+    PgHeapTuple {
+        tuple: PgBox::<pg_sys::HeapTupleData, AllocatedByRust>::from_rust(heap_tuple),
+        tupdesc: tuple_desc,
+    }
+    ```
+    */
+    pub fn for_composite_type(name: &str) -> Option<PgTupleDesc<'a>> {
         unsafe {
             let mut typoid = 0;
             let mut typmod = 0;


### PR DESCRIPTION
This implements the ability to create a new/empty `PgHeapTuple`.