### PR TITLE
ureq not rttp_client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,8 @@ version = "0.0.0"
 dependencies = [
  "pgx",
  "pgx-tests",
- "rand 0.8.5",
- "rttp_client",
+ "rand",
+ "ureq",
 ]
 
 [[package]]
@@ -148,12 +148,6 @@ checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -164,8 +158,7 @@ version = "0.0.0"
 dependencies = [
  "pgx",
  "pgx-tests",
- "rand 0.8.5",
- "rttp_client",
+ "rand",
 ]
 
 [[package]]
@@ -248,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
 name = "bytea"
 version = "0.1.0"
 dependencies = [
@@ -300,13 +299,13 @@ dependencies = [
  "quote",
  "rayon",
  "regex",
- "rttp_client",
  "semver 1.0.9",
  "syn",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
  "unescape",
+ "ureq",
 ]
 
 [[package]]
@@ -362,6 +361,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clang-sys"
@@ -879,17 +884,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
@@ -941,7 +935,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version 0.4.0",
- "spin",
+ "spin 0.9.3",
  "stable_deref_trait",
 ]
 
@@ -968,12 +962,6 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
-
-[[package]]
-name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "idna"
@@ -1022,6 +1010,15 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "js-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1148,22 +1145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
 ]
 
 [[package]]
@@ -1509,7 +1490,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rttp_client",
  "serde",
  "serde-xml-rs",
  "serde_derive",
@@ -1521,6 +1501,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "unescape",
+ "ureq",
  "url",
 ]
 
@@ -1566,7 +1547,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "indexmap",
  "line-wrap",
  "serde",
@@ -1594,14 +1575,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "stringprep",
 ]
@@ -1677,36 +1658,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1716,16 +1674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1734,16 +1683,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1785,7 +1725,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
@@ -1826,6 +1766,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "riscv"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,24 +1806,6 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
-name = "rttp_client"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1396558eebd03e50e6526071e0bdcec24e3d67f4fec14bcc8139f24ae941db72"
-dependencies = [
- "base64 0.11.0",
- "flate2",
- "httpdate",
- "mime",
- "mime_guess",
- "native-tls",
- "percent-encoding",
- "rand 0.7.3",
- "socks",
- "url",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -1907,6 +1844,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.9",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1960,6 +1909,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "seahash"
@@ -2156,23 +2115,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "spi"
 version = "0.0.0"
 dependencies = [
  "pgx",
  "pgx-tests",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2195,7 +2149,7 @@ version = "0.1.0"
 dependencies = [
  "pgx",
  "pgx-tests",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2531,15 +2485,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2506,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,7 +2547,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6d5d669b51467dcf7b2f1a796ce0f955f05f01cafda6c19d6e95f730df29238"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
 ]
 
 [[package]]
@@ -2641,12 +2610,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
@@ -2656,6 +2619,89 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+
+[[package]]
+name = "web-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "winapi"

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro2 = { version = "1.0.39", features = [ "span-locations" ] }
 quote = "1.0.18"
 rayon = "1.5.3"
 regex = "1.5.5"
-rttp_client = { version = "0.1.0", features = ["tls-native"] }
+ureq = { version = "2.4.0", features = ["native-tls"] }
 syn = { version = "1.0.95", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 fork = "0.1.19"

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -178,8 +178,8 @@ pub(crate) fn init_pgx(pgx: &Pgx) -> eyre::Result<()> {
 
 #[tracing::instrument(level = "error", skip_all, fields(pg_version = %pg_config.version()?, pgx_home))]
 fn download_postgres(pg_config: &PgConfig, pgx_home: &PathBuf) -> eyre::Result<PgConfig> {
-    use ureq::{Agent, AgentBuilder, Proxy};
     use env_proxy::for_url_str;
+    use ureq::{Agent, AgentBuilder, Proxy};
 
     println!(
         "{} Postgres v{}.{} from {}",
@@ -190,8 +190,12 @@ fn download_postgres(pg_config: &PgConfig, pgx_home: &PathBuf) -> eyre::Result<P
     );
     let url = pg_config.url().expect("no url for pg_config").as_str();
     tracing::debug!(url = %url, "Fetching");
-    let http_client = if let Some((host, port)) = for_url_str(pg_config.url().expect("no url for pg_config")).host_port() {
-        AgentBuilder::new().proxy(Proxy::new(format!("https://{host}:{port}"))?).build()
+    let http_client = if let Some((host, port)) =
+        for_url_str(pg_config.url().expect("no url for pg_config")).host_port()
+    {
+        AgentBuilder::new()
+            .proxy(Proxy::new(format!("https://{host}:{port}"))?)
+            .build()
     } else {
         Agent::new()
     };

--- a/pgx-examples/bad_ideas/Cargo.toml
+++ b/pgx-examples/bad_ideas/Cargo.toml
@@ -19,7 +19,7 @@ pg_test = []
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
 rand = "0.8.5"
-rttp_client = "0.1.0"
+ureq = "2.4.0"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/bad_ideas/src/lib.rs
+++ b/pgx-examples/bad_ideas/src/lib.rs
@@ -55,7 +55,9 @@ fn http(url: &str) -> String {
         .call()
         .expect("invalid http response");
 
-    response.into_string().expect("invalid string from response")
+    response
+        .into_string()
+        .expect("invalid string from response")
 }
 
 #[pg_extern]

--- a/pgx-examples/bad_ideas/src/lib.rs
+++ b/pgx-examples/bad_ideas/src/lib.rs
@@ -50,13 +50,12 @@ fn write_file(filename: &str, bytes: &[u8]) -> i64 {
 
 #[pg_extern]
 fn http(url: &str) -> String {
-    let response = rttp_client::HttpClient::new()
-        .get()
-        .url(url)
-        .emit()
+    let response = ureq::Agent::new()
+        .get(url)
+        .call()
         .expect("invalid http response");
 
-    response.to_string()
+    response.into_string().expect("invalid string from response")
 }
 
 #[pg_extern]

--- a/pgx-examples/bgworker/Cargo.toml
+++ b/pgx-examples/bgworker/Cargo.toml
@@ -19,7 +19,6 @@ pg_test = []
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
 rand = "0.8.5"
-rttp_client = "0.1.0"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -20,7 +20,6 @@ env_proxy = "0.4.1"
 proc-macro2 = { version = "1.0.39", features = [ "span-locations" ] }
 quote = "1.0.18"
 regex = "1.5.5"
-rttp_client = "0.1.0"
 serde = { version = "1.0.137", features = [ "derive" ] }
 serde_derive = "1.0.137"
 serde-xml-rs = "0.5.1"
@@ -29,6 +28,7 @@ syn = { version = "1.0.95", features = [ "extra-traits", "full", "fold", "parsin
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"] }
 toml = "0.5.9"
 unescape = "0.1.0"
+ureq = "2.4.0"
 url = "2.2.2"
 eyre = "0.6.8"
 tracing = "0.1.34"

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -414,7 +414,7 @@ mod rss {
     use crate::pg_config::PgVersion;
     use eyre::WrapErr;
     use owo_colors::OwoColorize;
-    use ureq::{AgentBuilder, Proxy};
+    use ureq::{Agent, AgentBuilder, Proxy};
     use serde_derive::Deserialize;
     use url::Url;
     use env_proxy::for_url_str;
@@ -425,9 +425,10 @@ mod rss {
         pub(super) fn new(supported_major_versions: &[u16]) -> eyre::Result<Vec<PgVersion>> {
             static VERSIONS_RSS_URL: &str = "https://www.postgresql.org/versions.rss";
 
-            let http_client = {
-                let (host, port) = for_url_str(VERSIONS_RSS_URL).host_port().unwrap();
+            let http_client = if let Some((host, port)) = for_url_str(pg_config.url().expect("no url for pg_config")).host_port() {
                 AgentBuilder::new().proxy(Proxy::new(format!("https://{host}:{port}"))?).build()
+            } else {
+                Agent::new()
             };
 
             let response = http_client

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -414,7 +414,7 @@ mod rss {
     use crate::pg_config::PgVersion;
     use eyre::WrapErr;
     use owo_colors::OwoColorize;
-    use ureq::{Agent, AgentBuilder, Proxy};
+    use ureq::{AgentBuilder, Proxy};
     use serde_derive::Deserialize;
     use url::Url;
     use env_proxy::for_url_str;
@@ -425,7 +425,7 @@ mod rss {
         pub(super) fn new(supported_major_versions: &[u16]) -> eyre::Result<Vec<PgVersion>> {
             static VERSIONS_RSS_URL: &str = "https://www.postgresql.org/versions.rss";
 
-            let http_client = if let Some((host, port)) = for_url_str(pg_config.url().expect("no url for pg_config")).host_port() {
+            let http_client = if let Some((host, port)) = for_url_str(VERSIONS_RSS_URL).host_port() {
                 AgentBuilder::new().proxy(Proxy::new(format!("https://{host}:{port}"))?).build()
             } else {
                 Agent::new()

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -414,7 +414,7 @@ mod rss {
     use crate::pg_config::PgVersion;
     use eyre::WrapErr;
     use owo_colors::OwoColorize;
-    use ureq::{AgentBuilder, Proxy};
+    use ureq::{Agent, AgentBuilder, Proxy};
     use serde_derive::Deserialize;
     use url::Url;
     use env_proxy::for_url_str;

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -414,9 +414,7 @@ mod rss {
     use crate::pg_config::PgVersion;
     use eyre::WrapErr;
     use owo_colors::OwoColorize;
-    use ureq::Agent as HttpClient;
-    use ureq;
-    use ureq::Proxy;
+    use ureq::{AgentBuilder, Proxy};
     use serde_derive::Deserialize;
     use url::Url;
     use env_proxy::for_url_str;
@@ -429,7 +427,7 @@ mod rss {
 
             let http_client = {
                 let (host, port) = for_url_str(VERSIONS_RSS_URL).host_port().unwrap();
-                ureq::AgentBuilder::new().proxy(Proxy::new(format!("https://{host}:{port}"))?).build()
+                AgentBuilder::new().proxy(Proxy::new(format!("https://{host}:{port}"))?).build()
             };
 
             let response = http_client


### PR DESCRIPTION
This replaces the rttp_client crate in the dependency tree with ureq. Unfortunately rttp_client is unmaintained. Aside from any possible security issues (and it does use a security sensitive dependency: rand), the main problem with heavily legacy code is it asks for heavily legacy dependencies, which causes duplicate dependency versions, which is bloat and also makes it harder and more annoying to override them.