### PR TITLE
Calling "cargo pgx install" from build script always enables --release

### DIFF
--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -33,7 +33,7 @@ pub(crate) struct Install {
     #[clap(long, parse(from_os_str))]
     manifest_path: Option<PathBuf>,
     /// Compile for release mode (default is debug)
-    #[clap(env = "PROFILE", long, short)]
+    #[clap(long, short)]
     release: bool,
     /// Build in test mode (for `cargo pgx test`)
     #[clap(long)]


### PR DESCRIPTION
The `PROFILE` env var is set by cargo within build scripts.
I believe clap is setting the `release` field to `true` when `PROFILE` is set regardless of whether it is set to `debug` or `release` as I assume it is coercing any non-empty string to `true`.
Since cargo respects the `PROFILE` env var it should just inherit without explicit argument passing.