### PR TITLE
PgRange<T> type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ Postgres Type | Rust Type (as `Option<T>`)
 `numeric` | `pgx::Numeric(String)` -- TODO: needs better support
 `void` | `()`
 `ARRAY[]::<type>` | `Vec<Option<T>>` or `pgx::Array<T>` (zero-copy)
+`int4range` | `PgRange<i32>` (zero-copy)
+`int8range` | `PgRange<i64>` (zero-copy)
+`daterange` | `PgRange<pgx::Date>` (zero-copy)
+`numrange` | `PgRange<pgx::Numeric>` (zero-copy)
+`tsrange` | `PgRange<pgx::Timestamp>` (zero-copy)
+`tstzrange` | `PgRange<pgx::TimestampWithTimeZone>` (zero-copy)
 `NULL` | `Option::None`
 `internal` | `pgx::PgBox<T>` where `T` is any Rust/Postgres struct
 `uuid` | `pgx::Uuid([u8; 16])`

--- a/pgx-pg-sys/include/pg10.h
+++ b/pgx-pg-sys/include/pg10.h
@@ -113,3 +113,4 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/rangetypes.h"

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -111,3 +111,4 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/rangetypes.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -108,3 +108,4 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/rangetypes.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -108,3 +108,4 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/rangetypes.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -108,3 +108,4 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/rangetypes.h"

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -175,6 +175,22 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_accept_date_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_date('infinity'::date) = 'infinity'::date;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_date_neg_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_date('-infinity'::date) = '-infinity'::date;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
     fn test_accept_time_now() {
         let result = Spi::get_one::<bool>("SELECT accept_time(now()::time) = now()::time;")
             .expect("failed to get SPI result");
@@ -226,6 +242,22 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_accept_timestamp_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_timestamp('infinity'::timestamp) = 'infinity'::timestamp;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_timestamp_neg_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_timestamp('-infinity'::timestamp) = '-infinity'::timestamp;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
     fn test_accept_timestamp_with_time_zone() {
         let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone(now()) = now();")
             .expect("failed to get SPI result");
@@ -235,6 +267,20 @@ mod tests {
     #[pg_test]
     fn test_accept_timestamp_with_time_zone_not_utc() {
         let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone('1990-01-23 03:45:00-07') = '1990-01-23 03:45:00-07'::timestamp with time zone;")
+            .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_timestamp_with_time_zone_infinity() {
+        let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone('infinity') = 'infinity'::timestamp with time zone;")
+            .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_timestamp_with_time_zone_neg_infinity() {
+        let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone('-infinity') = '-infinity'::timestamp with time zone;")
             .expect("failed to get SPI result");
         assert!(result)
     }

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -10,6 +10,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 mod aggregate_tests;
 mod anyarray_tests;
 mod array_tests;
+mod range_tests;
 mod bytea_tests;
 mod cfg_tests;
 mod datetime_tests;

--- a/pgx-tests/src/tests/range_tests.rs
+++ b/pgx-tests/src/tests/range_tests.rs
@@ -1,0 +1,717 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+use pgx::*;
+use std::ops::Range;
+
+#[pg_extern]
+fn make_pgrange_i32(lower: Option<i32>, upper: Option<i32>) -> Option<PgRange<i32>> {
+    Some(PgRange::from_values(lower, upper))
+}
+
+// #[pg_extern]
+// #[pg_guard]
+// fn make_range_i32(lower: Option<i32>, upper: Option<i32>) -> Option<Range<i32>> {
+//     match (lower, upper) {
+//         (Some(lower_val), Some(upper_val)) => Some(lower_val..upper_val),
+//         _ => None,
+//     }
+// }
+
+#[pg_extern]
+fn make_pgrange_i64(lower: Option<i64>, upper: Option<i64>) -> Option<PgRange<i64>> {
+    Some(PgRange::from_values(lower, upper))
+}
+
+// #[pg_extern]
+// fn make_range_i64(lower: Option<i64>, upper: Option<i64>) -> Option<Range<i64>> {
+//     match (lower, upper) {
+//         (Some(lower_val), Some(upper_val)) => Some(lower_val..upper_val),
+//         _ => None,
+//     }
+// }
+
+#[pg_extern]
+fn make_pgrange_date(lower: Option<Date>, upper: Option<Date>) -> Option<PgRange<Date>> {
+    Some(PgRange::from_values(lower, upper))
+}
+
+// #[pg_extern]
+// fn make_range_date(lower: Option<Date>, upper: Option<Date>) -> Option<Range<Date>> {
+//     match (lower, upper) {
+//         (Some(lower_val), Some(upper_val)) => Some(lower_val..upper_val),
+//         _ => None,
+//     }
+// }
+
+#[pg_extern]
+fn make_pgrange_ts(
+    lower: Option<Timestamp>,
+    upper: Option<Timestamp>,
+) -> Option<PgRange<Timestamp>> {
+    Some(PgRange::from_values(lower, upper))
+}
+
+#[pg_extern]
+fn make_pgrange_tstz(
+    lower: Option<TimestampWithTimeZone>,
+    upper: Option<TimestampWithTimeZone>,
+) -> Option<PgRange<TimestampWithTimeZone>> {
+    Some(PgRange::from_values(lower, upper))
+}
+
+#[pg_extern]
+fn make_pgrange_num(lower: Option<Numeric>, upper: Option<Numeric>) -> Option<PgRange<Numeric>> {
+    Some(PgRange::from_values(lower, upper))
+}
+
+#[pg_extern(name = "describe_pgrange")]
+fn describe_pgrange_i32(range: PgRange<i32>) -> String {
+    pgrange_to_string(&range)
+}
+
+#[pg_extern(name = "describe_pgrange")]
+fn describe_pgrange_i64(range: PgRange<i64>) -> String {
+    pgrange_to_string(&range)
+}
+
+#[pg_extern(name = "describe_pgrange")]
+fn describe_pgrange_date(range: PgRange<Date>) -> String {
+    pgrange_to_string(&range)
+}
+
+#[pg_extern(name = "describe_pgrange")]
+fn describe_pgrange_ts(range: PgRange<Timestamp>) -> String {
+    pgrange_to_string(&range)
+}
+
+#[pg_extern(name = "describe_pgrange")]
+fn describe_pgrange_tsz(range: PgRange<TimestampWithTimeZone>) -> String {
+    pgrange_to_string(&range)
+}
+
+#[pg_extern(name = "describe_pgrange")]
+fn describe_pgrange_numeric(range: PgRange<pgx::Numeric>) -> String {
+    pgrange_to_string(&range)
+}
+
+// #[pg_extern(name = "describe_range")]
+// fn describe_range_i32(range: Option<Range<i32>>) -> String {
+//     match range {
+//         Some(r) => range_to_string(&r),
+//         None => "null".into(),
+//     }
+// }
+
+// #[pg_extern(name = "describe_range")]
+// fn describe_range_i64(range: Option<Range<i64>>) -> String {
+//     match range {
+//         Some(r) => range_to_string(&r),
+//         None => "null".into(),
+//     }
+// }
+
+// #[pg_extern(name = "describe_range")]
+// fn describe_range_date(range: Option<Range<Date>>) -> String {
+//     match range {
+//         Some(r) => range_to_string(&r),
+//         None => "null".into(),
+//     }
+// }
+
+fn pgrange_to_string<T: FromDatum + IntoDatum + std::fmt::Display + RangeSubType>(
+    range: &PgRange<T>,
+) -> String {
+    if range.is_empty {
+        return "empty".into();
+    }
+    let lower_val = if range.lower.infinite {
+        "-infinity".into()
+    } else {
+        format!("{}", range.lower_val().unwrap())
+    };
+    let upper_val = if range.upper.infinite {
+        "infinity".into()
+    } else {
+        format!("{}", range.upper_val().unwrap())
+    };
+    format!(
+        "{} {} {} {}",
+        if range.lower.inclusive { "li" } else { "le" },
+        lower_val,
+        if range.upper.inclusive { "ui" } else { "ue" },
+        upper_val
+    )
+}
+
+fn range_to_string<T: std::fmt::Display>(range: &Range<T>) -> String {
+    format!("li {} ue {}", range.start, range.end)
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+
+    use pgx::*;
+
+    // i32
+
+    #[pg_test]
+    fn pgtest_i32_pgrange_half_open() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int4range'[1,10)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "li 1 ue 10");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_pgrange_half_closed() {
+        // know that (1,10] will be transformed to canonical form [2, 11)
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int4range'(1,10]')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "li 2 ue 11");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int4range'(,)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "le -infinity ue infinity");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_pgrange_empty() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int4range'(1,1]')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_make_pgrange_half_open() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i32(1,10)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "[1,10)");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_make_pgrange_val_inf() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i32(1,NULL::int)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "[1,)");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_make_pgrange_inf_val() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i32(NULL::int, 10)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "(,10)");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_make_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i32(NULL::int, NULL::int)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "(,)");
+    }
+
+    #[pg_test]
+    fn pgtest_i32_make_pgrange_empty() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i32(1,1)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    // #[pg_test]
+    // fn pgtest_i32_range_half_open() {
+    //     let desc = Spi::get_one::<String>("SELECT describe_range(int4range'[1,10)')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "li 1 ue 10");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_range_half_closed() {
+    //     // know that (1,10] will be transformed to canonical form [2, 11)
+    //     let desc = Spi::get_one::<String>("SELECT describe_range(int4range'(1,10]')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "li 2 ue 11");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_range_inf_inf() {
+    //     let desc = Spi::get_one::<String>("SELECT describe_range(int4range'(,)')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "le -infinity ue infinity");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_range_empty() {
+    //     let desc = Spi::get_one::<String>("SELECT describe_range(int4range'(1,1]')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "null");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_make_range_half_open() {
+    //     let desc = Spi::get_one::<String>("SELECT COALESCE(make_range_i32(1,10)::text, 'null')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "[1,10)");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_make_range_val_inf() {
+    //     let desc = Spi::get_one::<String>("SELECT COALESCE(make_range_i32(1,NULL::int)::text, 'null')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "[1,)");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_make_range_inf_val() {
+    //     let desc = Spi::get_one::<String>("SELECT COALESCE(make_range_i32(NULL::int, 10)::text, 'null')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "(,10)");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_make_range_inf_inf() {
+    //     let desc = Spi::get_one::<String>("SELECT COALESCE(make_range_i32(NULL::int, NULL::int)::text, 'null')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "(,)");
+    // }
+
+    // #[pg_test]
+    // fn pgtest_i32_make_range_empty() {
+    //     let desc = Spi::get_one::<String>("SELECT COALESCE(make_range_i32(1,1)::text, 'null')")
+    //         .expect("failed to get SPI result");
+    //     assert_eq!(desc, "null");
+    // }
+
+    // i64
+
+    #[pg_test]
+    fn pgtest_i64_pgrange_half_open() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int8range'[1,10)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "li 1 ue 10");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_pgrange_half_closed() {
+        // know that (1,10] will be transformed to canonical form [2, 11)
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int8range'(1,10]')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "li 2 ue 11");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int8range'(,)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "le -infinity ue infinity");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_pgrange_empty() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(int8range'(1,1]')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_make_pgrange_half_open() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i64(1,10)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "[1,10)");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_make_pgrange_val_inf() {
+        // know that (1,10] will be transformed to canonical form [2, 11)
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i64(1,NULL::int8)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "[1,)");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_make_pgrange_inf_val() {
+        // know that (1,10] will be transformed to canonical form [2, 11)
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i64(NULL::int8,10)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "(,10)");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_make_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i64(NULL::int8,NULL::int8)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "(,)");
+    }
+
+    #[pg_test]
+    fn pgtest_i64_make_pgrange_empty() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_i64(1,1)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    // date
+
+    #[pg_test]
+    fn pgtest_date_pgrange_half_open() {
+        let desc =
+            Spi::get_one::<String>("SELECT describe_pgrange(daterange'[2000-01-01,2022-01-01)')")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "li 2000-01-01 ue 2022-01-01");
+    }
+
+    #[pg_test]
+    fn pgtest_date_pgrange_half_closed() {
+        // know that (2000-01-01,2022-01-01] will be transformed to canonical form [2000-01-02,2022-01-02)
+        let desc =
+            Spi::get_one::<String>("SELECT describe_pgrange(daterange'(2000-01-01,2022-01-01]')")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "li 2000-01-02 ue 2022-01-02");
+    }
+
+    #[pg_test]
+    fn pgtest_date_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(daterange'(,)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "le -infinity ue infinity");
+    }
+
+    #[pg_test]
+    fn pgtest_date_pgrange_empty() {
+        let desc =
+            Spi::get_one::<String>("SELECT describe_pgrange(daterange'(2000-01-01,2000-01-01]')")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    #[pg_test]
+    fn pgtest_date_make_pgrange_half_open() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_date(date'2000-01-01',date'2022-01-01')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[2000-01-01,2022-01-01)");
+    }
+
+    #[pg_test]
+    fn pgtest_date_make_pgrange_val_inf() {
+        let desc =
+            Spi::get_one::<String>("SELECT make_pgrange_date(date'2000-01-01',NULL::date)::text")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "[2000-01-01,)");
+    }
+
+    #[pg_test]
+    fn pgtest_date_make_pgrange_val_infinity() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_date(date'2000-01-01',date'infinity')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[2000-01-01,infinity)");
+    }
+
+    #[pg_test]
+    fn pgtest_date_make_pgrange_neg_infinity_val() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_date(date'-infinity',date'2022-01-01')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[-infinity,2022-01-01)");
+    }
+
+    #[pg_test]
+    fn pgtest_date_make_pgrange_inf_val() {
+        let desc =
+            Spi::get_one::<String>("SELECT make_pgrange_date(NULL::date,date'2022-01-01')::text")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "(,2022-01-01)");
+    }
+
+    #[pg_test]
+    fn pgtest_date_make_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_date(NULL::date,NULL::date)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "(,)");
+    }
+
+    #[pg_test]
+    fn pgtest_date_make_pgrange_empty() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_date(date'2000-01-01',date'2000-01-01')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    // timestamp
+
+    #[pg_test]
+    fn pgtest_ts_pgrange_half_open() {
+        let desc = Spi::get_one::<String>(
+            "SELECT describe_pgrange(tsrange'[2000-01-01 00:00:00-00,2022-01-01 00:00:00-00)')",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "li 2000-01-01T00:00:00-00 ue 2022-01-01T00:00:00-00");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_pgrange_half_closed() {
+        let desc = Spi::get_one::<String>(
+            "SELECT describe_pgrange(tsrange'(2000-01-01 00:00:00-00,2022-01-01 00:00:00-00]')",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "le 2000-01-01T00:00:00-00 ui 2022-01-01T00:00:00-00");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(tsrange'(,)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "le -infinity ue infinity");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_pgrange_empty() {
+        let desc = Spi::get_one::<String>(
+            "SELECT describe_pgrange(tsrange'(2000-01-01 00:00:00-00,2000-01-01 00:00:00-00]')",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_make_pgrange_half_open() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_ts(timestamp'2000-01-01 00:00:00',timestamp'2022-01-01 00:00:00')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[\"2000-01-01 00:00:00\",\"2022-01-01 00:00:00\")");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_make_pgrange_val_inf() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_ts(timestamp'2000-01-01 00:00:00',NULL::timestamp)::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[\"2000-01-01 00:00:00\",)");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_make_pgrange_val_infinity() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_ts(timestamp'2000-01-01 00:00:00',timestamp'infinity')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[\"2000-01-01 00:00:00\",infinity)");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_make_pgrange_neg_infinity_val() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_ts(timestamp'-infinity',timestamp'2022-01-01 00:00:00')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[-infinity,\"2022-01-01 00:00:00\")");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_make_pgrange_inf_val() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_ts(NULL::timestamp,timestamp'2022-01-01 00:00:00')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "(,\"2022-01-01 00:00:00\")");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_make_pgrange_inf_inf() {
+        let desc =
+            Spi::get_one::<String>("SELECT make_pgrange_ts(NULL::timestamp,NULL::timestamp)::text")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "(,)");
+    }
+
+    #[pg_test]
+    fn pgtest_ts_make_pgrange_empty() {
+        let desc = Spi::get_one::<String>(
+            "SELECT make_pgrange_ts(timestamp'2000-01-01 00:00:00',timestamp'2000-01-01 00:00:00')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    // timestamp with time zone
+
+    #[pg_test]
+    fn pgtest_tstz_pgrange_half_open() {
+        let desc = Spi::get_one::<String>(
+            "SELECT describe_pgrange(tstzrange'[2000-01-01 00:00:00-00,2022-01-01 00:00:00-00)')",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "li 2000-01-01T00:00:00-00 ue 2022-01-01T00:00:00-00");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_pgrange_half_closed() {
+        let desc = Spi::get_one::<String>(
+            "SELECT describe_pgrange(tstzrange'(2000-01-01 00:00:00-00,2022-01-01 00:00:00-00]')",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "le 2000-01-01T00:00:00-00 ui 2022-01-01T00:00:00-00");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(tstzrange'(,)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "le -infinity ue infinity");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_pgrange_empty() {
+        let desc = Spi::get_one::<String>(
+            "SELECT describe_pgrange(tstzrange'(2000-01-01 00:00:00-00,2000-01-01 00:00:00-00]')",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_make_pgrange_half_open() {
+        let desc = Spi::get_one::<String>(
+            "SET LOCAL TIME ZONE 'UTC';SELECT make_pgrange_tstz(timestamp'2000-01-01 00:00:00' at time zone 'UTC',timestamp'2022-01-01 00:00:00' at time zone 'UTC')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(
+            desc,
+            "[\"2000-01-01 00:00:00+00\",\"2022-01-01 00:00:00+00\")"
+        );
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_make_pgrange_val_inf() {
+        let desc =
+            Spi::get_one::<String>("SET LOCAL TIME ZONE 'UTC';SELECT make_pgrange_tstz(timestamp'2000-01-01 00:00:00' at time zone 'UTC',NULL::timestamp)::text")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "[\"2000-01-01 00:00:00+00\",)");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_make_pgrange_val_infinity() {
+        let desc = Spi::get_one::<String>(
+            "SET LOCAL TIME ZONE 'UTC';SELECT make_pgrange_tstz(timestamp'2000-01-01 00:00:00' at time zone 'UTC',timestamp'infinity')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[\"2000-01-01 00:00:00+00\",infinity)");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_make_pgrange_neg_infinity_val() {
+        let desc = Spi::get_one::<String>(
+            "SET LOCAL TIME ZONE 'UTC';SELECT make_pgrange_tstz(timestamp'-infinity',timestamp'2022-01-01 00:00:00' at time zone 'UTC')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "[-infinity,\"2022-01-01 00:00:00+00\")");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_make_pgrange_inf_val() {
+        let desc =
+            Spi::get_one::<String>("SET LOCAL TIME ZONE 'UTC';SELECT make_pgrange_tstz(NULL::timestamp,timestamp'2022-01-01 00:00:00' at time zone 'UTC')::text")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "(,\"2022-01-01 00:00:00+00\")");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_make_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SET LOCAL TIME ZONE 'UTC';SELECT make_pgrange_tstz(NULL::timestamp,NULL::timestamp)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "(,)");
+    }
+
+    #[pg_test]
+    fn pgtest_tstz_make_pgrange_empty() {
+        let desc = Spi::get_one::<String>(
+            "SET LOCAL TIME ZONE 'UTC'; SELECT make_pgrange_tstz(timestamp'2000-01-01 00:00:00' at time zone 'UTC',timestamp'2000-01-01 00:00:00' at time zone 'UTC')::text",
+        )
+        .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    // numeric
+
+    #[pg_test]
+    fn pgtest_num_pgrange_half_open() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(numrange'[0.0,1.0)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "li 0.0 ue 1.0");
+    }
+
+    #[pg_test]
+    fn pgtest_num_pgrange_half_closed() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(numrange'(0.0,1.0]')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "le 0.0 ui 1.0");
+    }
+
+    #[pg_test]
+    fn pgtest_num_pgrange_inf_inf() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(numrange'(,)')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "le -infinity ue infinity");
+    }
+
+    #[pg_test]
+    fn pgtest_num_pgrange_empty() {
+        let desc = Spi::get_one::<String>("SELECT describe_pgrange(numrange'(0.0,0.0]')")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+
+    #[pg_test]
+    fn pgtest_num_make_pgrange_half_open() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_num(0.0,1.0)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "[0.0,1.0)");
+    }
+
+    #[pg_test]
+    fn pgtest_num_make_pgrange_val_inf() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_num(0.0,NULL::numeric)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "[0.0,)");
+    }
+
+    #[pg_test]
+    fn pgtest_num_make_pgrange_inf_val() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_num(NULL::numeric,1.0)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "(,1.0)");
+    }
+
+    #[pg_test]
+    fn pgtest_num_make_pgrange_inf_inf() {
+        let desc =
+            Spi::get_one::<String>("SELECT make_pgrange_num(NULL::numeric,NULL::numeric)::text")
+                .expect("failed to get SPI result");
+        assert_eq!(desc, "(,)");
+    }
+
+    #[pg_test]
+    fn pgtest_num_make_pgrange_empty() {
+        let desc = Spi::get_one::<String>("SELECT make_pgrange_num(1.0,1.0)::text")
+            .expect("failed to get SPI result");
+        assert_eq!(desc, "empty");
+    }
+}

--- a/pgx/src/datum/mod.rs
+++ b/pgx/src/datum/mod.rs
@@ -12,6 +12,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 mod anyarray;
 mod anyelement;
 mod array;
+mod range;
 mod date;
 mod from;
 mod geo;
@@ -34,6 +35,7 @@ pub use self::uuid::*;
 pub use anyarray::*;
 pub use anyelement::*;
 pub use array::*;
+pub use range::*;
 pub use date::*;
 pub use from::*;
 pub use geo::*;

--- a/pgx/src/datum/range.rs
+++ b/pgx/src/datum/range.rs
@@ -1,0 +1,303 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+use crate::{
+    pg_sys, void_mut_ptr, Date, FromDatum, IntoDatum, Numeric, Timestamp, TimestampWithTimeZone,
+};
+use pgx_pg_sys::{Oid, RangeBound};
+use std::default::Default;
+use std::marker::PhantomData;
+// use std::ops::Range;
+
+pub trait RangeSubType {
+    fn range_type_oid() -> Oid;
+}
+
+pub struct PgRange<T: FromDatum + IntoDatum + RangeSubType> {
+    ptr: *mut pg_sys::varlena,
+    range_type: *mut pg_sys::RangeType,
+    pub lower: RangeBound,
+    pub upper: RangeBound,
+    pub is_empty: bool,
+    __marker: PhantomData<T>,
+}
+
+impl<T: FromDatum + IntoDatum + RangeSubType> PgRange<T> {
+    unsafe fn from_pg(
+        ptr: *mut pg_sys::varlena,
+        range_type: *mut pg_sys::RangeType,
+        lower_bound: pg_sys::RangeBound,
+        upper_bound: pg_sys::RangeBound,
+        is_empty: bool,
+    ) -> Self {
+        PgRange {
+            ptr,
+            range_type,
+            lower: lower_bound,
+            upper: upper_bound,
+            is_empty,
+            __marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn lower_val(&self) -> Option<T> {
+        if self.is_empty || self.lower.infinite {
+            None
+        } else {
+            unsafe { T::from_datum(self.lower.val.clone(), false) }
+        }
+    }
+
+    #[inline]
+    pub fn upper_val(&self) -> Option<T> {
+        if self.is_empty || self.upper.infinite {
+            None
+        } else {
+            unsafe { T::from_datum(self.upper.val.clone(), false) }
+        }
+    }
+
+    pub fn empty_range() -> Self {
+        Self::from_values_internal(None, None, true)
+    }
+
+    pub fn from_values(lower: Option<T>, upper: Option<T>) -> Self {
+        Self::from_values_internal(lower, upper, false)
+    }
+
+    pub fn from_bounds(lower_bound: RangeBound, upper_bound: RangeBound) {
+        unsafe {
+            Self::from_bounds_internal(lower_bound, upper_bound, false);
+        }
+    }
+
+    unsafe fn from_bounds_internal(
+        mut lower_bound: RangeBound,
+        mut upper_bound: RangeBound,
+        is_empty: bool,
+    ) -> Self {
+        let typecache =
+            pg_sys::lookup_type_cache(T::range_type_oid(), pg_sys::TYPECACHE_RANGE_INFO as i32);
+
+        let range_type =
+            pg_sys::make_range(typecache, &mut lower_bound, &mut upper_bound, is_empty);
+
+        Self::from_pg(
+            range_type as *mut pg_sys::varlena,
+            range_type,
+            lower_bound,
+            upper_bound,
+            is_empty,
+        )
+    }
+
+    fn from_values_internal(lower: Option<T>, upper: Option<T>, is_empty: bool) -> Self {
+        let mut lower_bound = RangeBound::default();
+        lower_bound.lower = true;
+        lower_bound.inclusive = true;
+        let mut upper_bound = RangeBound::default();
+        upper_bound.lower = false;
+        upper_bound.inclusive = false;
+
+        if !is_empty {
+            match lower {
+                Some(lower_val) => {
+                    lower_bound.val = lower_val.into_datum().expect("lower value datum was null");
+                    lower_bound.infinite = false;
+                }
+                None => {
+                    lower_bound.infinite = true;
+                }
+            }
+
+            match upper {
+                Some(upper_val) => {
+                    upper_bound.val = upper_val.into_datum().expect("upper value datum was null");
+                    upper_bound.infinite = false;
+                }
+                None => {
+                    upper_bound.infinite = true;
+                }
+            }
+        }
+        unsafe { Self::from_bounds_internal(lower_bound, upper_bound, is_empty) }
+    }
+}
+
+impl<T: FromDatum + IntoDatum + RangeSubType> FromDatum for PgRange<T> {
+    #[inline]
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<PgRange<T>> {
+        if is_null {
+            None
+        } else {
+            let ptr = datum.ptr_cast();
+            let range_type = pg_sys::pg_detoast_datum(datum.ptr_cast()) as *mut pg_sys::RangeType;
+            let _ = range_type.as_ref().expect("RangeType * was NULL");
+
+            let typecache = pg_sys::lookup_type_cache(
+                (*range_type).rangetypid,
+                pg_sys::TYPECACHE_RANGE_INFO as i32,
+            );
+
+            let mut lower_bound: RangeBound = Default::default();
+            let mut upper_bound: RangeBound = Default::default();
+            let mut is_empty = false;
+
+            pg_sys::range_deserialize(
+                typecache,
+                range_type,
+                &mut lower_bound,
+                &mut upper_bound,
+                &mut is_empty,
+            );
+
+            Some(PgRange::from_pg(
+                ptr,
+                range_type,
+                lower_bound,
+                upper_bound,
+                is_empty,
+            ))
+        }
+    }
+}
+
+impl<T: FromDatum + IntoDatum + RangeSubType> Drop for PgRange<T> {
+    fn drop(&mut self) {
+        if !self.range_type.is_null() && self.range_type as *mut pg_sys::varlena != self.ptr {
+            unsafe {
+                pg_sys::pfree(self.range_type as void_mut_ptr);
+            }
+        }
+    }
+}
+
+impl<T: FromDatum + IntoDatum + RangeSubType> IntoDatum for PgRange<T> {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        Some(self.range_type.into())
+    }
+
+    fn type_oid() -> u32 {
+        unsafe { pg_sys::get_range_subtype(T::type_oid()) }
+    }
+}
+
+// impl<T: FromDatum + RangeSubType> FromDatum for Range<T> {
+//     #[inline]
+//     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self> {
+//         if is_null {
+//             None
+//         } else {
+//             let range = pg_sys::pg_detoast_datum(datum.ptr_cast()) as *mut pg_sys::RangeType;
+//             let _ = range.as_ref().expect("RangeType * was NULL");
+
+//             let typecache =
+//                 pg_sys::lookup_type_cache((*range).rangetypid, pg_sys::TYPECACHE_RANGE_INFO as i32);
+
+//             let mut lower_bound: RangeBound = Default::default();
+//             let mut upper_bound: RangeBound = Default::default();
+//             let mut is_empty = false;
+//             pg_sys::range_deserialize(
+//                 typecache,
+//                 range,
+//                 &mut lower_bound,
+//                 &mut upper_bound,
+//                 &mut is_empty,
+//             );
+
+//             if is_empty {
+//                 return None;
+//             }
+
+//             match (
+//                 T::from_datum(lower_bound.val, false),
+//                 T::from_datum(upper_bound.val, false),
+//             ) {
+//                 (Some(lower_val), Some(upper_val)) => Some(lower_val..upper_val),
+//                 _ => None,
+//             }
+//         }
+//     }
+// }
+
+// impl<T: IntoDatum + RangeSubType> IntoDatum for Range<T> {
+//     fn into_datum(self) -> Option<pg_sys::Datum> {
+//         unsafe {
+//             crate::log::elog(crate::log::PgLogLevel::INFO, "here");
+//             let is_empty = false;
+
+//             let typecache =
+//                 pg_sys::lookup_type_cache(T::range_type_oid(), pg_sys::TYPECACHE_RANGE_INFO as i32);
+
+//             let mut lower_bound = RangeBound {
+//                 inclusive: true,
+//                 infinite: false,
+//                 lower: true,
+//                 val: T::into_datum(self.start).unwrap(),
+//                 ..Default::default()
+//             };
+
+//             let mut upper_bound = RangeBound {
+//                 inclusive: false,
+//                 infinite: false,
+//                 lower: false,
+//                 val: T::into_datum(self.end).unwrap(),
+//                 ..Default::default()
+//             };
+
+//             crate::log::elog(crate::log::PgLogLevel::INFO, "here2");
+
+//             let range_type =
+//                 pg_sys::make_range(typecache, &mut lower_bound, &mut upper_bound, is_empty);
+
+//             crate::log::elog(crate::log::PgLogLevel::INFO, "here3");
+//             Some(range_type.into())
+//         }
+//     }
+//     fn type_oid() -> pg_sys::Oid {
+//         T::range_type_oid()
+//     }
+// }
+
+impl RangeSubType for i32 {
+    fn range_type_oid() -> Oid {
+        pg_sys::INT4RANGEOID
+    }
+}
+
+impl RangeSubType for i64 {
+    fn range_type_oid() -> Oid {
+        pg_sys::INT8RANGEOID
+    }
+}
+
+impl RangeSubType for Numeric {
+    fn range_type_oid() -> Oid {
+        pg_sys::NUMRANGEOID
+    }
+}
+
+impl RangeSubType for Date {
+    fn range_type_oid() -> Oid {
+        pg_sys::DATERANGEOID
+    }
+}
+
+impl RangeSubType for Timestamp {
+    fn range_type_oid() -> Oid {
+        pg_sys::TSRANGEOID
+    }
+}
+
+impl RangeSubType for TimestampWithTimeZone {
+    fn range_type_oid() -> Oid {
+        pg_sys::TSTZRANGEOID
+    }
+}

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -9,6 +9,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
+use std::fmt::Display;
 use std::{
     convert::TryFrom,
     ops::{Deref, DerefMut},
@@ -36,45 +37,54 @@ impl FromDatum for TimestampWithTimeZone {
         if is_null {
             None
         } else {
-            let mut tm = pg_sys::pg_tm {
-                tm_sec: 0,
-                tm_min: 0,
-                tm_hour: 0,
-                tm_mday: 0,
-                tm_mon: 0,
-                tm_year: 0,
-                tm_wday: 0,
-                tm_yday: 0,
-                tm_isdst: 0,
-                tm_gmtoff: 0,
-                tm_zone: std::ptr::null_mut(),
-            };
-            let mut tz = 0i32;
-            let mut fsec = 0 as pg_sys::fsec_t;
-            let mut tzn = std::ptr::null::<std::os::raw::c_char>();
-            pg_sys::timestamp2tm(
-                datum.value() as i64,
-                &mut tz,
-                &mut tm,
-                &mut fsec,
-                &mut tzn,
-                std::ptr::null_mut(),
-            );
-            let date = time::Date::from_calendar_date(
-                tm.tm_year,
-                time::Month::try_from(tm.tm_mon as u8)
-                    .expect("Got month outside of range in TimestampWithTimeZone::from_datum"),
-                tm.tm_mday as u8,
-            )
-            .expect("failed to create date from TimestampWithTimeZone");
+            let datum_val = datum.value() as i64;
+            let (date, time, tz) = match datum_val {
+                i64::MIN => (time::Date::MIN, time::Time::MIDNIGHT, 0i32),
+                i64::MAX => (time::Date::MAX, time::Time::MIDNIGHT, 0i32),
+                _ => {
+                    let mut tm = pg_sys::pg_tm {
+                        tm_sec: 0,
+                        tm_min: 0,
+                        tm_hour: 0,
+                        tm_mday: 0,
+                        tm_mon: 0,
+                        tm_year: 0,
+                        tm_wday: 0,
+                        tm_yday: 0,
+                        tm_isdst: 0,
+                        tm_gmtoff: 0,
+                        tm_zone: std::ptr::null_mut(),
+                    };
+                    let mut tz = 0i32;
+                    let mut fsec = 0 as pg_sys::fsec_t;
+                    let mut tzn = std::ptr::null::<std::os::raw::c_char>();
+                    pg_sys::timestamp2tm(
+                        datum_val,
+                        &mut tz,
+                        &mut tm,
+                        &mut fsec,
+                        &mut tzn,
+                        std::ptr::null_mut(),
+                    );
+                    let date = time::Date::from_calendar_date(
+                        tm.tm_year,
+                        time::Month::try_from(tm.tm_mon as u8).expect(
+                            "Got month outside of range in TimestampWithTimeZone::from_datum",
+                        ),
+                        tm.tm_mday as u8,
+                    )
+                    .expect("failed to create date from TimestampWithTimeZone");
 
-            let time = time::Time::from_hms_micro(
-                tm.tm_hour as u8,
-                tm.tm_min as u8,
-                tm.tm_sec as u8,
-                fsec as u32,
-            )
-            .expect("failed to create time from TimestampWithTimeZonez");
+                    let time = time::Time::from_hms_micro(
+                        tm.tm_hour as u8,
+                        tm.tm_min as u8,
+                        tm.tm_sec as u8,
+                        fsec as u32,
+                    )
+                    .expect("failed to create time from TimestampWithTimeZonez");
+                    (date, time, tz)
+                }
+            };
 
             Some(TimestampWithTimeZone(
                 time::PrimitiveDateTime::new(date, time)
@@ -91,26 +101,33 @@ impl FromDatum for TimestampWithTimeZone {
 impl IntoDatum for TimestampWithTimeZone {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let year = self.year();
-        let month = self.month() as i32;
-        let mday = self.day() as i32;
-        let hour = self.hour() as i32;
-        let minute = self.minute() as i32;
-        let second = self.second() as f64 + (self.microsecond() as f64 / USECS_PER_SEC as f64);
+        match self.0.date() {
+            time::Date::MIN => i64::MIN.into_datum(),
+            time::Date::MAX => i64::MAX.into_datum(),
+            _ => {
+                let year = self.year();
+                let month = self.month() as i32;
+                let mday = self.day() as i32;
+                let hour = self.hour() as i32;
+                let minute = self.minute() as i32;
+                let second =
+                    self.second() as f64 + (self.microsecond() as f64 / USECS_PER_SEC as f64);
 
-        unsafe {
-            direct_function_call_as_datum(
-                pg_sys::make_timestamptz_at_timezone,
-                vec![
-                    year.into_datum(),
-                    month.into_datum(),
-                    mday.into_datum(),
-                    hour.into_datum(),
-                    minute.into_datum(),
-                    second.into_datum(),
-                    "UTC".into_datum(),
-                ],
-            )
+                unsafe {
+                    direct_function_call_as_datum(
+                        pg_sys::make_timestamptz_at_timezone,
+                        vec![
+                            year.into_datum(),
+                            month.into_datum(),
+                            mday.into_datum(),
+                            hour.into_datum(),
+                            minute.into_datum(),
+                            second.into_datum(),
+                            "UTC".into_datum(),
+                        ],
+                    )
+                }
+            }
         }
     }
 
@@ -129,6 +146,24 @@ impl TimestampWithTimeZone {
                         .expect("Unexpected error in `UtcOffset::from_whole_seconds` during `TimestampWithTimeZone::new`")
                 ),
         )
+    }
+
+    pub fn infinity() -> Self {
+        unsafe { Self::from_datum(i64::MAX.into_datum().unwrap(), false).unwrap() }
+    }
+
+    pub fn neg_infinity() -> Self {
+        unsafe { Self::from_datum(i64::MIN.into_datum().unwrap(), false).unwrap() }
+    }
+
+    #[inline]
+    pub fn is_infinity(self) -> bool {
+        self.0.date() == time::Date::MAX
+    }
+
+    #[inline]
+    pub fn is_neg_infinity(self) -> bool {
+        self.0.date() == time::Date::MIN
     }
 }
 
@@ -192,3 +227,15 @@ impl serde::Serialize for TimestampWithTimeZone {
 
 static DEFAULT_TIMESTAMP_WITH_TIMEZONE_FORMAT: &[FormatItem<'static>] =
     time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]-00");
+
+impl Display for TimestampWithTimeZone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            &self
+                .format(&DEFAULT_TIMESTAMP_WITH_TIMEZONE_FORMAT)
+                .expect("Date formatting problem")
+        )
+    }
+}

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -235,6 +235,15 @@ pub static DEFAULT_RUST_TYPE_ID_TO_SQL: Lazy<HashSet<RustSqlMapping>> = Lazy::ne
     map_type!(m, datum::Inet, "inet");
     map_type!(m, datum::Uuid, "uuid");
     map_type!(m, pgx_pg_sys::FdwRoutine, "fdw_handler");
+    map_type!(m, datum::PgRange<i32>, "int4range");
+    map_type!(m, datum::PgRange<i64>, "int8range");
+    map_type!(m, datum::PgRange<datum::Numeric>, "numrange");
+    map_type!(m, datum::PgRange<datum::Date>, "daterange");
+    map_type!(m, datum::PgRange<datum::Timestamp>, "tsrange");
+    map_type!(m, datum::PgRange<datum::TimestampWithTimeZone>, "tstzrange");
+    // map_type!(m, std::ops::Range<i32>, "int4range");  // discrete pg_types only
+    // map_type!(m, std::ops::Range<i64>, "int8range");  // discrete pg_types only
+    // map_type!(m, std::ops::Range<datum::Date>, "daterange");  // discrete pg_types only
 
     m
 });


### PR DESCRIPTION
### Mapping for `PgRange<T>` type
`PgRange<T>` maps to the PG `*RangeType` and provides mappings for `int4range` `int8range` `daterange` `numrange` `tsrange` and `tstzrange`

This does not yet include pg14 multirange variations

Note: work on mappings for `std::ops::Range<T>` is commented out for now as `std::ops::Range<T>` would only support "half-open" ranges (ex. `[1..10)`) with non-infinite bounds, and only on discrete types (to allow for `[)` pg's range canonicalization) so utility is very limited.  Need to explore possibility of `dyn RangeBounds<T>` to handle all the different range possibilities `(..]` `[..]` `(..)` `[..)` `(,)`

### Also: 
 Added `infinity`/`-infinity` support for `Date`, `Timestamp`, `TimestampWithTimeZone`

