### PR TITLE
Eliminate duplicate function modifiers.

### DIFF
--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -106,6 +106,8 @@ impl ToSql for PgExternEntity {
         if strict_upgrade {
             extern_attrs.push(ExternArgs::Strict);
         }
+        extern_attrs.sort();
+        extern_attrs.dedup();
 
         let module_pathname = &context.get_module_pathname();
 


### PR DESCRIPTION
Some conditions cause the `STRICT` function modifier to be added to the `extern_attrs` list multiple times, which causes misbehavior like #639.

Closes #639.