### PR TITLE
Refactor version defaulting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,12 +300,16 @@ dependencies = [
  "rayon",
  "regex",
  "semver 1.0.9",
+ "serde",
+ "serde-xml-rs",
+ "serde_derive",
  "syn",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
  "unescape",
  "ureq",
+ "url",
 ]
 
 [[package]]
@@ -1491,7 +1495,6 @@ dependencies = [
  "quote",
  "regex",
  "serde",
- "serde-xml-rs",
  "serde_derive",
  "serde_json",
  "syn",
@@ -1501,7 +1504,6 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "unescape",
- "ureq",
  "url",
 ]
 

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -30,6 +30,10 @@ quote = "1.0.18"
 rayon = "1.5.3"
 regex = "1.5.5"
 ureq = { version = "2.4.0", features = ["native-tls"] }
+url = "2.2.2"
+serde = { version = "1.0.137", features = [ "derive" ] }
+serde_derive = "1.0.137"
+serde-xml-rs = "0.5.1"
 syn = { version = "1.0.95", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 fork = "0.1.19"

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -8,8 +8,8 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::command::stop::stop_postgres;
-use crate::CommandExecute;
 use crate::command::version::pgx_default;
+use crate::CommandExecute;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use pgx_utils::{

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -9,6 +9,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::command::stop::stop_postgres;
 use crate::CommandExecute;
+use crate::command::version::pgx_default;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use pgx_utils::{
@@ -86,7 +87,7 @@ impl CommandExecute for Init {
 
         if versions.is_empty() {
             // no arguments specified, so we'll just install our defaults
-            init_pgx(&Pgx::default(SUPPORTED_MAJOR_VERSIONS)?)
+            init_pgx(&pgx_default(SUPPORTED_MAJOR_VERSIONS)?)
         } else {
             // user specified arguments, so we'll only install those versions of Postgres
             let mut default_pgx = None;
@@ -95,7 +96,7 @@ impl CommandExecute for Init {
             for (pgver, pg_config_path) in versions {
                 let config = if pg_config_path == "download" {
                     if default_pgx.is_none() {
-                        default_pgx = Some(Pgx::default(SUPPORTED_MAJOR_VERSIONS)?);
+                        default_pgx = Some(pgx_default(SUPPORTED_MAJOR_VERSIONS)?);
                     }
                     default_pgx
                         .as_ref()

--- a/cargo-pgx/src/command/mod.rs
+++ b/cargo-pgx/src/command/mod.rs
@@ -20,3 +20,4 @@ pub(crate) mod start;
 pub(crate) mod status;
 pub(crate) mod stop;
 pub(crate) mod test;
+pub(crate) mod version;

--- a/cargo-pgx/src/command/version.rs
+++ b/cargo-pgx/src/command/version.rs
@@ -1,19 +1,19 @@
-use pgx_utils::pg_config::{Pgx, PgConfig};
+use pgx_utils::pg_config::{PgConfig, Pgx};
 
 pub(crate) fn pgx_default(supported_major_versions: &[u16]) -> eyre::Result<Pgx> {
     let mut pgx = Pgx::new();
     rss::PostgreSQLVersionRss::new(supported_major_versions)?
-            .into_iter()
-            .for_each(|version| pgx.push(PgConfig::from(version)));
+        .into_iter()
+        .for_each(|version| pgx.push(PgConfig::from(version)));
 
     Ok(pgx)
 }
 
 mod rss {
-    use pgx_utils::pg_config::PgVersion;
     use env_proxy::for_url_str;
     use eyre::WrapErr;
     use owo_colors::OwoColorize;
+    use pgx_utils::pg_config::PgVersion;
     use serde_derive::Deserialize;
     use ureq::{Agent, AgentBuilder, Proxy};
     use url::Url;

--- a/cargo-pgx/src/command/version.rs
+++ b/cargo-pgx/src/command/version.rs
@@ -1,0 +1,99 @@
+use pgx_utils::pg_config::{Pgx, PgConfig};
+
+pub(crate) fn pgx_default(supported_major_versions: &[u16]) -> eyre::Result<Pgx> {
+    let mut pgx = Pgx::new();
+    rss::PostgreSQLVersionRss::new(supported_major_versions)?
+            .into_iter()
+            .for_each(|version| pgx.push(PgConfig::from(version)));
+
+    Ok(pgx)
+}
+
+mod rss {
+    use pgx_utils::pg_config::PgVersion;
+    use env_proxy::for_url_str;
+    use eyre::WrapErr;
+    use owo_colors::OwoColorize;
+    use serde_derive::Deserialize;
+    use ureq::{Agent, AgentBuilder, Proxy};
+    use url::Url;
+
+    pub(super) struct PostgreSQLVersionRss;
+
+    impl PostgreSQLVersionRss {
+        pub(super) fn new(supported_major_versions: &[u16]) -> eyre::Result<Vec<PgVersion>> {
+            static VERSIONS_RSS_URL: &str = "https://www.postgresql.org/versions.rss";
+
+            let http_client = if let Some((host, port)) = for_url_str(VERSIONS_RSS_URL).host_port()
+            {
+                AgentBuilder::new()
+                    .proxy(Proxy::new(format!("https://{host}:{port}"))?)
+                    .build()
+            } else {
+                Agent::new()
+            };
+
+            let response = http_client
+                .get(VERSIONS_RSS_URL)
+                .call()
+                .wrap_err_with(|| format!("unable to retrieve {}", VERSIONS_RSS_URL))?;
+
+            let rss: Rss = match serde_xml_rs::from_str(&response.into_string()?) {
+                Ok(rss) => rss,
+                Err(e) => return Err(e.into()),
+            };
+
+            let mut versions = Vec::new();
+            for item in rss.channel.item {
+                let title = item.title.trim();
+                let mut parts = title.split('.');
+                let major = parts.next();
+                let minor = parts.next();
+
+                // if we don't have major/minor versions or if they don't parse correctly
+                // we'll just assume zero for them and eventually skip them
+                let major = major.unwrap().parse::<u16>().unwrap_or_default();
+                let minor = minor.unwrap().parse::<u16>().unwrap_or_default();
+
+                if supported_major_versions.contains(&major) {
+                    versions.push(PgVersion::new(
+                        major,
+                        minor,
+                        Url::parse(
+                            &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2",
+                                     major = major, minor = minor)
+                        )
+                            .expect("invalid url")
+                    ))
+                }
+            }
+
+            println!(
+                "{} Postgres {}",
+                "  Discovered".white().bold(),
+                versions
+                    .iter()
+                    .map(|ver| format!("v{ver}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+
+            Ok(versions)
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct Rss {
+        channel: Channel,
+    }
+
+    #[derive(Deserialize)]
+    struct Channel {
+        item: Vec<Item>,
+    }
+
+    #[derive(Deserialize)]
+    struct Item {
+        title: String,
+    }
+}

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -22,13 +22,11 @@ quote = "1.0.18"
 regex = "1.5.5"
 serde = { version = "1.0.137", features = [ "derive" ] }
 serde_derive = "1.0.137"
-serde-xml-rs = "0.5.1"
 serde_json = "1.0.81"
 syn = { version = "1.0.95", features = [ "extra-traits", "full", "fold", "parsing" ] }
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"] }
 toml = "0.5.9"
 unescape = "0.1.0"
-ureq = "2.4.0"
 url = "2.2.2"
 eyre = "0.6.8"
 tracing = "0.1.34"

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -20,14 +20,24 @@ use url::Url;
 
 #[derive(Clone)]
 pub struct PgVersion {
-    major_version: u16,
-    minor_version: u16,
+    major: u16,
+    minor: u16,
     url: Url,
+}
+
+impl PgVersion {
+    pub fn new(major: u16, minor: u16, url: Url) -> PgVersion {
+        PgVersion {
+            major,
+            minor,
+            url
+        }
+    }
 }
 
 impl Display for PgVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}", self.major_version, self.minor_version)
+        write!(f, "{}.{}", self.major, self.minor)
     }
 }
 
@@ -92,7 +102,7 @@ impl PgConfig {
 
     pub fn major_version(&self) -> eyre::Result<u16> {
         match &self.version {
-            Some(version) => Ok(version.major_version),
+            Some(version) => Ok(version.major),
             None => {
                 let version_string = self.run("--version")?;
                 let version_parts = version_string.split_whitespace().collect::<Vec<&str>>();
@@ -115,7 +125,7 @@ impl PgConfig {
 
     pub fn minor_version(&self) -> eyre::Result<u16> {
         match &self.version {
-            Some(version) => Ok(version.minor_version),
+            Some(version) => Ok(version.minor),
             None => {
                 let version_string = self.run("--version")?;
                 let version_parts = version_string.split_whitespace().collect::<Vec<&str>>();
@@ -458,8 +468,8 @@ mod rss {
 
                 if supported_major_versions.contains(&major) {
                     versions.push(PgVersion {
-                        major_version: major,
-                        minor_version: minor,
+                        major,
+                        minor,
                         url: Url::parse(
                             &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2",
                                      major = major, minor = minor)
@@ -474,7 +484,7 @@ mod rss {
                 "  Discovered".white().bold(),
                 versions
                     .iter()
-                    .map(|v| format!("v{}.{}", v.major_version, v.minor_version))
+                    .map(|ver| format!("v{ver}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             );

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -73,7 +73,10 @@ impl Default for PgConfig {
 
 impl From<PgVersion> for PgConfig {
     fn from(version: PgVersion) -> Self {
-        PgConfig { version: Some(version), pg_config: None, }
+        PgConfig {
+            version: Some(version),
+            pg_config: None,
+        }
     }
 }
 

--- a/pgx-utils/src/pg_config.rs
+++ b/pgx-utils/src/pg_config.rs
@@ -7,8 +7,11 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 //! Wrapper around Postgres' `pg_config` command-line tool
+use crate::{BASE_POSTGRES_PORT_NO, BASE_POSTGRES_TESTING_PORT_NO};
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
+use serde_derive::{Deserialize, Serialize};
+use std::fmt::{self, Display, Formatter};
 use std::{
     collections::HashMap,
     io::ErrorKind,
@@ -27,16 +30,12 @@ pub struct PgVersion {
 
 impl PgVersion {
     pub fn new(major: u16, minor: u16, url: Url) -> PgVersion {
-        PgVersion {
-            major,
-            minor,
-            url
-        }
+        PgVersion { major, minor, url }
     }
 }
 
 impl Display for PgVersion {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}", self.major, self.minor)
     }
 }
@@ -48,7 +47,7 @@ pub struct PgConfig {
 }
 
 impl Display for PgConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let major = self
             .major_version()
             .expect("could not determine major version");
@@ -258,10 +257,6 @@ impl PgConfig {
 pub struct Pgx {
     pg_configs: Vec<PgConfig>,
 }
-
-use crate::{BASE_POSTGRES_PORT_NO, BASE_POSTGRES_TESTING_PORT_NO};
-use serde_derive::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ConfigToml {


### PR DESCRIPTION
This boots the code for selecting versions from pgx-utils to cargo-pgx so as to make it easier to use pgx-utils without having to think or be aware of networks existing, making pgx-utils closer to a "pure" macro crate.