### PR TITLE
Low-level interop for PG arrays

### DIFF
--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -117,9 +117,9 @@ char *pgx_ARR_DATA_PTR(ArrayType *arr) {
     return ARR_DATA_PTR(arr);
 }
 
-PGDLLEXPORT int pgx_ARR_NELEMS(ArrayType *arr);
-int pgx_ARR_NELEMS(ArrayType *arr) {
-    return ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
+PGDLLEXPORT int pgx_ARRNELEMS(ArrayType *arr);
+int ARRNELEMS(ArrayType *arr) {
+    return ArrayGetNItems(arr->ndim, ARR_DIMS(arr));
 }
 
 PGDLLEXPORT bits8 *pgx_ARR_NULLBITMAP(ArrayType *arr);
@@ -135,4 +135,9 @@ int pgx_ARR_NDIM(ArrayType *arr) {
 PGDLLEXPORT bool pgx_ARR_HASNULL(ArrayType *arr);
 bool pgx_ARR_HASNULL(ArrayType *arr) {
     return ARR_HASNULL(arr);
+}
+
+PGDLLEXPORT int *pgx_ARR_HASNULL(ArrayType *arr);
+int *pgx_ARR_DIMS(ArrayType *arr){
+    return ARR_DIMS(arr);
 }

--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -117,8 +117,8 @@ char *pgx_ARR_DATA_PTR(ArrayType *arr) {
     return ARR_DATA_PTR(arr);
 }
 
-PGDLLEXPORT int pgx_ARRNELEMS(ArrayType *arr);
-int ARRNELEMS(ArrayType *arr) {
+PGDLLEXPORT int pgx_ARR_NELEMS(ArrayType *arr);
+int pgx_ARR_NELEMS(ArrayType *arr) {
     return ArrayGetNItems(arr->ndim, ARR_DIMS(arr));
 }
 
@@ -137,7 +137,7 @@ bool pgx_ARR_HASNULL(ArrayType *arr) {
     return ARR_HASNULL(arr);
 }
 
-PGDLLEXPORT int *pgx_ARR_HASNULL(ArrayType *arr);
+PGDLLEXPORT int *pgx_ARR_DIMS(ArrayType *arr);
 int *pgx_ARR_DIMS(ArrayType *arr){
     return ARR_DIMS(arr);
 }

--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -25,6 +25,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parsetree.h"
 #include "utils/memutils.h"
 #include "utils/builtins.h"
+#include "utils/array.h"
 
 
 PGDLLEXPORT MemoryContext pgx_GetMemoryContextChunk(void *ptr);
@@ -109,4 +110,29 @@ Oid pgx_HeapTupleHeaderGetOid(HeapTupleHeader htup_header) {
 PGDLLEXPORT char *pgx_GETSTRUCT(HeapTuple tuple);
 char *pgx_GETSTRUCT(HeapTuple tuple) {
     return GETSTRUCT(tuple);
+}
+
+PGDLLEXPORT char *pgx_ARR_DATA_PTR(ArrayType *arr);
+char *pgx_ARR_DATA_PTR(ArrayType *arr) {
+    return ARR_DATA_PTR(arr);
+}
+
+PGDLLEXPORT int pgx_ARR_NELEMS(ArrayType *arr);
+int pgx_ARR_NELEMS(ArrayType *arr) {
+    return ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
+}
+
+PGDLLEXPORT bits8 *pgx_ARR_NULLBITMAP(ArrayType *arr);
+bits8 *pgx_ARR_NULLBITMAP(ArrayType *arr) {
+    return ARR_NULLBITMAP(arr);
+}
+
+PGDLLEXPORT int pgx_ARR_NDIM(ArrayType *arr);
+int pgx_ARR_NDIM(ArrayType *arr) {
+    return ARR_NDIM(arr);
+}
+
+PGDLLEXPORT bool pgx_ARR_HASNULL(ArrayType *arr);
+bool pgx_ARR_HASNULL(ArrayType *arr) {
+    return ARR_HASNULL(arr);
 }

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -240,6 +240,11 @@ mod all_versions {
         pub fn pgx_list_nth_oid(list: *mut super::List, nth: i32) -> super::Oid;
         pub fn pgx_list_nth_cell(list: *mut super::List, nth: i32) -> *mut super::ListCell;
         pub fn pgx_GETSTRUCT(tuple: pg_sys::HeapTuple) -> *mut std::os::raw::c_char;
+        pub fn pgx_ARR_DATA_PTR(arrayType: *mut pg_sys::ArrayType) -> *mut u8;
+        pub fn pgx_ARR_NELEMS(arrayType: *mut pg_sys::ArrayType) -> i32;
+        pub fn pgx_ARR_NDIM(arrayType: *mut pg_sys::ArrayType) -> i32;
+        pub fn pgx_ARR_NULLBITMAP(arrayType: *mut pg_sys::ArrayType) -> *mut pg_sys::bits8;
+        pub fn pgx_ARR_HASNULL(arrayType: *mut pg_sys::ArrayType) -> bool;
     }
 
     #[inline]
@@ -444,6 +449,42 @@ mod all_versions {
             >,
             context: *mut ::std::os::raw::c_void,
         ) -> bool;
+    }
+
+    #[inline]
+    pub fn get_arr_data_ptr<T>(arr: *mut super::ArrayType) -> *mut T {
+        unsafe { pgx_ARR_DATA_PTR(arr) as *mut T }
+    }
+
+    #[inline]
+    pub fn get_arr_nelems(arr: *mut super::ArrayType) -> i32 {
+        unsafe { pgx_ARR_NELEMS(arr) }
+    }
+
+    #[inline]
+    pub fn get_arr_ndim(arr: *mut super::ArrayType) -> i32 {
+        unsafe { pgx_ARR_NDIM(arr) }
+    }
+
+    #[inline]
+    pub fn get_arr_nullbitmap<'a>(arr: *mut super::ArrayType) -> &'a [pg_sys::bits8] {
+        unsafe {
+            let len = (pgx_ARR_NELEMS(arr) + 7) / 8;
+            std::slice::from_raw_parts(pgx_ARR_NULLBITMAP(arr), len as usize)
+        }
+    }
+
+    #[inline]
+    pub fn get_arr_nullbitmap_mut<'a>(arr: *mut super::ArrayType) -> &'a mut [u8] {
+        unsafe {
+            let len = (pgx_ARR_NELEMS(arr) + 7) / 8;
+            std::slice::from_raw_parts_mut(pgx_ARR_NULLBITMAP(arr), len as usize)
+        }
+    }
+
+    #[inline]
+    pub fn get_arr_hasnull(arr: *mut super::ArrayType) -> bool {
+        unsafe { pgx_ARR_HASNULL(arr) }
     }
 }
 

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -240,11 +240,6 @@ mod all_versions {
         pub fn pgx_list_nth_oid(list: *mut super::List, nth: i32) -> super::Oid;
         pub fn pgx_list_nth_cell(list: *mut super::List, nth: i32) -> *mut super::ListCell;
         pub fn pgx_GETSTRUCT(tuple: pg_sys::HeapTuple) -> *mut std::os::raw::c_char;
-        pub fn pgx_ARR_DATA_PTR(arrayType: *mut pg_sys::ArrayType) -> *mut u8;
-        pub fn pgx_ARR_NELEMS(arrayType: *mut pg_sys::ArrayType) -> i32;
-        pub fn pgx_ARR_NDIM(arrayType: *mut pg_sys::ArrayType) -> i32;
-        pub fn pgx_ARR_NULLBITMAP(arrayType: *mut pg_sys::ArrayType) -> *mut pg_sys::bits8;
-        pub fn pgx_ARR_HASNULL(arrayType: *mut pg_sys::ArrayType) -> bool;
     }
 
     #[inline]
@@ -449,42 +444,6 @@ mod all_versions {
             >,
             context: *mut ::std::os::raw::c_void,
         ) -> bool;
-    }
-
-    #[inline]
-    pub fn get_arr_data_ptr<T>(arr: *mut super::ArrayType) -> *mut T {
-        unsafe { pgx_ARR_DATA_PTR(arr) as *mut T }
-    }
-
-    #[inline]
-    pub fn get_arr_nelems(arr: *mut super::ArrayType) -> i32 {
-        unsafe { pgx_ARR_NELEMS(arr) }
-    }
-
-    #[inline]
-    pub fn get_arr_ndim(arr: *mut super::ArrayType) -> i32 {
-        unsafe { pgx_ARR_NDIM(arr) }
-    }
-
-    #[inline]
-    pub fn get_arr_nullbitmap<'a>(arr: *mut super::ArrayType) -> &'a [pg_sys::bits8] {
-        unsafe {
-            let len = (pgx_ARR_NELEMS(arr) + 7) / 8;
-            std::slice::from_raw_parts(pgx_ARR_NULLBITMAP(arr), len as usize)
-        }
-    }
-
-    #[inline]
-    pub fn get_arr_nullbitmap_mut<'a>(arr: *mut super::ArrayType) -> &'a mut [u8] {
-        unsafe {
-            let len = (pgx_ARR_NELEMS(arr) + 7) / 8;
-            std::slice::from_raw_parts_mut(pgx_ARR_NULLBITMAP(arr), len as usize)
-        }
-    }
-
-    #[inline]
-    pub fn get_arr_hasnull(arr: *mut super::ArrayType) -> bool {
-        unsafe { pgx_ARR_HASNULL(arr) }
     }
 }
 

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -108,18 +108,10 @@ fn get_arr_nelems(arr: Array<i32>) -> libc::c_int {
 
 #[pg_extern]
 fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
-    let len = arr.len();
-    let arr_type = arr.into_array_type();
-
     unsafe {
-        let ptr = array::get_arr_data_ptr::<i32>(arr_type as *mut ArrayType);
-        let elem = elem as usize;
-        let data = std::slice::from_raw_parts(ptr, len);
-        if elem < len {
-            Some(data[elem])
-        } else {
-            None
-        }
+        let raw = RawArray::from_array(arr).unwrap().data_slice::<i32>();
+        let slice = &(*raw.as_ptr());
+        slice.get(elem as usize).copied()
     }
 }
 

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -102,9 +102,8 @@ fn return_zero_length_vec() -> Vec<i32> {
 }
 
 #[pg_extern]
-fn get_arr_nelems(arr: Array<i32>) -> i32 {
-    let arr_type = arr.into_array_type();
-    array::get_arr_nelems(arr_type as *mut ArrayType)
+fn get_arr_nelems(arr: Array<i32>) -> libc::c_int {
+    unsafe { RawArray::from_array(arr).unwrap().len() }
 }
 
 #[pg_extern]

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use pgx::array::ArrayPtr;
+use pgx::array::{ArrayPtr, RawArray};
 use pgx::*;
 use serde_json::*;
 
@@ -114,7 +114,7 @@ unsafe fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
     // SAFETY: this is Known to be an Array from ArrayType,
     // and the index has to be a valid one.
     unsafe {
-        let raw = ArrayPtr::from_array(arr).unwrap().data::<i32>();
+        let raw = RawArray::from_valid(ArrayPtr::from_array(arr).unwrap()).data::<i32>();
         let slice = &(*raw.as_ptr());
         slice.get(elem as usize).copied()
     }
@@ -122,7 +122,7 @@ unsafe fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
 
 #[pg_extern]
 fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
-    let raw = unsafe { ArrayPtr::from_array(arr) }.unwrap();
+    let raw = unsafe { RawArray::from_valid(ArrayPtr::from_array(arr).unwrap()) };
 
     if let Some(slice) = raw.nulls() {
         // SAFETY: If the test has gotten this far, the ptr is good for 0+ bytes,

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -125,7 +125,8 @@ fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
     let raw = unsafe { RawArray::from_array(arr) }.unwrap();
 
     if let Some(slice) = raw.nulls() {
-        // SAFETY: If the test has gotten this far, the ptr is good for 0+ bytes.
+        // SAFETY: If the test has gotten this far, the ptr is good for 0+ bytes,
+        // so reborrow NonNull<[u8]> as &[u8] for the hot second we're looking at it.
         let slice = unsafe { &*slice.as_ptr() };
         // might panic if the array is len 0
         format!("{:#010b}", slice[0])

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -7,6 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
+use pgx::array::RawArray;
 use pgx::{pg_sys::ArrayType, *};
 use serde_json::*;
 
@@ -135,9 +136,8 @@ fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
 }
 
 #[pg_extern]
-fn get_arr_ndim(arr: Array<i32>) -> i32 {
-    let arr_type = arr.into_array_type();
-    array::get_arr_ndim(arr_type as *mut ArrayType)
+fn get_arr_ndim(arr: Array<i32>) -> libc::c_int {
+    unsafe { RawArray::from_array(arr).unwrap().ndims() }
 }
 
 #[pg_extern]

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -138,7 +138,7 @@ fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
 #[pg_extern]
 fn get_arr_ndim(arr: Array<i32>) -> libc::c_int {
     // SAFETY: This is a valid ArrayType and it's just a field access.
-    unsafe { ArrayPtr::from_array(arr) .unwrap().ndims() }
+    unsafe { ArrayPtr::from_array(arr).unwrap().ndims() }
 }
 
 #[pg_extern]

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use pgx::array::{ArrayPtr, RawArray};
+use pgx::array::RawArray;
 use pgx::*;
 use serde_json::*;
 
@@ -103,7 +103,7 @@ fn return_zero_length_vec() -> Vec<i32> {
 #[pg_extern]
 fn get_arr_nelems(arr: Array<i32>) -> libc::c_int {
     // SAFETY: Eh it's fine, it's just a len check.
-    unsafe { ArrayPtr::from_array(arr).unwrap().len() }
+    unsafe { RawArray::from_array(arr) }.unwrap().len() as _
 }
 
 /// # Safety
@@ -114,7 +114,7 @@ unsafe fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
     // SAFETY: this is Known to be an Array from ArrayType,
     // and the index has to be a valid one.
     unsafe {
-        let raw = RawArray::from_valid(ArrayPtr::from_array(arr).unwrap()).data::<i32>();
+        let raw = RawArray::from_array(arr).unwrap().data::<i32>();
         let slice = &(*raw.as_ptr());
         slice.get(elem as usize).copied()
     }
@@ -122,7 +122,7 @@ unsafe fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
 
 #[pg_extern]
 fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
-    let raw = unsafe { RawArray::from_valid(ArrayPtr::from_array(arr).unwrap()) };
+    let raw = unsafe { RawArray::from_array(arr) }.unwrap();
 
     if let Some(slice) = raw.nulls() {
         // SAFETY: If the test has gotten this far, the ptr is good for 0+ bytes,
@@ -138,13 +138,13 @@ fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
 #[pg_extern]
 fn get_arr_ndim(arr: Array<i32>) -> libc::c_int {
     // SAFETY: This is a valid ArrayType and it's just a field access.
-    unsafe { ArrayPtr::from_array(arr).unwrap().ndims() }
+    unsafe { RawArray::from_array(arr).unwrap().ndims() }
 }
 
 #[pg_extern]
 fn get_arr_hasnull(arr: Array<i32>) -> bool {
     // SAFETY: This is a valid ArrayType and it's just a field access.
-    unsafe { ArrayPtr::from_array(arr).unwrap().nullable() }
+    unsafe { RawArray::from_array(arr).unwrap().nullable() }
 }
 
 #[pg_extern]

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -109,7 +109,7 @@ fn get_arr_nelems(arr: Array<i32>) -> libc::c_int {
 #[pg_extern]
 fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
     unsafe {
-        let raw = RawArray::from_array(arr).unwrap().data_slice::<i32>();
+        let raw = RawArray::from_array(arr).unwrap().data::<i32>();
         let slice = &(*raw.as_ptr());
         slice.get(elem as usize).copied()
     }

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -106,13 +106,10 @@ fn get_arr_nelems(arr: Array<i32>) -> libc::c_int {
     unsafe { RawArray::from_array(arr) }.unwrap().len() as _
 }
 
-/// # Safety
-/// Don't call with an actually-null index, or you might see an invalid value.
 #[pg_extern]
-#[deny(unsafe_op_in_unsafe_fn)]
-unsafe fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
+fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
     // SAFETY: this is Known to be an Array from ArrayType,
-    // and the index has to be a valid one.
+    // and it's valid-ish to see any bitpattern of an i32 inbounds of a slice.
     unsafe {
         let raw = RawArray::from_array(arr).unwrap().data::<i32>();
         let slice = &(*raw.as_ptr());

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -102,16 +102,16 @@ fn return_zero_length_vec() -> Vec<i32> {
 #[pg_extern]
 fn get_arr_nelems(arr: Array<i32>) -> i32 {
     let arr_type = arr.into_array_type();
-    pg_sys::get_arr_nelems(arr_type as *mut ArrayType)
+    array::get_arr_nelems(arr_type as *mut ArrayType)
 }
 
 #[pg_extern]
 fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
     let len = arr.len();
     let arr_type = arr.into_array_type();
-    let ptr = pg_sys::get_arr_data_ptr::<i32>(arr_type as *mut ArrayType);
 
     unsafe {
+        let ptr = array::get_arr_data_ptr::<i32>(arr_type as *mut ArrayType);
         let elem = elem as usize;
         let data = std::slice::from_raw_parts(ptr, len);
         if elem < len {
@@ -126,8 +126,8 @@ fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
 fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
     let arr_type = arr.into_array_type();
 
-    if pg_sys::get_arr_hasnull(arr_type as *mut ArrayType) {
-        let bitmap_slice = pg_sys::get_arr_nullbitmap(arr_type as *mut ArrayType);
+    if array::get_arr_hasnull(arr_type as *mut ArrayType) {
+        let bitmap_slice = array::get_arr_nullbitmap(arr_type as *mut ArrayType);
         format!("{:#010b}", bitmap_slice[0])
     } else {
         String::from("")
@@ -137,13 +137,13 @@ fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
 #[pg_extern]
 fn get_arr_ndim(arr: Array<i32>) -> i32 {
     let arr_type = arr.into_array_type();
-    pg_sys::get_arr_ndim(arr_type as *mut ArrayType)
+    array::get_arr_ndim(arr_type as *mut ArrayType)
 }
 
 #[pg_extern]
 fn get_arr_hasnull(arr: Array<i32>) -> bool {
     let arr_type = arr.into_array_type();
-    pg_sys::get_arr_hasnull(arr_type as *mut ArrayType)
+    array::get_arr_hasnull(arr_type as *mut ArrayType)
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use pgx::array::RawArray;
+use pgx::array::ArrayPtr;
 use pgx::*;
 use serde_json::*;
 
@@ -103,7 +103,7 @@ fn return_zero_length_vec() -> Vec<i32> {
 #[pg_extern]
 fn get_arr_nelems(arr: Array<i32>) -> libc::c_int {
     // SAFETY: Eh it's fine, it's just a len check.
-    unsafe { RawArray::from_array(arr).unwrap().len() }
+    unsafe { ArrayPtr::from_array(arr).unwrap().len() }
 }
 
 /// # Safety
@@ -114,7 +114,7 @@ unsafe fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
     // SAFETY: this is Known to be an Array from ArrayType,
     // and the index has to be a valid one.
     unsafe {
-        let raw = RawArray::from_array(arr).unwrap().data::<i32>();
+        let raw = ArrayPtr::from_array(arr).unwrap().data::<i32>();
         let slice = &(*raw.as_ptr());
         slice.get(elem as usize).copied()
     }
@@ -122,7 +122,7 @@ unsafe fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
 
 #[pg_extern]
 fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
-    let raw = unsafe { RawArray::from_array(arr) }.unwrap();
+    let raw = unsafe { ArrayPtr::from_array(arr) }.unwrap();
 
     if let Some(slice) = raw.nulls() {
         // SAFETY: If the test has gotten this far, the ptr is good for 0+ bytes,
@@ -138,13 +138,13 @@ fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
 #[pg_extern]
 fn get_arr_ndim(arr: Array<i32>) -> libc::c_int {
     // SAFETY: This is a valid ArrayType and it's just a field access.
-    unsafe { RawArray::from_array(arr).unwrap().ndims() }
+    unsafe { ArrayPtr::from_array(arr) .unwrap().ndims() }
 }
 
 #[pg_extern]
 fn get_arr_hasnull(arr: Array<i32>) -> bool {
     // SAFETY: This is a valid ArrayType and it's just a field access.
-    unsafe { RawArray::from_array(arr).unwrap().nullable() }
+    unsafe { ArrayPtr::from_array(arr).unwrap().nullable() }
 }
 
 #[pg_extern]

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -138,13 +138,7 @@ fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
 #[pg_extern]
 fn get_arr_ndim(arr: Array<i32>) -> libc::c_int {
     // SAFETY: This is a valid ArrayType and it's just a field access.
-    unsafe { RawArray::from_array(arr).unwrap().ndims() }
-}
-
-#[pg_extern]
-fn get_arr_hasnull(arr: Array<i32>) -> bool {
-    // SAFETY: This is a valid ArrayType and it's just a field access.
-    unsafe { RawArray::from_array(arr).unwrap().nullable() }
+    unsafe { RawArray::from_array(arr) }.unwrap().dims().len() as _
 }
 
 #[pg_extern]

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -1,3 +1,6 @@
+use crate::datum::{Array, FromDatum};
+use crate::pg_sys;
+use core::ptr::NonNull;
 use pgx_pg_sys::*;
 
 extern "C" {
@@ -16,14 +19,6 @@ pub unsafe fn get_arr_data_ptr<T>(arr: *mut ArrayType) -> *mut T {
 #[inline]
 pub fn get_arr_nelems(arr: *mut ArrayType) -> i32 {
     unsafe { pgx_ARR_NELEMS(arr) }
-}
-
-#[inline]
-pub fn get_arr_ndim(arr: *mut ArrayType) -> i32 {
-    extern "C" {
-        pub fn pgx_ARR_NDIM(arrayType: *mut ArrayType) -> i32;
-    }
-    unsafe { pgx_ARR_NDIM(arr) }
 }
 
 #[inline]
@@ -56,5 +51,81 @@ pub fn get_arr_dims<'a>(arr: *mut ArrayType) -> &'a [i32] {
     unsafe {
         let len = (*arr).ndim;
         std::slice::from_raw_parts(pgx_ARR_DIMS(arr), len as usize)
+    }
+}
+
+/// Handle describing a bare, "untyped" pointer to an array,
+/// offering safe accessors to the various fields of one.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct RawArray {
+    at: NonNull<ArrayType>,
+}
+
+#[deny(unsafe_op_in_unsafe_fn)]
+impl RawArray {
+    // General implementation notes:
+    // RawArray is not Copy or Clone, making it harder to misuse versus *mut ArrayType.
+    // But this also offers safe accessors to the fields, like &ArrayType,
+    // so it requires validity assertions in order to be constructed.
+
+    /// Returns a handle to the raw array header.
+    ///
+    /// # Safety
+    ///
+    /// When calling this method, you have to ensure that all of the following is true:
+    /// * The pointer must be properly aligned.
+    /// * It must be "dereferenceable" in the sense defined in [the std documentation].
+    /// * The pointer must point to an initialized instance of `ArrayType`.
+    /// * You aren't going to alias the data like mad.
+    ///
+    /// It should be noted as RawArray is not inherently lifetime-bound, it can be racy and unsafe!
+    ///
+    /// [the std documentation]: core::ptr#safety
+    pub unsafe fn from_raw(at: NonNull<ArrayType>) -> RawArray {
+        // SAFETY: the caller must guarantee that `self` meets all the
+        // requirements for a mutable reference, as we're going to treat this like one.
+        RawArray { at }
+    }
+
+    /// # Safety
+    ///
+    /// Array must have been constructed from an ArrayType pointer.
+    pub unsafe fn from_array<T: FromDatum>(arr: Array<T>) -> Option<RawArray> {
+        let array_type = arr.into_array_type() as *mut _;
+        Some(RawArray {
+            at: NonNull::new(array_type)?,
+        })
+    }
+
+    /// Returns the inner raw pointer to the ArrayType.
+    pub fn into_raw(self) -> NonNull<ArrayType> {
+        self.at
+    }
+
+    /// Get the number of dimensions.
+    pub fn ndims(&self) -> libc::c_int {
+        // SAFETY: Validity asserted on construction.
+        unsafe {
+            (*self.at.as_ptr()).ndim
+            // FIXME: While this is a c_int, the max ndim is normally 6
+            // While the value can be set higher, it is... unlikely
+            // that it is going to actually challenge even 16-bit pointer widths.
+            // It would be preferable to return a usize instead,
+            // however, PGX has trouble with that, unfortunately.
+            as _
+        }
+    }
+
+    pub fn oid(&self) -> pg_sys::Oid {
+        // SAFETY: Validity asserted on construction.
+        unsafe { (*self.at.as_ptr()).elemtype }
+    }
+
+    /// Gets the offset to the ArrayType's data.
+    /// Note that this should not be "taken literally".
+    pub fn data_offset(&self) -> libc::c_int {
+        // SAFETY: Validity asserted on construction.
+        unsafe { (*self.at.as_ptr()).dataoffset }
     }
 }

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -38,12 +38,6 @@ pub fn get_arr_nullbitmap_mut<'a>(arr: *mut ArrayType) -> &'a mut [u8] {
 }
 
 #[inline]
-pub fn get_arr_hasnull(arr: *mut ArrayType) -> bool {
-    // copied from array.h
-    unsafe { (*arr).dataoffset != 0 }
-}
-
-#[inline]
 pub fn get_arr_dims<'a>(arr: *mut ArrayType) -> &'a [i32] {
     extern "C" {
         pub fn pgx_ARR_DIMS(arrayType: *mut ArrayType) -> *mut i32;
@@ -127,5 +121,12 @@ impl RawArray {
     pub fn data_offset(&self) -> libc::c_int {
         // SAFETY: Validity asserted on construction.
         unsafe { (*self.at.as_ptr()).dataoffset }
+    }
+
+    /// Equivalent to ARR_HASNULL(ArrayType*)
+    /// Note this means that it only asserts that there MIGHT be a null
+    pub fn nullable(&self) -> bool {
+        // copied from postgres/src/include/utils/array.h
+        self.data_offset() != 0
     }
 }

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -18,8 +18,19 @@ extern "C" {
     fn pgx_ARR_NULLBITMAP(arrayType: *mut ArrayType) -> *mut bits8;
 }
 
-/// Handle describing a bare, "untyped" pointer to an array,
-/// offering safe accessors to the various fields of one.
+/// Handle describing a bare, "untyped" pointer to a Postgres varlena array,
+/// offering safe accessors to the various fields of the ArrayType,
+/// and access to the various slices that are implicitly present in the varlena.
+///
+/// # On sizes and subscripts
+///
+/// Postgres uses C's `int` (`c_int` in Rust) for sizes, and Rust uses `usize`.
+/// Thus various functions of RawArray return `c_int` values, but you must convert to usize.
+/// On 32-bit or 64-bit machines with 32-bit `c_int`s, you can losslessly upgrade to `as usize`,
+/// except with negative indices, which Postgres asserts against creating.
+/// PGX currently only intentionally supports 64-bit machines,
+/// and while support for ILP32 or I64LP128 C data models may become possible,
+/// PGX will **not** support 16-bit machines in any practical case, even though Rust does.
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct RawArray {

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -190,6 +190,9 @@ impl RawArray {
 
     Note that unlike the `is_null: bool` that appears elsewhere, here a 0 bit is null,
     or possibly out of bounds for the final byte of the bitslice.
+
+    Note that if this is None, that does not mean it's always okay to read!
+    If len is 0, then this slice will be valid for 0 bytes.
     */
     pub fn nulls(&self) -> Option<NonNull<[u8]>> {
         // for expected behavior, see:
@@ -237,6 +240,9 @@ impl RawArray {
     The first element should be correctly aligned to the type, but that is not certain.
     Successive indices are even less likely to match the data type you want
     unless Postgres also uses an identical layout.
+
+    This returns a slice to make it somewhat harder to fail to read it correctly.
+    However, it should be noted that a len 0 slice may not be read via raw pointers.
 
     [MaybeUninit]: core::mem::MaybeUninit
     [nonnull]: core::ptr::NonNull

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -143,27 +143,6 @@ impl RawArray {
         }
     }
 
-    /**
-    The ability to rewrite the dimensions slice.
-
-    You almost certainly do not actually want to call this,
-    unless you intentionally stored the actually intended ndim and wrote 0 instead.
-    Returns a triple tuple of
-    * a mutable reference to the underlying ArrayType's ndim field
-    * a pointer to the first c_int of the dimensions slice
-    * a mutable reference to RawArray's len field
-
-    Write to them in order.
-    */
-    pub unsafe fn dims_mut(&mut self) -> (&mut libc::c_int, NonNull<libc::c_int>, &mut usize) {
-        // SAFETY: Validity asserted on construction, origin ptr is non-null.
-        let dims_ptr = unsafe { NonNull::new_unchecked(pgx_ARR_DIMS(self.ptr.as_ptr())) };
-        let len = &mut self.len;
-
-        // SAFETY: Validity asserted on construction. Just reborrowing a subfield.
-        (unsafe { &mut self.ptr.as_mut().ndim }, dims_ptr, len)
-    }
-
     /// The flattened length of the array over every single element.
     /// Includes all items, even the ones that might be null.
     pub fn len(&self) -> usize {

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -140,11 +140,12 @@ impl RawArray {
     /**
     The ability to rewrite the dimensions slice.
 
-    You almost certainly do not actually want to call this.
+    You almost certainly do not actually want to call this,
+    unless you intentionally stored the actually intended ndim and wrote 0 instead.
     Returns a triple tuple of
-    * a mutable reference to ndim,
-    * a pointer to the first c_int
-    * a mutable reference to RawArray's len field.
+    * a mutable reference to the underlying ArrayType's ndim field
+    * a pointer to the first c_int of the dimensions slice
+    * a mutable reference to RawArray's len field
 
     Write to them in order.
     */
@@ -184,7 +185,15 @@ impl RawArray {
         self.data_offset() != 0
     }
 
-    /// Oxidized form of ARR_NULLBITMAP(ArrayType*)
+    /**
+    Oxidized form of ARR_NULLBITMAP(ArrayType*)
+
+    If this returns None, the array cannot have nulls.
+    If this returns Some, it points to the bitslice that marks nulls in this array.
+
+    Note that unlike the `is_null: bool` that appears elsewhere, here a 0 bit is null,
+    or possibly out of bounds for the final byte of the bitslice.
+    */
     pub fn nulls(&self) -> Option<NonNull<[u8]>> {
         // for expected behavior, see:
         // postgres/src/include/utils/array.h

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -181,9 +181,6 @@ impl RawArray {
         // This is because, while the initial pointer is NonNull,
         // ARR_NULLBITMAP can return a nullptr!
         let nulls = unsafe { slice_from_raw_parts_mut(pgx_ARR_NULLBITMAP(self.at.as_ptr()), len) };
-        // This code doesn't assert validity per se, but in practice,
-        // the caller will probably immediately turn this into a borrowed slice,
-        // opening up the methods that are available on borrowed slices.
         Some(NonNull::new(nulls)?)
     }
 

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -267,7 +267,7 @@ impl RawArray {
     fn into_ptr(self) -> ArrayPtr {
         self.ptr
     }
-    
+
     /// Oxidized form of ARR_NULLBITMAP(ArrayType*)
     pub fn nulls(&self) -> Option<NonNull<[u8]>> {
         // for expected behavior, see:
@@ -280,7 +280,9 @@ impl RawArray {
         // it isn't correct to trust it. Instead, this gets null-checked.
         // This is because, while the initial pointer is NonNull,
         // ARR_NULLBITMAP can return a nullptr!
-        Some(unsafe { NonNull::new_unchecked(slice_from_raw_parts_mut(self.ptr.nulls()?.as_ptr(), len)) } )
+        Some(unsafe {
+            NonNull::new_unchecked(slice_from_raw_parts_mut(self.ptr.nulls()?.as_ptr(), len))
+        })
     }
 
     /// # Safety
@@ -297,6 +299,11 @@ impl RawArray {
         // Most importantly, the caller has asserted this is in fact a valid [T],
         // by calling this function, so both this code and the caller can rely
         // on that assertion, only requiring that it is correct.
-        unsafe { NonNull::new_unchecked(slice_from_raw_parts_mut(self.ptr.data::<T>().as_ptr(), self.len)) }
+        unsafe {
+            NonNull::new_unchecked(slice_from_raw_parts_mut(
+                self.ptr.data::<T>().as_ptr(),
+                self.len,
+            ))
+        }
     }
 }

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -4,10 +4,18 @@ use core::ptr::{slice_from_raw_parts_mut, NonNull};
 use pgx_pg_sys::*;
 
 extern "C" {
-    pub fn pgx_ARR_NELEMS(arrayType: *mut ArrayType) -> i32;
-    pub fn pgx_ARR_NULLBITMAP(arrayType: *mut ArrayType) -> *mut bits8;
-    pub fn pgx_ARR_DATA_PTR(arrayType: *mut ArrayType) -> *mut u8;
-    pub fn pgx_ARR_DIMS(arrayType: *mut ArrayType) -> *mut libc::c_int;
+    /// # Safety
+    /// Does a field access, but doesn't deref out of bounds of ArrayType
+    fn pgx_ARR_DATA_PTR(arrayType: *mut ArrayType) -> *mut u8;
+    /// # Safety
+    /// Does a field access, but doesn't deref out of bounds of ArrayType
+    fn pgx_ARR_DIMS(arrayType: *mut ArrayType) -> *mut libc::c_int;
+    /// # Safety
+    /// Must only be used on a "valid" (Postgres-constructed) ArrayType
+    fn pgx_ARR_NELEMS(arrayType: *mut ArrayType) -> i32;
+    /// # Safety
+    /// Does a field access, but doesn't deref out of bounds of ArrayType
+    fn pgx_ARR_NULLBITMAP(arrayType: *mut ArrayType) -> *mut bits8;
 }
 
 /// Handle describing a bare, "untyped" pointer to an array,

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -205,7 +205,7 @@ impl RawArray {
 
     Note that if this is None, that does not mean it's always okay to read!
     If len is 0, then this slice will be valid for 0 bytes.
-    
+
     [ARR_NULLBITMAP]: <https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/utils/array.h;h=4ae6c3be2f8b57afa38c19af2779f67c782e4efc;hb=278273ccbad27a8834dfdf11895da9cd91de4114#l293>
     */
     pub fn nulls(&self) -> Option<NonNull<[u8]>> {

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -150,9 +150,10 @@ impl RawArray {
 
     /// Gets the offset to the ArrayType's data.
     /// Note that this should not be "taken literally".
-    pub fn data_offset(&self) -> libc::c_int {
+    fn data_offset(&self) -> i32 {
         // SAFETY: Validity asserted on construction.
         unsafe { (*self.at.as_ptr()).dataoffset }
+        // This field is an "int32" in Postgres
     }
 
     /// Equivalent to ARR_HASNULL(ArrayType*)

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -1,0 +1,60 @@
+use pgx_pg_sys::*;
+
+extern "C" {
+    pub fn pgx_ARR_NELEMS(arrayType: *mut ArrayType) -> i32;
+    pub fn pgx_ARR_NULLBITMAP(arrayType: *mut ArrayType) -> *mut bits8;
+}
+
+#[inline]
+pub unsafe fn get_arr_data_ptr<T>(arr: *mut ArrayType) -> *mut T {
+    extern "C" {
+        pub fn pgx_ARR_DATA_PTR(arrayType: *mut ArrayType) -> *mut u8;
+    }
+    pgx_ARR_DATA_PTR(arr) as *mut T
+}
+
+#[inline]
+pub fn get_arr_nelems(arr: *mut ArrayType) -> i32 {
+    unsafe { pgx_ARR_NELEMS(arr) }
+}
+
+#[inline]
+pub fn get_arr_ndim(arr: *mut ArrayType) -> i32 {
+    extern "C" {
+        pub fn pgx_ARR_NDIM(arrayType: *mut ArrayType) -> i32;
+    }
+    unsafe { pgx_ARR_NDIM(arr) }
+}
+
+#[inline]
+pub fn get_arr_nullbitmap<'a>(arr: *mut ArrayType) -> &'a [bits8] {
+    unsafe {
+        let len = (pgx_ARR_NELEMS(arr) + 7) / 8;
+        std::slice::from_raw_parts(pgx_ARR_NULLBITMAP(arr), len as usize)
+    }
+}
+
+#[inline]
+pub fn get_arr_nullbitmap_mut<'a>(arr: *mut ArrayType) -> &'a mut [u8] {
+    unsafe {
+        let len = (pgx_ARR_NELEMS(arr) + 7) / 8;
+        std::slice::from_raw_parts_mut(pgx_ARR_NULLBITMAP(arr), len as usize)
+    }
+}
+
+#[inline]
+pub fn get_arr_hasnull(arr: *mut ArrayType) -> bool {
+    // copied from array.h
+    unsafe { (*arr).dataoffset != 0 }
+}
+
+#[inline]
+pub fn get_arr_dims<'a>(arr: *mut ArrayType) -> &'a [i32] {
+    extern "C" {
+        pub fn pgx_ARR_DIMS(arrayType: *mut ArrayType) -> *mut i32;
+    }
+    unsafe {
+        let len = (*arr).ndim;
+        std::slice::from_raw_parts(pgx_ARR_DIMS(arr), len as usize)
+    }
+}

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -137,6 +137,24 @@ impl RawArray {
         }
     }
 
+    /**
+    The ability to rewrite the dimensions slice.
+
+    You almost certainly do not actually want to call this.
+    Returns a triple tuple of
+    * a mutable reference to ndim,
+    * a pointer to the first c_int
+    * a mutable reference to RawArray's len field.
+
+    Write to them in order.
+    */
+    pub unsafe fn dims_mut(&mut self) -> (&mut libc::c_int, NonNull<libc::c_int>, &mut usize) {
+        let dims_ptr = unsafe { NonNull::new_unchecked(pgx_ARR_DIMS(self.ptr.as_ptr())) };
+        let len = &mut self.len;
+
+        (unsafe { &mut self.ptr.as_mut().ndim }, dims_ptr, len)
+    }
+
     /// The flattened length of the array.
     pub fn len(&self) -> usize {
         self.len

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -126,7 +126,7 @@ impl RawArray {
     /// Equivalent to ARR_HASNULL(ArrayType*)
     /// Note this means that it only asserts that there MIGHT be a null
     pub fn nullable(&self) -> bool {
-        // copied from postgres/src/include/utils/array.h
+        // must match postgres/src/include/utils/array.h #define ARR_HASNULL
         self.data_offset() != 0
     }
 }

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -1,8 +1,8 @@
 use crate::datum::{Array, FromDatum};
 use crate::pg_sys;
 use core::ptr::{slice_from_raw_parts_mut, NonNull};
-use pgx_pg_sys::*;
 use core::slice;
+use pgx_pg_sys::*;
 
 extern "C" {
     /// # Safety
@@ -130,10 +130,7 @@ impl RawArray {
         */
         unsafe {
             let ndim = self.ndim() as usize;
-            slice::from_raw_parts(
-                pgx_ARR_DIMS(self.ptr.as_ptr()),
-                ndim,
-            )
+            slice::from_raw_parts(pgx_ARR_DIMS(self.ptr.as_ptr()), ndim)
         }
     }
 
@@ -201,7 +198,7 @@ impl RawArray {
 
         let len = self.len + 7 >> 3; // Obtains 0 if len was 0.
 
-        /* 
+        /*
         SAFETY: This obtains the nulls pointer, which is valid to obtain because
         the len was asserted on construction. However, unlike the other cases,
         it isn't correct to trust it. Instead, this gets null-checked.

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -188,9 +188,18 @@ impl RawArray {
     /// But even if the index is not marked as null, the value may be equal to nullptr,
     /// thus leaving it correct to read the value but incorrect to then dereference.
     ///
-    /// That is why this returns `NonNull<[T]>`: if it returned `&mut [T]`,
-    /// then for many possible types, that would actually be UB, as it would assert
-    /// that each particular index was a valid `T`.
+    /// That is why this returns [`NonNull<[T]>`]: if it returned `&mut [T]`,
+    /// then for many possible types that can be **undefined behavior**,
+    /// as it would assert that each particular index was a valid `T`.
+    /// A Rust borrow, including of a slice, will always be
+    /// - non-null
+    /// - aligned
+    /// - **validly initialized**, except in the case of [MaybeUninit] types
+    /// It can be incorrect to assume that data that Postgres has marked "null"
+    /// follows Rust-level initialization requirements.
+    ///
+    /// [MaybeUninit]: core::mem::MaybeUninit
+    /// [`NonNull<[T]>`]: core::ptr::NonNull
     pub unsafe fn data<T>(&mut self) -> NonNull<[T]> {
         let len = self.len() as usize;
 

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -109,11 +109,13 @@ impl RawArray {
         // SAFETY: Validity asserted on construction.
         unsafe {
             (*self.ptr.as_ptr()).ndim
-            // FIXME: While this is a c_int, the max ndim is normally 6
-            // While the value can be set higher, it is... unlikely
-            // that it is going to actually challenge even 16-bit pointer widths.
-            // It would be preferable to return a usize instead,
-            // however, PGX has trouble with that, unfortunately.
+            /*
+            FIXME: While this is a c_int, the max ndim is normally 6
+            While the value can be set higher, it is... unlikely
+            that it is going to actually challenge even 16-bit pointer widths.
+            It would be preferable to return a usize instead,
+            however, PGX has trouble with that, unfortunately.
+            */
             as _
         }
     }
@@ -209,10 +211,6 @@ impl RawArray {
     [ARR_NULLBITMAP]: <https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/utils/array.h;h=4ae6c3be2f8b57afa38c19af2779f67c782e4efc;hb=278273ccbad27a8834dfdf11895da9cd91de4114#l293>
     */
     pub fn nulls(&self) -> Option<NonNull<[u8]>> {
-        // for expected behavior, see:
-        // postgres/src/include/utils/array.h
-        // #define ARR_NULLBITMAP
-
         let len = self.len + 7 >> 3; // Obtains 0 if len was 0.
 
         /*

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -61,8 +61,6 @@ impl RawArray {
     ///
     /// [the std documentation]: core::ptr#safety
     pub unsafe fn from_raw(at: NonNull<ArrayType>) -> RawArray {
-        // SAFETY: the caller must guarantee that `self` meets all the
-        // requirements for a mutable reference, as we're going to treat this like one.
         RawArray { at }
     }
 
@@ -160,7 +158,9 @@ impl RawArray {
     /// Equivalent to ARR_HASNULL(ArrayType*)
     /// Note this means that it only asserts that there MIGHT be a null
     pub fn nullable(&self) -> bool {
-        // must match postgres/src/include/utils/array.h #define ARR_HASNULL
+        // for expected behavior, see:
+        // postgres/src/include/utils/array.h
+        // #define ARR_HASNULL
         self.data_offset() != 0
     }
 

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -46,6 +46,7 @@ pub mod itemptr;
 pub mod list;
 #[macro_use]
 pub mod log;
+pub mod array;
 pub mod atomics;
 pub mod bgworkers;
 pub mod heap_tuple;


### PR DESCRIPTION
These PG function shims will allow for future work to improve the `pgx::Array<T>` type, as well as manual access to ArrayType data in the meantime.