### PR TITLE
Refactor to use NonNull in datum::Array

### DIFF
--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -139,6 +139,7 @@ fn get_arr_ndim(arr: Array<i32>) -> libc::c_int {
 }
 
 #[pg_extern]
+#[allow(deprecated)]
 fn over_implicit_drop() -> Vec<i64> {
     // Create an array of exactly Datum-sized numbers.
     let mut vec: Vec<i64> = vec![1, 2, 3, 4, 5];

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -54,11 +54,24 @@ impl<'a, T: FromDatum> Array<'a, T> {
     /// - `elements` is non-null
     /// - `nulls` is non-null
     /// - both `elements` and `nulls` point to a slice of equal-or-greater length than `nelems`
+    #[deprecated(
+        since = "0.5.0",
+        note = "creating arbitrary Arrays from raw pointers has unsound interactions!
+    please open an issue in tcdi/pgx if you need this, with your stated use-case"
+    )]
     pub unsafe fn over(
         elements: *mut pg_sys::Datum,
         nulls: *mut bool,
         nelems: usize,
     ) -> Array<'a, T> {
+        // FIXME: This function existing prevents simply using NonNull<varlena>
+        // or NonNull<ArrayType>. It has also caused issues like tcdi/pgx#633
+        // Ideally it would cease being used soon.
+        // It can be replaced with ways to make Postgres varlena arrays in Rust,
+        // if there are any users who desire such a thing.
+        //
+        // Remember to remove the Array::over tests in pgx-tests/src/tests/array_tests.rs
+        // when you finally kill this off.
         let _ptr: Option<NonNull<pg_sys::varlena>> = None;
         let array_type: Option<NonNull<pg_sys::ArrayType>> = None;
         Array::<T> {


### PR DESCRIPTION
This removes a small but, IMO, pointless `panic!` in our exposed call surface. It is not unsafe to return the null pointer. That's why `ptr::null()` is safe to call. `panic!` should be used to avoid unsafe or invalid conditions, not just undesirable ones.

This also begins the deprecation process for `Array::over`.