### PR TITLE
Explain sysreqs without implying MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
  
  † PGX has no MSRV policy, thus may require the latest stable version of Rust, available via Rustup
  
- ‡ A local Postgres installation is not required. `cargo pgx` can download and compile PostgreSQL versions on its own.
+ ‡ A local PostgreSQL server installation is not required. `cargo pgx` can download and compile PostgreSQL versions on its own.
 
 <details>
    <summary>How to: GCC 7 on CentOS 7</summary>

--- a/README.md
+++ b/README.md
@@ -65,15 +65,19 @@
 
 ## System Requirements
 
-- A `rustup` managed toolchain (>=1.58) (or `rustc`, `cargo`, and `rustfmt`)
+- A Rust toolchain: `rustc`, `cargo`, and `rustfmt`. The recommended way to get these is from https://rustup.rs †
 - `git`
 - `libclang`
-   - Ubuntu: `libclang-dev` or `clang`
-   - RHEL: `clang`
+   - Ubuntu: `apt install libclang-dev` or `apt install clang`
+   - RHEL: `yum install clang`
 - `tar`
 - `bzip2`
 - GCC 7 or newer
-- [Build dependencies for PostgreSQL](https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code)
+- [PostgreSQL's build dependencies](https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code) ‡
+ 
+ † PGX has no MSRV policy, thus may require the latest stable version of Rust, available via Rustup
+ 
+ ‡ A local Postgres installation is not required. `cargo pgx` can download and compile PostgreSQL versions on its own.
 
 <details>
    <summary>How to: GCC 7 on CentOS 7</summary>
@@ -86,8 +90,6 @@ yum install devtoolset-7
 scl enable devtoolset-7 bash
 ```
 </details>
-
-Note that a local PostgreSQL Server installation is not required. `pgx` typically downloads and compiles PostgreSQL versions itself.
 
 ## Getting Started
 


### PR DESCRIPTION
Leaving an old version of rustc in the README implies rustc 1.58 is sufficient to build and run today's PGX.
Even if it is today, there is no guarantee it will be tomorrow.
The README should be clear that PGX doesn't necessarily support anything but the latest stable.