### PR TITLE
Adding -infinity/infinity to Date/Timestamp(Tz)

### DIFF
--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -175,6 +175,22 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_accept_date_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_date('infinity'::date) = 'infinity'::date;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_date_neg_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_date('-infinity'::date) = '-infinity'::date;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
     fn test_accept_time_now() {
         let result = Spi::get_one::<bool>("SELECT accept_time(now()::time) = now()::time;")
             .expect("failed to get SPI result");
@@ -226,6 +242,22 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_accept_timestamp_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_timestamp('infinity'::timestamp) = 'infinity'::timestamp;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_timestamp_neg_infinity() {
+        let result =
+            Spi::get_one::<bool>("SELECT accept_timestamp('-infinity'::timestamp) = '-infinity'::timestamp;")
+                .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
     fn test_accept_timestamp_with_time_zone() {
         let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone(now()) = now();")
             .expect("failed to get SPI result");
@@ -235,6 +267,20 @@ mod tests {
     #[pg_test]
     fn test_accept_timestamp_with_time_zone_not_utc() {
         let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone('1990-01-23 03:45:00-07') = '1990-01-23 03:45:00-07'::timestamp with time zone;")
+            .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_timestamp_with_time_zone_infinity() {
+        let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone('infinity') = 'infinity'::timestamp with time zone;")
+            .expect("failed to get SPI result");
+        assert!(result)
+    }
+
+    #[pg_test]
+    fn test_accept_timestamp_with_time_zone_neg_infinity() {
+        let result = Spi::get_one::<bool>("SELECT accept_timestamp_with_time_zone('-infinity') = '-infinity'::timestamp with time zone;")
             .expect("failed to get SPI result");
         assert!(result)
     }

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -9,6 +9,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::datum::time::USECS_PER_SEC;
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
+use std::fmt::Display;
 use std::{
     convert::TryFrom,
     ops::{Deref, DerefMut},
@@ -36,45 +37,54 @@ impl FromDatum for TimestampWithTimeZone {
         if is_null {
             None
         } else {
-            let mut tm = pg_sys::pg_tm {
-                tm_sec: 0,
-                tm_min: 0,
-                tm_hour: 0,
-                tm_mday: 0,
-                tm_mon: 0,
-                tm_year: 0,
-                tm_wday: 0,
-                tm_yday: 0,
-                tm_isdst: 0,
-                tm_gmtoff: 0,
-                tm_zone: std::ptr::null_mut(),
-            };
-            let mut tz = 0i32;
-            let mut fsec = 0 as pg_sys::fsec_t;
-            let mut tzn = std::ptr::null::<std::os::raw::c_char>();
-            pg_sys::timestamp2tm(
-                datum.value() as i64,
-                &mut tz,
-                &mut tm,
-                &mut fsec,
-                &mut tzn,
-                std::ptr::null_mut(),
-            );
-            let date = time::Date::from_calendar_date(
-                tm.tm_year,
-                time::Month::try_from(tm.tm_mon as u8)
-                    .expect("Got month outside of range in TimestampWithTimeZone::from_datum"),
-                tm.tm_mday as u8,
-            )
-            .expect("failed to create date from TimestampWithTimeZone");
+            let datum_val = datum.value() as i64;
+            let (date, time, tz) = match datum_val {
+                i64::MIN => (time::Date::MIN, time::Time::MIDNIGHT, 0i32),
+                i64::MAX => (time::Date::MAX, time::Time::MIDNIGHT, 0i32),
+                _ => {
+                    let mut tm = pg_sys::pg_tm {
+                        tm_sec: 0,
+                        tm_min: 0,
+                        tm_hour: 0,
+                        tm_mday: 0,
+                        tm_mon: 0,
+                        tm_year: 0,
+                        tm_wday: 0,
+                        tm_yday: 0,
+                        tm_isdst: 0,
+                        tm_gmtoff: 0,
+                        tm_zone: std::ptr::null_mut(),
+                    };
+                    let mut tz = 0i32;
+                    let mut fsec = 0 as pg_sys::fsec_t;
+                    let mut tzn = std::ptr::null::<std::os::raw::c_char>();
+                    pg_sys::timestamp2tm(
+                        datum_val,
+                        &mut tz,
+                        &mut tm,
+                        &mut fsec,
+                        &mut tzn,
+                        std::ptr::null_mut(),
+                    );
+                    let date = time::Date::from_calendar_date(
+                        tm.tm_year,
+                        time::Month::try_from(tm.tm_mon as u8).expect(
+                            "Got month outside of range in TimestampWithTimeZone::from_datum",
+                        ),
+                        tm.tm_mday as u8,
+                    )
+                    .expect("failed to create date from TimestampWithTimeZone");
 
-            let time = time::Time::from_hms_micro(
-                tm.tm_hour as u8,
-                tm.tm_min as u8,
-                tm.tm_sec as u8,
-                fsec as u32,
-            )
-            .expect("failed to create time from TimestampWithTimeZonez");
+                    let time = time::Time::from_hms_micro(
+                        tm.tm_hour as u8,
+                        tm.tm_min as u8,
+                        tm.tm_sec as u8,
+                        fsec as u32,
+                    )
+                    .expect("failed to create time from TimestampWithTimeZonez");
+                    (date, time, tz)
+                }
+            };
 
             Some(TimestampWithTimeZone(
                 time::PrimitiveDateTime::new(date, time)
@@ -91,26 +101,33 @@ impl FromDatum for TimestampWithTimeZone {
 impl IntoDatum for TimestampWithTimeZone {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let year = self.year();
-        let month = self.month() as i32;
-        let mday = self.day() as i32;
-        let hour = self.hour() as i32;
-        let minute = self.minute() as i32;
-        let second = self.second() as f64 + (self.microsecond() as f64 / USECS_PER_SEC as f64);
+        match self.0.date() {
+            time::Date::MIN => i64::MIN.into_datum(),
+            time::Date::MAX => i64::MAX.into_datum(),
+            _ => {
+                let year = self.year();
+                let month = self.month() as i32;
+                let mday = self.day() as i32;
+                let hour = self.hour() as i32;
+                let minute = self.minute() as i32;
+                let second =
+                    self.second() as f64 + (self.microsecond() as f64 / USECS_PER_SEC as f64);
 
-        unsafe {
-            direct_function_call_as_datum(
-                pg_sys::make_timestamptz_at_timezone,
-                vec![
-                    year.into_datum(),
-                    month.into_datum(),
-                    mday.into_datum(),
-                    hour.into_datum(),
-                    minute.into_datum(),
-                    second.into_datum(),
-                    "UTC".into_datum(),
-                ],
-            )
+                unsafe {
+                    direct_function_call_as_datum(
+                        pg_sys::make_timestamptz_at_timezone,
+                        vec![
+                            year.into_datum(),
+                            month.into_datum(),
+                            mday.into_datum(),
+                            hour.into_datum(),
+                            minute.into_datum(),
+                            second.into_datum(),
+                            "UTC".into_datum(),
+                        ],
+                    )
+                }
+            }
         }
     }
 
@@ -129,6 +146,24 @@ impl TimestampWithTimeZone {
                         .expect("Unexpected error in `UtcOffset::from_whole_seconds` during `TimestampWithTimeZone::new`")
                 ),
         )
+    }
+
+    pub fn infinity() -> Self {
+        unsafe { Self::from_datum(i64::MAX.into_datum().unwrap(), false).unwrap() }
+    }
+
+    pub fn neg_infinity() -> Self {
+        unsafe { Self::from_datum(i64::MIN.into_datum().unwrap(), false).unwrap() }
+    }
+
+    #[inline]
+    pub fn is_infinity(self) -> bool {
+        self.0.date() == time::Date::MAX
+    }
+
+    #[inline]
+    pub fn is_neg_infinity(self) -> bool {
+        self.0.date() == time::Date::MIN
     }
 }
 
@@ -192,3 +227,15 @@ impl serde::Serialize for TimestampWithTimeZone {
 
 static DEFAULT_TIMESTAMP_WITH_TIMEZONE_FORMAT: &[FormatItem<'static>] =
     time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]-00");
+
+impl Display for TimestampWithTimeZone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            &self
+                .format(&DEFAULT_TIMESTAMP_WITH_TIMEZONE_FORMAT)
+                .expect("Date formatting problem")
+        )
+    }
+}


### PR DESCRIPTION
Added infinity/-infinity support for Date, Timestamp, TimestampWithTimeZone

without this `date'infinity'` or `'infinity'::timestamp` would cause a i64 overflow.

+/- infinity for Date/Timestamps are defined in PG as the i64 Min/Max values and have special significance
```
#define DT_NOBEGIN		PG_INT64_MIN
#define DT_NOEND		PG_INT64_MAX
```