### PR TITLE
Opaque Timestamp/Tz types

### DIFF
--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -7,80 +7,131 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::datum::time::USECS_PER_SEC;
-use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum, TimestampWithTimeZone};
-use std::ops::{Deref, DerefMut};
-use time::{format_description::FormatItem, PrimitiveDateTime};
+use crate::{pg_sys, FromDatum, IntoDatum, TimestampConversionError, TimestampWithTimeZone};
+use std::ffi::CStr;
 
-#[derive(Debug, Copy, Clone)]
-pub struct Timestamp(time::PrimitiveDateTime);
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Timestamp(pg_sys::Timestamp);
 
-impl From<pg_sys::Timestamp> for Timestamp {
-    fn from(item: pg_sys::Timestamp) -> Self {
-        unsafe { Timestamp::from_datum(item.into(), false).unwrap() }
-    }
-}
+impl Timestamp {
+    pub const NEG_INFINITY: Self = Timestamp(i64::MIN);
+    pub const INFINITY: Self = Timestamp(i64::MAX);
 
-impl FromDatum for Timestamp {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Timestamp> {
-        let ts: Option<TimestampWithTimeZone> = TimestampWithTimeZone::from_datum(datum, is_null);
-        match ts {
-            None => None,
-            Some(ts) => {
-                let date = ts.date();
-                let time = ts.time();
+    pub fn is_infinity(&self) -> bool {
+        self == &Self::INFINITY
+    }
 
-                Some(Timestamp(PrimitiveDateTime::new(date, time)))
-            }
-        }
+    #[inline]
+    pub fn is_neg_infinity(&self) -> bool {
+        self == &Self::NEG_INFINITY
+    }
+
+    #[inline]
+    #[deprecated(
+        since = "0.5.0",
+        note = "the repr of pgx::Timestamp is no longer time::PrimitiveDateTime \
+    and this fn will be removed in a future version"
+    )]
+    pub fn new(timestamp: time::PrimitiveDateTime) -> Self {
+        let tstz = TryInto::<TimestampWithTimeZone>::try_into(timestamp)
+            .expect("unable to convert time::PrimitiveDateTime to pgx::TimestampWithTimeZone");
+        tstz.into()
     }
 }
+
+impl From<TimestampWithTimeZone> for Timestamp {
+    fn from(tstz: TimestampWithTimeZone) -> Self {
+        Timestamp(tstz.into())
+    }
+}
+
+impl From<Timestamp> for TimestampWithTimeZone {
+    fn from(ts: Timestamp) -> Self {
+        ts.0.try_into()
+            .expect("error converting Timestamp to TimestampWithTimeZone")
+    }
+}
+
+impl From<Timestamp> for i64 {
+    fn from(ts: Timestamp) -> Self {
+        ts.0
+    }
+}
+
+impl TryFrom<pg_sys::Timestamp> for Timestamp {
+    type Error = TimestampConversionError;
+
+    fn try_from(value: pg_sys::Timestamp) -> Result<Self, Self::Error> {
+        TryInto::<TimestampWithTimeZone>::try_into(value).map(|tstz| tstz.into())
+    }
+}
+
+impl TryFrom<pg_sys::Datum> for Timestamp {
+    type Error = TimestampConversionError;
+
+    fn try_from(datum: pg_sys::Datum) -> Result<Self, Self::Error> {
+        (datum.value() as pg_sys::Timestamp).try_into()
+    }
+}
+
+impl TryFrom<time::OffsetDateTime> for Timestamp {
+    type Error = TimestampConversionError;
+
+    fn try_from(offset: time::OffsetDateTime) -> Result<Self, Self::Error> {
+        TryInto::<TimestampWithTimeZone>::try_into(offset).map(|tstz| tstz.into())
+    }
+}
+
+impl TryFrom<Timestamp> for time::PrimitiveDateTime {
+    type Error = TimestampConversionError;
+
+    fn try_from(ts: Timestamp) -> Result<Self, Self::Error> {
+        let tstz: TimestampWithTimeZone = ts.into();
+        TryInto::<time::PrimitiveDateTime>::try_into(tstz)
+    }
+}
+
+impl TryFrom<time::PrimitiveDateTime> for Timestamp {
+    type Error = TimestampConversionError;
+
+    fn try_from(datetime: time::PrimitiveDateTime) -> Result<Self, Self::Error> {
+        TryInto::<TimestampWithTimeZone>::try_into(datetime).map(|tstz| tstz.into())
+    }
+}
+
+impl TryFrom<Timestamp> for time::OffsetDateTime {
+    type Error = TimestampConversionError;
+    fn try_from(ts: Timestamp) -> Result<Self, Self::Error> {
+        let tstz: TimestampWithTimeZone = ts.into();
+        tstz.try_into()
+    }
+}
+
 impl IntoDatum for Timestamp {
-    #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let year = self.year();
-        let month = self.month() as i32;
-        let mday = self.day() as i32;
-        let hour = self.hour() as i32;
-        let minute = self.minute() as i32;
-        let second = self.second() as f64 + (self.microsecond() as f64 / USECS_PER_SEC as f64);
-
-        unsafe {
-            direct_function_call_as_datum(
-                pg_sys::make_timestamp,
-                vec![
-                    year.into_datum(),
-                    month.into_datum(),
-                    mday.into_datum(),
-                    hour.into_datum(),
-                    minute.into_datum(),
-                    second.into_datum(),
-                ],
-            )
-        }
+        Some(pg_sys::Datum::from(self.0))
     }
-
     fn type_oid() -> u32 {
         pg_sys::TIMESTAMPOID
     }
 }
-impl Timestamp {
-    pub fn new(timestamp: time::PrimitiveDateTime) -> Self {
-        Timestamp(timestamp)
-    }
-}
 
-impl Deref for Timestamp {
-    type Target = time::PrimitiveDateTime;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl DerefMut for Timestamp {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl FromDatum for Timestamp {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            Some(
+                datum
+                    .try_into()
+                    .expect("Error converting timestamp with time zone datum"),
+            )
+        }
     }
 }
 
@@ -92,32 +143,54 @@ impl serde::Serialize for Timestamp {
     where
         S: serde::Serializer,
     {
-        if self.millisecond() > 0 {
-            serializer.serialize_str(
-                &self
-                    .format(
-                        &time::format_description::parse(&format!(
-                            "[year]-[month]-[day]T[hour]:[minute]:[second].{}-00",
-                            self.millisecond()
-                        ))
-                        .map_err(|e| {
-                            serde::ser::Error::custom(format!(
-                                "Timestamp invalid format problem: {:?}",
-                                e
-                            ))
-                        })?,
-                    )
-                    .map_err(|e| {
-                        serde::ser::Error::custom(format!("Timestamp formatting problem: {:?}", e))
-                    })?,
-            )
-        } else {
-            serializer.serialize_str(&self.format(&DEFAULT_TIMESTAMP_FORMAT).map_err(|e| {
-                serde::ser::Error::custom(format!("Timestamp formatting problem: {:?}", e))
-            })?)
+        let cstr;
+        assert!(pg_sys::MAXDATELEN > 0); // free at runtime
+        const BUF_LEN: usize = pg_sys::MAXDATELEN as usize * 2;
+        let mut buffer = [0u8; BUF_LEN];
+        let buf = buffer.as_mut_slice().as_mut_ptr().cast::<libc::c_char>();
+        // SAFETY: This provides a quite-generous writing pad to Postgres
+        // and Postgres has promised to use far less than this.
+        unsafe {
+            match self {
+                &Self::NEG_INFINITY | &Self::INFINITY => {
+                    pg_sys::EncodeSpecialTimestamp(self.0, buf);
+                }
+                _ => {
+                    let mut pg_tm: pg_sys::pg_tm = pg_sys::pg_tm {
+                        tm_zone: std::ptr::null_mut(),
+                        ..Default::default()
+                    };
+                    let mut tz = 0i32;
+                    let mut fsec = 0 as pg_sys::fsec_t;
+                    let mut tzn = std::ptr::null::<std::os::raw::c_char>();
+                    pg_sys::timestamp2tm(
+                        self.0,
+                        &mut tz,
+                        &mut pg_tm,
+                        &mut fsec,
+                        &mut tzn,
+                        std::ptr::null_mut(),
+                    );
+                    pg_sys::EncodeDateTime(
+                        &mut pg_tm,
+                        fsec,
+                        false,
+                        0,
+                        std::ptr::null::<std::os::raw::c_char>(),
+                        pg_sys::USE_XSD_DATES as i32,
+                        buf,
+                    );
+                }
+            }
+            assert!(buffer[BUF_LEN - 1] == 0);
+            cstr = CStr::from_ptr(buf);
         }
+
+        /* This unwrap is fine as Postgres won't ever write invalid UTF-8,
+           because Postgres only writes ASCII
+        */
+        serializer
+            .serialize_str(cstr.to_str().unwrap())
+            .map_err(|e| serde::ser::Error::custom(format!("Date formatting problem: {:?}", e)))
     }
 }
-
-static DEFAULT_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
-    time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]-00");

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -8,141 +8,167 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::datum::time::USECS_PER_SEC;
-use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
-use std::{
-    convert::TryFrom,
-    ops::{Deref, DerefMut},
-};
-use time::{format_description::FormatItem, UtcOffset};
+use crate::{pg_sys, FromDatum, IntoDatum};
+use std::convert::TryFrom;
+use std::ffi::CStr;
+use std::ops::Sub;
+use time::{macros::date, UtcOffset};
 
-#[derive(Debug, Copy, Clone)]
-pub struct TimestampWithTimeZone(time::OffsetDateTime);
+const PG_EPOCH_OFFSET: time::OffsetDateTime = date!(2000 - 01 - 01).midnight().assume_utc();
+const PG_EPOCH_DATETIME: time::PrimitiveDateTime = date!(2000 - 01 - 01).midnight();
 
-impl From<pg_sys::TimestampTz> for TimestampWithTimeZone {
-    fn from(item: pg_sys::TimestampTz) -> Self {
-        unsafe { TimestampWithTimeZone::from_datum(item.into(), false).unwrap() }
-    }
-}
+// taken from /include/datatype/timestamp.h
+const MIN_TIMESTAMP_USEC: i64 = -211_813_488_000_000_000;
+const END_TIMESTAMP_USEC: i64 = 9_223_371_331_200_000_000;
 
-impl From<time::OffsetDateTime> for TimestampWithTimeZone {
-    fn from(time: time::OffsetDateTime) -> Self {
-        TimestampWithTimeZone(time)
-    }
-}
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct TimestampWithTimeZone(pg_sys::TimestampTz);
 
-impl FromDatum for TimestampWithTimeZone {
+impl TimestampWithTimeZone {
+    pub const NEG_INFINITY: Self = TimestampWithTimeZone(i64::MIN);
+    pub const INFINITY: Self = TimestampWithTimeZone(i64::MAX);
+
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<TimestampWithTimeZone> {
-        if is_null {
-            None
-        } else {
-            let mut tm = pg_sys::pg_tm {
-                tm_sec: 0,
-                tm_min: 0,
-                tm_hour: 0,
-                tm_mday: 0,
-                tm_mon: 0,
-                tm_year: 0,
-                tm_wday: 0,
-                tm_yday: 0,
-                tm_isdst: 0,
-                tm_gmtoff: 0,
-                tm_zone: std::ptr::null_mut(),
-            };
-            let mut tz = 0i32;
-            let mut fsec = 0 as pg_sys::fsec_t;
-            let mut tzn = std::ptr::null::<std::os::raw::c_char>();
-            pg_sys::timestamp2tm(
-                datum.value() as i64,
-                &mut tz,
-                &mut tm,
-                &mut fsec,
-                &mut tzn,
-                std::ptr::null_mut(),
-            );
-            let date = time::Date::from_calendar_date(
-                tm.tm_year,
-                time::Month::try_from(tm.tm_mon as u8)
-                    .expect("Got month outside of range in TimestampWithTimeZone::from_datum"),
-                tm.tm_mday as u8,
-            )
-            .expect("failed to create date from TimestampWithTimeZone");
+    pub fn is_infinity(&self) -> bool {
+        self == &Self::INFINITY
+    }
 
-            let time = time::Time::from_hms_micro(
-                tm.tm_hour as u8,
-                tm.tm_min as u8,
-                tm.tm_sec as u8,
-                fsec as u32,
-            )
-            .expect("failed to create time from TimestampWithTimeZonez");
+    #[inline]
+    pub fn is_neg_infinity(&self) -> bool {
+        self == &Self::NEG_INFINITY
+    }
 
-            Some(TimestampWithTimeZone(
-                time::PrimitiveDateTime::new(date, time)
-                    .assume_utc()
-                    .to_offset(
-                        UtcOffset::from_whole_seconds(tz)
-                            .expect("Unexpected error in `UtcOffset::from_whole_seconds` during `TimestampWithTimeZone::from_datum`")
-                    ),
-            ))
+    #[inline]
+    #[deprecated(
+        since = "0.5.0",
+        note = "the repr of pgx::TimestampWithTimeZone is no longer time::OffsetDateTime \
+    and this fn will be removed in a future version"
+    )]
+    pub fn new(time: time::PrimitiveDateTime, at_tz_offset: UtcOffset) -> Self {
+        let offset = time.assume_utc()
+                        .to_offset(
+                            UtcOffset::from_whole_seconds(-at_tz_offset.whole_seconds())
+                                .expect("Unexpected error in `UtcOffset::from_whole_seconds` during `TimestampWithTimeZone::new`")
+                        );
+        offset
+            .try_into()
+            .expect("unable to convert time::PrimitiveDateTime to pgx::TimestampWithTimeZone")
+    }
+}
+
+impl From<TimestampWithTimeZone> for i64 {
+    fn from(tstz: TimestampWithTimeZone) -> Self {
+        tstz.0
+    }
+}
+
+impl TryFrom<pg_sys::TimestampTz> for TimestampWithTimeZone {
+    type Error = TimestampConversionError;
+
+    fn try_from(value: pg_sys::TimestampTz) -> Result<Self, Self::Error> {
+        let usec = value as i64;
+        match usec {
+            i64::MIN => Ok(Self::NEG_INFINITY),
+            i64::MAX => Ok(Self::INFINITY),
+            // https://github.com/rust-lang/rust/issues/37854 for funny exlusive range guard
+            MIN_TIMESTAMP_USEC..=END_TIMESTAMP_USEC if usec < END_TIMESTAMP_USEC => {
+                Ok(TimestampWithTimeZone(usec))
+            }
+            _ => Err(TimestampConversionError::OutOfRangeMicroseconds),
         }
+    }
+}
+
+impl TryFrom<pg_sys::Datum> for TimestampWithTimeZone {
+    type Error = TimestampConversionError;
+    fn try_from(datum: pg_sys::Datum) -> Result<Self, Self::Error> {
+        (datum.value() as pg_sys::TimestampTz).try_into()
+    }
+}
+
+impl TryFrom<time::OffsetDateTime> for TimestampWithTimeZone {
+    type Error = TimestampConversionError;
+    fn try_from(offset: time::OffsetDateTime) -> Result<Self, Self::Error> {
+        let usecs = offset.sub(PG_EPOCH_OFFSET).whole_microseconds() as i64;
+        usecs.try_into()
+    }
+}
+
+impl TryFrom<TimestampWithTimeZone> for time::PrimitiveDateTime {
+    type Error = TimestampConversionError;
+    fn try_from(tstz: TimestampWithTimeZone) -> Result<Self, Self::Error> {
+        match tstz {
+            TimestampWithTimeZone::NEG_INFINITY => {
+                Err(TimestampConversionError::TimestampNegativeInfinity)
+            }
+            TimestampWithTimeZone::INFINITY => Err(TimestampConversionError::TimestampInfinity),
+            _ => {
+                let sec = tstz.0 / USECS_PER_SEC;
+                let usec = tstz.0 - (sec * USECS_PER_SEC);
+                let duration = time::Duration::new(sec, (usec as i32) * 1000);
+                match PG_EPOCH_DATETIME.checked_add(duration) {
+                    Some(datetime) => Ok(datetime),
+                    None => Err(TimestampConversionError::TimeCrateConversionError),
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<time::PrimitiveDateTime> for TimestampWithTimeZone {
+    type Error = TimestampConversionError;
+
+    fn try_from(datetime: time::PrimitiveDateTime) -> Result<Self, Self::Error> {
+        let offset = datetime.assume_utc();
+        offset.try_into()
+    }
+}
+
+impl TryFrom<TimestampWithTimeZone> for time::OffsetDateTime {
+    type Error = TimestampConversionError;
+    fn try_from(tstz: TimestampWithTimeZone) -> Result<Self, Self::Error> {
+        let datetime: time::PrimitiveDateTime = tstz.try_into()?;
+        Ok(datetime.assume_utc())
     }
 }
 
 impl IntoDatum for TimestampWithTimeZone {
-    #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let year = self.year();
-        let month = self.month() as i32;
-        let mday = self.day() as i32;
-        let hour = self.hour() as i32;
-        let minute = self.minute() as i32;
-        let second = self.second() as f64 + (self.microsecond() as f64 / USECS_PER_SEC as f64);
-
-        unsafe {
-            direct_function_call_as_datum(
-                pg_sys::make_timestamptz_at_timezone,
-                vec![
-                    year.into_datum(),
-                    month.into_datum(),
-                    mday.into_datum(),
-                    hour.into_datum(),
-                    minute.into_datum(),
-                    second.into_datum(),
-                    "UTC".into_datum(),
-                ],
-            )
-        }
+        Some(pg_sys::Datum::from(self.0))
     }
-
     fn type_oid() -> u32 {
         pg_sys::TIMESTAMPTZOID
     }
 }
 
-impl TimestampWithTimeZone {
-    /// This shifts the provided `time` back to UTC
-    pub fn new(time: time::PrimitiveDateTime, at_tz_offset: time::UtcOffset) -> Self {
-        TimestampWithTimeZone(
-            time.assume_utc()
-                .to_offset(
-                    UtcOffset::from_whole_seconds(-at_tz_offset.whole_seconds())
-                        .expect("Unexpected error in `UtcOffset::from_whole_seconds` during `TimestampWithTimeZone::new`")
-                ),
-        )
+impl FromDatum for TimestampWithTimeZone {
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            Some(
+                datum
+                    .try_into()
+                    .expect("Error converting timestamp with time zone datum"),
+            )
+        }
     }
 }
 
-impl Deref for TimestampWithTimeZone {
-    type Target = time::OffsetDateTime;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl DerefMut for TimestampWithTimeZone {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum TimestampConversionError {
+    #[error("timestamp value is negative infinity and shouldn't map to time::PrimitiveDateTime")]
+    TimestampNegativeInfinity,
+    #[error("timestamp value is negative infinity and shouldn't map to time::PrimitiveDateTime")]
+    TimestampInfinity,
+    #[error("time::PrimitiveDateTime was unable to convert this timestamp")]
+    TimeCrateConversionError,
+    #[error("usec outside of PG's defined Timestamp range")]
+    OutOfRangeMicroseconds,
 }
 
 impl serde::Serialize for TimestampWithTimeZone {
@@ -153,42 +179,54 @@ impl serde::Serialize for TimestampWithTimeZone {
     where
         S: serde::Serializer,
     {
-        if self.millisecond() > 0 {
-            serializer.serialize_str(
-                &self
-                    .format(
-                        &time::format_description::parse(&format!(
-                            "[year]-[month]-[day]T[hour]:[minute]:[second].{}-00",
-                            self.millisecond()
-                        ))
-                        .map_err(|e| {
-                            serde::ser::Error::custom(format!(
-                                "TimeStampWithTimeZone invalid format problem: {:?}",
-                                e
-                            ))
-                        })?,
-                    )
-                    .map_err(|e| {
-                        serde::ser::Error::custom(format!(
-                            "TimeStampWithTimeZone formatting problem: {:?}",
-                            e
-                        ))
-                    })?,
-            )
-        } else {
-            serializer.serialize_str(
-                &self
-                    .format(&DEFAULT_TIMESTAMP_WITH_TIMEZONE_FORMAT)
-                    .map_err(|e| {
-                        serde::ser::Error::custom(format!(
-                            "TimeStampWithTimeZone formatting problem: {:?}",
-                            e
-                        ))
-                    })?,
-            )
+        let cstr;
+        assert!(pg_sys::MAXDATELEN > 0); // free at runtime
+        const BUF_LEN: usize = pg_sys::MAXDATELEN as usize * 2;
+        let mut buffer = [0u8; BUF_LEN];
+        let buf = buffer.as_mut_slice().as_mut_ptr().cast::<libc::c_char>();
+        // SAFETY: This provides a quite-generous writing pad to Postgres
+        // and Postgres has promised to use far less than this.
+        unsafe {
+            match self {
+                &Self::NEG_INFINITY | &Self::INFINITY => {
+                    pg_sys::EncodeSpecialTimestamp(self.0, buf);
+                }
+                _ => {
+                    let mut pg_tm: pg_sys::pg_tm = pg_sys::pg_tm {
+                        tm_zone: std::ptr::null_mut(),
+                        ..Default::default()
+                    };
+                    let mut tz = 0i32;
+                    let mut fsec = 0 as pg_sys::fsec_t;
+                    let mut tzn = std::ptr::null::<std::os::raw::c_char>();
+                    pg_sys::timestamp2tm(
+                        self.0,
+                        &mut tz,
+                        &mut pg_tm,
+                        &mut fsec,
+                        &mut tzn,
+                        std::ptr::null_mut(),
+                    );
+                    pg_sys::EncodeDateTime(
+                        &mut pg_tm,
+                        fsec,
+                        true,
+                        tz,
+                        tzn,
+                        pg_sys::USE_XSD_DATES as i32,
+                        buf,
+                    );
+                }
+            }
+            assert!(buffer[BUF_LEN - 1] == 0);
+            cstr = CStr::from_ptr(buf);
         }
+
+        /* This unwrap is fine as Postgres won't ever write invalid UTF-8,
+           because Postgres only writes ASCII
+        */
+        serializer
+            .serialize_str(cstr.to_str().unwrap())
+            .map_err(|e| serde::ser::Error::custom(format!("Date formatting problem: {:?}", e)))
     }
 }
-
-static DEFAULT_TIMESTAMP_WITH_TIMEZONE_FORMAT: &[FormatItem<'static>] =
-    time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]-00");


### PR DESCRIPTION
Similar to `pgx::Date` I've made `pgx::Timestamp` and `pgx::TimestampWithTimeZone` simply represented by their `i64` microsecond datum.  Also `+/-infinity` is supported.  Various `TryFrom` implementations will provide conversions to/from `time::PrimitiveDateTime` and `time::OffsetDateTime`.  Note that conversion will lose any embedded timezones as that is not part of the storage datum, but applied by PG at display time.

I moved the serialization #[test] to #[pg_test] so that serialization can leverage PG's built in serialization. This is especially important for boundary case and +/- infinity.