### PR TITLE
Input functions should take Option

### DIFF
--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -773,8 +773,13 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
 
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_in #generics(input: &#lifetime pgx::cstr_core::CStr) -> #name #generics {
-                #name::input(input)
+            pub fn #funcname_in #generics(input: Option<&#lifetime pgx::cstr_core::CStr>) -> Option<#name #generics> {
+                input.map_or_else(|| {
+                    for m in #name::NULL_ERROR_MESSAGE {
+                        pgx::error!("{}", m);
+                    }
+                    None
+                }, |i| Some(#name::input(i)))
             }
 
             #[doc(hidden)]
@@ -791,8 +796,13 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
         stream.extend(quote! {
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_in #generics(input: &#lifetime pgx::cstr_core::CStr) -> #name #generics {
-                #name::input(input)
+            pub fn #funcname_in #generics(input: Option<&#lifetime pgx::cstr_core::CStr>) -> Option<#name #generics> {
+                input.map_or_else(|| {
+                    for m in #name::NULL_ERROR_MESSAGE {
+                        pgx::error!("{}", m);
+                    }
+                    None
+                }, |i| Some(#name::input(i)))
             }
 
             #[doc(hidden)]
@@ -808,8 +818,13 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
         stream.extend(quote! {
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_in #generics(input: &#lifetime pgx::cstr_core::CStr) -> pgx::PgVarlena<#name #generics> {
-                #name::input(input)
+            pub fn #funcname_in #generics(input: Option<&#lifetime pgx::cstr_core::CStr>) -> Option<pgx::PgVarlena<#name #generics>> {
+                input.map_or_else(|| {
+                    for m in #name::NULL_ERROR_MESSAGE {
+                        pgx::error!("{}", m);
+                    }
+                    None
+                }, |i| Some(#name::input(i)))
             }
 
             #[doc(hidden)]

--- a/pgx/src/inoutfuncs.rs
+++ b/pgx/src/inoutfuncs.rs
@@ -27,6 +27,10 @@ pub trait PgVarlenaInOutFuncs {
 
     /// Convert `Self` into text by writing to the supplied `StringInfo` buffer
     fn output(&self, buffer: &mut StringInfo);
+
+    /// If PostgreSQL calls the conversion function with NULL as an argument, what
+    /// error message should be generated?
+    const NULL_ERROR_MESSAGE: Option<&'static str> = None;
 }
 
 /// `#[derive(Serialize, Deserialize, PostgresType)]` types may implement this trait if they prefer
@@ -41,6 +45,10 @@ pub trait InOutFuncs {
 
     /// Convert `Self` into text by writing to the supplied `StringInfo` buffer
     fn output(&self, buffer: &mut StringInfo);
+
+    /// If PostgreSQL calls the conversion function with NULL as an argument, what
+    /// error message should be generated?
+    const NULL_ERROR_MESSAGE: Option<&'static str> = None;
 }
 
 /// Automatically implemented for `#[derive(Serialize, Deserialize, PostgresType)]` types that do
@@ -59,4 +67,8 @@ pub trait JsonInOutFuncs<'de>: serde::de::Deserialize<'de> + serde::ser::Seriali
     {
         serde_json::to_writer(buffer, self).expect("failed to serialize to json")
     }
+
+    /// If PostgreSQL calls the conversion function with NULL as an argument, what
+    /// error message should be generated?
+    const NULL_ERROR_MESSAGE: Option<&'static str> = None;
 }


### PR DESCRIPTION
This PR contrasts with [PR 641](https://github.com/tcdi/pgx/pull/641). The primary motivation here is that the various input functions take optional arguments, and produce optional results. This is implemented by changing the interface in `pgx/src/inoutfuncs.rs`, then the macro in `pgx-macros/src/lib.rs`, then teaching the SQL generator that this is acceptable in `pgx/src/datum/mod.rs`. Finally, I changed all the implementations of those functions that I could find, so that `cargo test --workspace` passes with these changes.