### PR TITLE
Skip initdb during cargo pgx init if `$USER == "root"`

### DIFF
--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -19,8 +19,8 @@ use pgx_utils::{
 use rayon::prelude::*;
 
 use std::collections::HashMap;
-use std::fs::File;
 use std::env;
+use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::Stdio;


### PR DESCRIPTION
## Notes 
In some use case, we would set up rust toolchain and pgx as root user, we do not necessarily need pgx to spin up running postgres instance. However during `cargo pgx init`, as pgx is trying to `initdb` for postgres, it will fail to do so since `initdb` cannot be executed as root user.

## Changes
If current user is root user, skip doing `initdb`.

## Testing

`cargo test --features pg14 --no-default-features` passed

```
> ls -l ~/.pgx   
total 0

> cargo pgx init --pg14 /usr/local/pgsql/bin/pg_config 
   Validating /usr/local/pgsql/bin/pg_config
 Initializing data directory at /Users/antholeu/.pgx/data-14

> ls -l ~/.pgx                                        
total 8
drwx------  24 antholeu  staff   768B Aug 25 16:36 data-14
-rw-r--r--   1 antholeu  staff    48B Aug 25 16:36 config.toml
```

```
> ls -l ~/.pgx                                             
total 0

> sudo cargo pgx init --pg14 /usr/local/pgsql/bin/pg_config
   Validating /usr/local/pgsql/bin/pg_config
   Skipping initdb as current user is root user

> ls -l ~/.pgx                                             
total 8
-rw-r--r--  1 root  staff    48B Aug 25 16:37 config.toml
```
