### PR TITLE
Refactor Nix sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 cmake*/
 .direnv
 pgx-examples/*/target
+result

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,24 +1,22 @@
-{ buildRustPackage
+{ gitignoreSource
 , lib
 , pkg-config
 , openssl
-, rustToolchain
 , libiconv
 , llvmPackages
-, gitignoreSource
+, rustPlatform
 , release ? true
 }:
 
 let
   cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
-in buildRustPackage {
+in rustPlatform.buildRustPackage {
   inherit release;
   inherit (cargoToml.package) name version;
   cargoSha256 = "sha256-bxzBYrQGA3PmwGh5B2qUaOM9oif9hwk2OR5ZcfDkltY=";
   src = gitignoreSource ../.;
 
   nativeBuildInputs = [
-    rustToolchain
     pkg-config
   ];
   buildInputs = [

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,5 +1,5 @@
-{ lib
-, naersk
+{ buildRustPackage
+, lib
 , hostPlatform
 , fetchFromGitHub
 , postgresql_10
@@ -8,29 +8,24 @@
 , postgresql_13
 , pkg-config
 , openssl
+, rustToolchain
 , rustfmt
 , libiconv
 , llvmPackages
 , gitignoreSource
 , release ? true
-,
 }:
 
 let
   cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
-in
-
-naersk.lib."${hostPlatform.system}".buildPackage rec {
-  name = cargoToml.package.name;
-  version = cargoToml.package.version;
-
-  src = gitignoreSource ../.;
+in buildRustPackage {
   inherit release;
-
-  cargoBuildOptions = final: final ++ [ "--package" "cargo-pgx" ];
-  cargoTestOptions = final: final ++ [ "--package" "cargo-pgx" ];
+  inherit (cargoToml.package) name version;
+  cargoSha256 = "sha256-bxzBYrQGA3PmwGh5B2qUaOM9oif9hwk2OR5ZcfDkltY=";
+  src = gitignoreSource ../.;
 
   nativeBuildInputs = [
+    rustToolchain
     pkg-config
   ];
   buildInputs = [

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,10 +1,12 @@
 { gitignoreSource
+, stdenv
 , lib
 , pkg-config
 , openssl
 , libiconv
 , llvmPackages
 , rustPlatform
+, darwin
 , release ? true
 }:
 
@@ -15,6 +17,10 @@ in rustPlatform.buildRustPackage {
   inherit (cargoToml.package) name version;
   cargoSha256 = "sha256-bxzBYrQGA3PmwGh5B2qUaOM9oif9hwk2OR5ZcfDkltY=";
   src = gitignoreSource ../.;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  cargoBuildFlags = ["--package" "cargo-pgx"];
+  cargoTestFlags = ["--package" "cargo-pgx"];
 
   nativeBuildInputs = [
     pkg-config
@@ -22,7 +28,7 @@ in rustPlatform.buildRustPackage {
   buildInputs = [
     openssl
     libiconv
-  ];
+  ] ++ (lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ]);
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,15 +1,8 @@
 { buildRustPackage
 , lib
-, hostPlatform
-, fetchFromGitHub
-, postgresql_10
-, postgresql_11
-, postgresql_12
-, postgresql_13
 , pkg-config
 , openssl
 , rustToolchain
-, rustfmt
 , libiconv
 , llvmPackages
 , gitignoreSource

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1635165013,
-        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
+        "lastModified": 1657706534,
+        "narHash": "sha256-5jIzNHKtDu06mA325K/5CshUVb5r7sSmnRiula6Gr7o=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "rev": "f840a659d57e53fa751a9248b17149fd0cf2a221",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641224400,
-        "narHash": "sha256-unXptp6PtSHSFVSAz+v6ZLtFDgaZZUCSjV0ie5A0qIw=",
+        "lastModified": 1657888067,
+        "narHash": "sha256-GnwJoFBTPfW3+mz7QEeJEEQ9OMHZOiIJ/qDhZxrlKh8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adf7f03d3bfceaba64788e1e846191025283b60d",
+        "rev": "65fae659e31098ca4ac825a6fef26d890aaf3f4e",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1641177598,
-        "narHash": "sha256-ixQ72QmhIfb7bAzvLUn6GtjpoMA/N3V1PBwjZQQyc1k=",
+        "lastModified": 1657853760,
+        "narHash": "sha256-X6ERAyUXGsrhbhgkxNaQl40wcus5uyQZOCxUh5neK+g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d93e905bc0d36508590b6ec0e2e6e92d2cf8289a",
+        "rev": "a97a761cc11327bb109dc30af1c637b986be7959",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,26 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655042882,
+        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1657888067,
@@ -68,6 +88,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
+        "naersk": "naersk",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,6 +2,21 @@
   "nodes": {
     "flake-utils": {
       "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
         "lastModified": 1637014545,
         "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
@@ -35,26 +50,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1641224400,
@@ -71,15 +66,15 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,12 @@
 
       # Inheritance helpers
       inherit (gitignore.lib) gitignoreSource;
+
+      # Not yet in use
+      releaseAndDebug = attr: call: args: {
+        "${attr}" = call args;
+        "${attr}_debug" = call (args // { release = false; });
+      };
     in flake-utils.lib.eachDefaultSystem (system:
       {
         packages = let

--- a/flake.nix
+++ b/flake.nix
@@ -15,36 +15,31 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, rust-overlay, gitignore, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        inherit (pkgs) callPackage;
-        inherit (pkgs.rustPlatform) buildRustPackage;
-        inherit (gitignore.lib) gitignoreSource;
-
+    let
+      # Helper function for producing a package-specific nixpkgs
+      nixpkgsWithOverlays = { nixpkgs, system, extraOverlays ? [ ] }: (import nixpkgs {
+        inherit system;
         overlays = [
+          self.overlays.default
           (import rust-overlay)
-        ];
+          (self: super: { inherit (self.rust-bin.stable.latest) rustc cargo rustdoc rust-std; })
+        ] ++ extraOverlays;
+      });
 
-        pkgs = import nixpkgs { inherit overlays system; };
-        
-        rustToolchain = pkgs.rust-bin.stable.latest.default;
-
-        cargo-pgx = callPackage ./cargo-pgx {
-          inherit buildRustPackage gitignoreSource rustToolchain;
-        };
-
-        cargo-pgx_debug = callPackage ./cargo-pgx {
-          release = false;
-          inherit buildRustPackage gitignoreSource rustToolchain;
-        };
-      in {
-        packages = {
+      # Inheritance helpers
+      inherit (gitignore.lib) gitignoreSource;
+    in flake-utils.lib.eachDefaultSystem (system:
+      {
+        packages = let
+          pkgs = nixpkgsWithOverlays { inherit nixpkgs system; };
+        in rec {
           default = cargo-pgx;
-
-          inherit cargo-pgx cargo-pgx_debug;
+          inherit (pkgs) cargo-pgx;
         };
 
-        devShells.default = pkgs.mkShell {
+        devShells.default = let
+          pkgs = nixpkgsWithOverlays { inherit nixpkgs system; };
+        in pkgs.mkShell {
           inputsFrom = with pkgs; [
             postgresql_10
             postgresql_11
@@ -52,17 +47,18 @@
             postgresql_13
             postgresql_14
           ];
-          buildInputs = with pkgs; [
+           buildInputs = with pkgs; [
             rustfmt
             nixpkgs-fmt
             cargo-pgx
-            rust-bin.stable.latest.minimal
-            rust-bin.stable.latest.rustfmt
-            rust-bin.stable.latest.clippy
             postgresql
             libiconv
             pkg-config
-          ];
+          ] ++ (with pkgs.rust-bin.stable.latest; [
+            clippy
+            minimal
+            rustfmt
+          ]);
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
           PGX_PG_SYS_SKIP_BINDING_REWRITE = "1";
           BINDGEN_EXTRA_CLANG_ARGS = [
@@ -72,19 +68,31 @@
           ] else [ ]);
         };
 
-        checks = {
+        checks = let
+          pkgs = nixpkgsWithOverlays { inherit system nixpkgs; };
+        in {
           format = pkgs.runCommand "check-format"
             {
-              buildInputs = with pkgs; [ cargo rustfmt ];
+              buildInputs = with pkgs; [ rustfmt cargo ];
             } ''
             ${pkgs.rustfmt}/bin/cargo-fmt fmt --manifest-path ${./.}/Cargo.toml -- --check
             ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${./.}
             touch $out # it worked!
           '';
-          pkgs-cargo-pgx = cargo-pgx_debug.out;
+          pkgs-cargo-pgx = pkgs.cargo-pgx_debug.out;
         };
       }
     ) // {
+      overlays.default = final: prev: {
+        cargo-pgx = final.callPackage ./cargo-pgx {
+          inherit gitignoreSource;
+        };
+        cargo-pgx_debug = final.callPackage ./cargo-pgx {
+          inherit gitignoreSource;
+          release = false;
+        };
+      };
+
       templates = {
         default = {
           path = ./nix/templates/default;

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/hrn6aim61g3ci6795phm3c5dzs3hq7ss-rustc-1.57.0-aarch64-apple-darwin

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/hrn6aim61g3ci6795phm3c5dzs3hq7ss-rustc-1.57.0-aarch64-apple-darwin


### PR DESCRIPTION
This PR refactors the Nix sources in a few ways:

* It removes the `naersk` dependency from the main `cargo-pgx` package build
* It uses Nixpkgs' `buildRustPackage` for the `cargo-pgx` build
* It brings things in line with some flake best practices and silences some errors (e.g. using `package.default` instead of `defaultPackage`)
* It makes the `cargo-pgx` package buildable on macOS via some optional `buildInputs`
* It introduces `flake-utils` helpers for system-specific needs

An important thing to note is that I've left the `lib` output as-is, as I'm not fully sure what the current intentions are for that.