### PR TITLE
Fix unsound interaction between `Array::over` and `Drop`

### DIFF
--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -17,11 +17,11 @@ fn sum_array_i32(values: Array<i32>) -> i32 {
     let mut sum = 0_i32;
     for v in values {
         let v = v.unwrap_or(0);
-        let tmp = sum.overflowing_add(v);
-        if tmp.1 {
+        let (val, overflow) = sum.overflowing_add(v);
+        if overflow {
             panic!("attempt to add with overflow");
         } else {
-            sum = tmp.0;
+            sum = val;
         }
     }
     sum
@@ -109,7 +109,6 @@ fn over_implicit_drop() -> Vec<i64> {
     let len = vec.len();
     // Create an Array...
     let _arr = unsafe { Array::<'_, i64>::over(vec.as_mut_ptr().cast(), nulls.as_mut_ptr(), len) };
-    // core::mem::forget(_arr); // Uncomment me to make the tests pass.
     vec
     // Implicit drop of _arr
 }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -14,7 +14,7 @@ use std::marker::PhantomData;
 pub type VariadicArray<'a, T> = Array<'a, T>;
 
 pub struct Array<'a, T: FromDatum> {
-    ptr: *mut pg_sys::varlena,
+    _ptr: *mut pg_sys::varlena,
     array_type: *mut pg_sys::ArrayType,
     nelems: usize,
     elem_slice: &'a [pg_sys::Datum],
@@ -56,7 +56,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
         nelems: usize,
     ) -> Array<'a, T> {
         Array::<T> {
-            ptr: std::ptr::null_mut(),
+            _ptr: std::ptr::null_mut(),
             array_type: std::ptr::null_mut(),
             nelems,
             elem_slice: std::slice::from_raw_parts(elements, nelems),
@@ -66,14 +66,14 @@ impl<'a, T: FromDatum> Array<'a, T> {
     }
 
     unsafe fn from_pg(
-        ptr: *mut pg_sys::varlena,
+        _ptr: *mut pg_sys::varlena,
         array_type: *mut pg_sys::ArrayType,
         elements: *mut pg_sys::Datum,
         nulls: *mut bool,
         nelems: usize,
     ) -> Self {
         Array::<T> {
-            ptr,
+            _ptr,
             array_type,
             nelems,
             elem_slice: std::slice::from_raw_parts(elements, nelems),

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -66,6 +66,12 @@ impl<'a, T: FromDatum> Array<'a, T> {
         }
     }
 
+    /// # Safety
+    ///
+    /// This function requires that:
+    /// - `elements` is non-null
+    /// - `nulls` is non-null
+    /// - both `elements` and `nulls` point to a slice of equal-or-greater length than `nelems`
     unsafe fn from_pg(
         _ptr: *mut pg_sys::varlena,
         array_type: *mut pg_sys::ArrayType,

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -245,32 +245,6 @@ impl<'a, T: FromDatum> Iterator for ArrayIntoIterator<'a, T> {
     }
 }
 
-impl<'a, T: FromDatum> Drop for Array<'a, T> {
-    fn drop(&mut self) {
-        if !self.elements.is_null() {
-            unsafe {
-                pg_sys::pfree(self.elements as void_mut_ptr);
-            }
-        }
-
-        if !self.nulls.is_null() {
-            unsafe {
-                pg_sys::pfree(self.nulls as void_mut_ptr);
-            }
-        }
-
-        if !self.array_type.is_null() && self.array_type as *mut pg_sys::varlena != self.ptr {
-            unsafe {
-                pg_sys::pfree(self.array_type as void_mut_ptr);
-            }
-        }
-
-        // NB:  we don't pfree(self.ptr) because we don't know if it's actually
-        // safe to do that.  It'll be freed whenever Postgres deletes/resets its parent
-        // MemoryContext
-    }
-}
-
 impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
     #[inline]
     unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Array<'a, T>> {

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -266,6 +266,11 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
             let mut nulls = std::ptr::null_mut();
             let mut nelems = 0;
 
+            // FIXME: This way of getting array buffers causes problems for any Drop impl,
+            // and clashes with assumptions of Array being a "zero-copy", lifetime-bound array,
+            // some of which are implicitly embedded in other methods (e.g. Array::over).
+            // It also risks leaking memory, as deconstruct_array calls palloc.
+            // So either we don't use this, we use it more conditionally, or something.
             pg_sys::deconstruct_array(
                 array,
                 array_ref.elemtype,

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::{pg_sys, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts};
+use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 use serde::Serializer;
 use std::marker::PhantomData;
 
@@ -16,8 +16,6 @@ pub type VariadicArray<'a, T> = Array<'a, T>;
 pub struct Array<'a, T: FromDatum> {
     ptr: *mut pg_sys::varlena,
     array_type: *mut pg_sys::ArrayType,
-    elements: *mut pg_sys::Datum,
-    nulls: *mut bool,
     nelems: usize,
     elem_slice: &'a [pg_sys::Datum],
     null_slice: &'a [bool],
@@ -60,8 +58,6 @@ impl<'a, T: FromDatum> Array<'a, T> {
         Array::<T> {
             ptr: std::ptr::null_mut(),
             array_type: std::ptr::null_mut(),
-            elements,
-            nulls,
             nelems,
             elem_slice: std::slice::from_raw_parts(elements, nelems),
             null_slice: std::slice::from_raw_parts(nulls, nelems),
@@ -79,8 +75,6 @@ impl<'a, T: FromDatum> Array<'a, T> {
         Array::<T> {
             ptr,
             array_type,
-            elements,
-            nulls,
             nelems,
             elem_slice: std::slice::from_raw_parts(elements, nelems),
             null_slice: std::slice::from_raw_parts(nulls, nelems),

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -49,8 +49,10 @@ impl<'a, T: FromDatum> Array<'a, T> {
     ///
     /// # Safety
     ///
-    /// This function is unsafe as it can't validate the provided pointer are valid or that
-    ///
+    /// This function requires that:
+    /// - `elements` is non-null
+    /// - `nulls` is non-null
+    /// - both `elements` and `nulls` point to a slice of equal-or-greater length than `nelems`
     pub unsafe fn over(
         elements: *mut pg_sys::Datum,
         nulls: *mut bool,


### PR DESCRIPTION
This closes #633.
It also partially addresses #631 (i.e. for this type).
It introduces a new problem (leaking arrays) that I hope to fix soon,
as part of trying to fix, in the future, #627.