### PR TITLE
Opaque Date type with +/- infinity support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "enum-primitive-derive",
  "eyre",
  "heapless",
+ "libc",
  "num-traits",
  "once_cell",
  "pgx-macros",

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -205,21 +205,23 @@ mod tests {
             Spi::get_one::<bool>("SELECT accept_date('1823-03-28'::date) = '1823-03-28'::date;")
                 .expect("failed to get SPI result");
         assert!(result)
-    } 
-    
+    }
+
     #[pg_test]
     fn test_accept_date_round_trip_large_date() {
-        let result =
-            Spi::get_one::<bool>("SELECT accept_date_round_trip('10001-01-01'::date) = '10001-01-01'::date;")
-                .expect("failed to get SPI result");
+        let result = Spi::get_one::<bool>(
+            "SELECT accept_date_round_trip('10001-01-01'::date) = '10001-01-01'::date;",
+        )
+        .expect("failed to get SPI result");
         assert!(result)
     }
 
     #[pg_test]
     fn test_accept_date_round_trip_random() {
-        let result =
-            Spi::get_one::<bool>("SELECT accept_date_round_trip('1823-03-28'::date) = '1823-03-28'::date;")
-                .expect("failed to get SPI result");
+        let result = Spi::get_one::<bool>(
+            "SELECT accept_date_round_trip('1823-03-28'::date) = '1823-03-28'::date;",
+        )
+        .expect("failed to get SPI result");
         assert!(result)
     }
 

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -66,6 +66,37 @@ fn timestamptz_to_i64(tstz: pg_sys::TimestampTz) -> i64 {
 
 #[cfg(test)]
 #[pgx::pg_schema]
+mod date_epoch_tests {
+    use pg_sys;
+    use pgx::*;
+
+    #[test]
+    fn test_to_pg_epoch_days() {
+        let d = time::Date::from_calendar_date(2000, time::Month::January, 2).unwrap();
+        let date = Date::from_date(d);
+
+        assert_eq!(date.to_pg_epoch_days(), 1);
+    }
+
+    #[test]
+    fn test_to_posix_time() {
+        let d = time::Date::from_calendar_date(1970, time::Month::January, 2).unwrap();
+        let date = Date::from_date(d);
+
+        assert_eq!(date.to_posix_time(), 86400);
+    }
+
+    #[test]
+    fn test_to_julian_days() {
+        let d = time::Date::from_calendar_date(2000, time::Month::January, 1).unwrap();
+        let date = Date::from_date(d);
+
+        assert_eq!(date.to_julian_days(), pg_sys::POSTGRES_EPOCH_JDATE as i32);
+    }
+}
+
+#[cfg(test)]
+#[pgx::pg_schema]
 mod serialization_tests {
     use pgx::*;
     use serde_json::*;

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -36,6 +36,7 @@ cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.15"
 seahash = "4.1.0"
+libc = "0.2.126"
 pgx-macros = { path = "../pgx-macros/", version = "=0.5.0-beta.0" }
 pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.5.0-beta.0" }
 pgx-utils = { path = "../pgx-utils/", version = "=0.5.0-beta.0" }

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -48,6 +48,16 @@ impl Date {
     pub const INFINITY: Self = Date(i32::MAX);
 
     #[inline]
+    #[deprecated(
+        since = "0.5.0",
+        note = "the repr of pgx::Date is no longer time::Date \
+    and this fn will be removed in a future version"
+    )]
+    pub fn new(date: time::Date) -> Date {
+        Self::from_date(date)
+    }
+
+    #[inline]
     pub fn from_date(date: time::Date) -> Date {
         Self::from_pg_epoch_days(date.to_julian_day() - pg_sys::POSTGRES_EPOCH_JDATE as i32)
     }
@@ -122,9 +132,6 @@ impl serde::Serialize for Date {
 
         /* This unwrap is fine as Postgres won't ever write invalid UTF-8,
            because Postgres only writes ASCII
-           (or uses locale-ignorant functions to write,
-            or uses a fully compliant UTF-8 suite,
-            whatever's actually true).
         */
         serializer
             .serialize_str(cstr.to_str().unwrap())

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -8,54 +8,79 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::{pg_sys, FromDatum, IntoDatum};
-use std::ops::{Deref, DerefMut};
-use time::format_description::FormatItem;
+use std::ffi::CStr;
 
 #[derive(Debug)]
-pub struct Date(time::Date);
-impl FromDatum for Date {
-    #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Date> {
-        if is_null {
-            None
-        } else {
-            Some(Date(
-                time::Date::from_julian_day(
-                    datum.value() as i32 + pg_sys::POSTGRES_EPOCH_JDATE as i32,
-                )
-                .expect("Unexpected error getting the Julian day in Date::from_datum"),
-            ))
-        }
+pub struct Date(i32);
+
+impl TryFrom<pg_sys::Datum> for Date {
+    type Error = i32;
+    fn try_from(d: pg_sys::Datum) -> Result<Self, Self::Error> {
+        Ok(Date(d.value() as i32))
     }
 }
-impl IntoDatum for Date {
-    #[inline]
-    fn into_datum(self) -> Option<pg_sys::Datum> {
-        Some((self.to_julian_day() as i32 - pg_sys::POSTGRES_EPOCH_JDATE as i32).into())
-    }
 
+impl IntoDatum for Date {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        Some(pg_sys::Datum::from(self.0))
+    }
     fn type_oid() -> u32 {
         pg_sys::DATEOID
     }
 }
 
+impl FromDatum for Date {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            Some(datum.try_into().expect("Error converting date datum"))
+        }
+    }
+}
+
 impl Date {
-    pub fn new(date: time::Date) -> Self {
-        Date(date)
+    pub const NEG_INFINITY: i32 = i32::MIN;
+    pub const INFINITY: i32 = i32::MAX;
+
+    #[inline]
+    pub fn from_date(date: time::Date) -> Date {
+        Self::from_pg_epoch_days(date.to_julian_day() - pg_sys::POSTGRES_EPOCH_JDATE as i32)
     }
-}
 
-impl Deref for Date {
-    type Target = time::Date;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub fn from_pg_epoch_days(pg_epoch_days: i32) -> Date {
+        Date(pg_epoch_days)
     }
-}
 
-impl DerefMut for Date {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    #[inline]
+    pub fn is_infinity(&self) -> bool {
+        self.0 == Self::INFINITY
+    }
+
+    #[inline]
+    pub fn is_neg_infinity(&self) -> bool {
+        self.0 == Self::NEG_INFINITY
+    }
+
+    #[inline]
+    pub fn to_julian_day(&self) -> i32 {
+        self.0
+    }
+
+    pub fn try_get_date(&self) -> Result<time::Date, i32> {
+        const INNER_RANGE_BEGIN: i32 = time::Date::MIN.to_julian_day();
+        const INNER_RANGE_END: i32 = time::Date::MAX.to_julian_day();
+        match self.0 {
+            INNER_RANGE_BEGIN..=INNER_RANGE_END => {
+                time::Date::from_julian_day(self.0 + pg_sys::POSTGRES_EPOCH_JDATE as i32)
+                    .or_else(|_e| Err(self.0))
+            }
+            v => Err(v),
+        }
     }
 }
 
@@ -67,13 +92,29 @@ impl serde::Serialize for Date {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(
-            &self.format(&DATE_FORMAT).map_err(|e| {
-                serde::ser::Error::custom(format!("Date formatting problem: {:?}", e))
-            })?,
-        )
+        let cstr;
+        unsafe {
+            let buf = [0u8; pg_sys::MAXDATELEN as usize + 1].as_mut_ptr() as *mut i8;
+            match &self.0 {
+                &Self::NEG_INFINITY | &Self::INFINITY => {
+                    pg_sys::EncodeSpecialDate(self.0, buf);
+                }
+                _ => {
+                    let mut pg_tm: pg_sys::pg_tm = Default::default();
+                    pg_sys::j2date(
+                        &self.0 + pg_sys::POSTGRES_EPOCH_JDATE as i32,
+                        &mut pg_tm.tm_year,
+                        &mut pg_tm.tm_mon,
+                        &mut pg_tm.tm_mday,
+                    );
+                    pg_sys::EncodeDateOnly(&mut pg_tm, pg_sys::USE_XSD_DATES as i32, buf)
+                }
+            }
+            cstr = CStr::from_ptr(pg_sys::pstrdup(buf));
+        }
+
+        serializer
+            .serialize_str(cstr.to_str().unwrap())
+            .map_err(|e| serde::ser::Error::custom(format!("Date formatting problem: {:?}", e)))
     }
 }
-
-static DATE_FORMAT: &[FormatItem<'static>] =
-    time::macros::format_description!("[year]-[month]-[day]");


### PR DESCRIPTION
I switched the Date type with one that's an alias for the `i32` datum.  `try_get_date(&self)` will get you a `time:Date` if it's within the `time` crate's bounds, or an `Err(pg_epoch_days: i32)` if out of range.  `-infinity` and `infinity` are handled on their own.

I moved the serialization `#[test]` to `#[pg_test]` so that serialization can leverage PG's built in serialization.  This is especially important for values outside of `time:Date` bounds which we couldn't format/serialize otherwise.