### PR TITLE
Added utils/catcache.h to includes in pg_sys

### DIFF
--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -93,6 +93,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "tsearch/ts_public.h"
 #include "tsearch/ts_utils.h"
 #include "utils/builtins.h"
+#include "utils/catcache.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
 

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -91,6 +91,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "tsearch/ts_public.h"
 #include "tsearch/ts_utils.h"
 #include "utils/builtins.h"
+#include "utils/catcache.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
 

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -91,6 +91,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "tcop/tcopprot.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
+#include "utils/catcache.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
 #include "utils/float.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -91,6 +91,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "tsearch/ts_public.h"
 #include "tsearch/ts_utils.h"
 #include "utils/builtins.h"
+#include "utils/catcache.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
 #include "utils/float.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -91,6 +91,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "tsearch/ts_public.h"
 #include "tsearch/ts_utils.h"
 #include "utils/builtins.h"
+#include "utils/catcache.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
 #include "utils/float.h"


### PR DESCRIPTION
Added catcache.h file to includes to generate mappings for `CatCList` structure which is returned by `SearchSysCacheList`. For more information please refer to https://github.com/tcdi/pgx/issues/608