### PR TITLE
Add `RawArray::nulls_bitslice` with bitvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +809,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1415,6 +1433,7 @@ version = "0.5.0-beta.0"
 dependencies = [
  "atomic-traits",
  "bitflags",
+ "bitvec",
  "cstr_core",
  "enum-primitive-derive",
  "eyre",
@@ -1435,6 +1454,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "uuid",
+ "wyz",
 ]
 
 [[package]]
@@ -1681,6 +1701,12 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2259,6 +2285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,6 +2828,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,6 @@ dependencies = [
  "tracing",
  "tracing-error",
  "uuid",
- "wyz",
 ]
 
 [[package]]

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -119,7 +119,7 @@ fn get_arr_data_ptr_nth_elem(arr: Array<i32>, elem: i32) -> Option<i32> {
 
 #[pg_extern]
 fn display_get_arr_nullbitmap(arr: Array<i32>) -> String {
-    let raw = unsafe { RawArray::from_array(arr) }.unwrap();
+    let mut raw = unsafe { RawArray::from_array(arr) }.unwrap();
 
     if let Some(slice) = raw.nulls() {
         // SAFETY: If the test has gotten this far, the ptr is good for 0+ bytes,

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -34,7 +34,7 @@ rustc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitflags = "1.3.2"
 bitvec = "1.0" # processing array nullbitmaps
-wyz = "0.5"
+wyz = "0.5" # assist crate for bitvec
 cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.15"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -32,6 +32,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+bitflags = "1.3.2"
+bitvec = "1.0" # processing array nullbitmaps
+wyz = "0.5"
 cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.15"
@@ -48,7 +51,6 @@ atomic-traits = "0.3.0"
 heapless = "0.7.13"
 uuid = { version = "1.0.0", features = [ "v4" ] }
 once_cell = "1.10.0"
-bitflags = "1.3.2"
 eyre = "0.6.8"
 tracing = "0.1.34"
 tracing-error = "0.2.0"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -34,7 +34,6 @@ rustc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitflags = "1.3.2"
 bitvec = "1.0" # processing array nullbitmaps
-wyz = "0.5" # assist crate for bitvec
 cstr_core = "0.2.5"
 enum-primitive-derive = "0.2.2"
 num-traits = "0.2.15"

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -205,6 +205,18 @@ impl RawArray {
     }
 
     /**
+    Checks the array for any NULL values by assuming it is a proper varlena array,
+
+    # Safety
+
+    * This requires every index is valid to read or correctly marked as null.
+    */
+    pub unsafe fn any_nulls(&self) -> bool {
+        // SAFETY: Caller asserted safety conditions.
+        unsafe { pg_sys::array_contains_nulls(self.ptr.as_ptr()) }
+    }
+
+    /**
     Oxidized form of [ARR_DATA_PTR(ArrayType*)][ARR_DATA_PTR]
 
     # Safety

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -185,6 +185,8 @@ impl RawArray {
     /// May return null.
     #[inline]
     fn nulls_mut_ptr(&mut self) -> *mut u8 {
+        // SAFETY: This isn't public for a reason: it's a maybe-null *mut BitSlice, which is easy to misuse.
+        // Obtaining it, however, is perfectly safe.
         unsafe { pgx_ARR_NULLBITMAP(self.ptr.as_ptr()) }
     }
 

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -1,9 +1,12 @@
 use crate::datum::{Array, FromDatum};
-use bitvec::{prelude::*, ptr::{bitslice_from_raw_parts_mut,BitPtrError, BitPtr}};
-use wyz::comu::NullPtrError;
-use crate::pg_sys::{self, ArrayType, bits8};
+use crate::pg_sys::{self, bits8, ArrayType};
+use bitvec::{
+    prelude::*,
+    ptr::{bitslice_from_raw_parts_mut, BitPtr, BitPtrError},
+};
 use core::ptr::{slice_from_raw_parts_mut, NonNull};
 use core::slice;
+use wyz::comu::NullPtrError;
 
 extern "C" {
     /// # Safety
@@ -205,9 +208,7 @@ impl RawArray {
         This is because, while the initial pointer is NonNull,
         ARR_NULLBITMAP can return a nullptr!
         */
-        NonNull::new(unsafe {
-            slice_from_raw_parts_mut(self.nulls_mut_ptr(), len)
-        })
+        NonNull::new(unsafe { slice_from_raw_parts_mut(self.nulls_mut_ptr(), len) })
     }
 
     pub fn null_bits(&mut self) -> Result<NonNull<BitSlice<u8>>, BitPtrError<u8>> {
@@ -218,8 +219,9 @@ impl RawArray {
         This is because, while the initial pointer is NonNull,
         ARR_NULLBITMAP can return a nullptr!
         */
-        let ptr = BitPtr::try_from(self.nulls_mut_ptr())?;//, BitIdx::new(0).ok()?).ok()?;
-        NonNull::new(bitslice_from_raw_parts_mut(ptr, self.len)).ok_or(BitPtrError::Null(NullPtrError))
+        let ptr = BitPtr::try_from(self.nulls_mut_ptr())?;
+        NonNull::new(bitslice_from_raw_parts_mut(ptr, self.len))
+            .ok_or(BitPtrError::Null(NullPtrError))
     }
 
     /**

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -230,10 +230,14 @@ impl RawArray {
         This is because, while the initial pointer is NonNull,
         ARR_NULLBITMAP can return a nullptr!
         */
-        let ptr = BitPtr::try_from(self.nulls_mut_ptr()).map_err(|e| match e {
-            BitPtrError::Misaligned(_) => unreachable!("it should be impossible to misalign this"),
-            v => v,
-        }).ok()?;
+        let ptr = BitPtr::try_from(self.nulls_mut_ptr())
+            .map_err(|e| match e {
+                BitPtrError::Misaligned(_) => {
+                    unreachable!("it should be impossible to misalign this")
+                }
+                v => v,
+            })
+            .ok()?;
         NonNull::new(bitslice_from_raw_parts_mut(ptr, self.len))
     }
 

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -232,10 +232,8 @@ impl RawArray {
         */
         let ptr = BitPtr::try_from(self.nulls_mut_ptr())
             .map_err(|e| match e {
-                BitPtrError::Misaligned(_) => {
-                    unreachable!("it should be impossible to misalign this")
-                }
-                v => v,
+                BitPtrError::Null(v) => BitPtrError::<u8>::Null(v),
+                BitPtrError::Misaligned(_) => unreachable!("impossible to misalign *mut u8"),
             })
             .ok()?;
         NonNull::new(bitslice_from_raw_parts_mut(ptr, self.len))

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
+use crate::{array::RawArray, pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 use core::ptr::NonNull;
 use serde::Serializer;
 use std::marker::PhantomData;
@@ -17,7 +17,7 @@ pub type VariadicArray<'a, T> = Array<'a, T>;
 
 pub struct Array<'a, T: FromDatum> {
     _ptr: Option<NonNull<pg_sys::varlena>>,
-    array_type: Option<NonNull<pg_sys::ArrayType>>,
+    raw: Option<RawArray>,
     nelems: usize,
     elem_slice: &'a [pg_sys::Datum],
     null_slice: &'a [bool],
@@ -73,10 +73,10 @@ impl<'a, T: FromDatum> Array<'a, T> {
         // Remember to remove the Array::over tests in pgx-tests/src/tests/array_tests.rs
         // when you finally kill this off.
         let _ptr: Option<NonNull<pg_sys::varlena>> = None;
-        let array_type: Option<NonNull<pg_sys::ArrayType>> = None;
+        let raw: Option<RawArray> = None;
         Array::<T> {
             _ptr,
-            array_type,
+            raw,
             nelems,
             elem_slice: slice::from_raw_parts(elements, nelems),
             null_slice: slice::from_raw_parts(nulls, nelems),
@@ -92,14 +92,14 @@ impl<'a, T: FromDatum> Array<'a, T> {
     /// - both `elements` and `nulls` point to a slice of equal-or-greater length than `nelems`
     unsafe fn from_pg(
         _ptr: Option<NonNull<pg_sys::varlena>>,
-        array_type: Option<NonNull<pg_sys::ArrayType>>,
+        raw: Option<RawArray>,
         elements: *mut pg_sys::Datum,
         nulls: *mut bool,
         nelems: usize,
     ) -> Self {
         Array::<T> {
             _ptr,
-            array_type,
+            raw,
             nelems,
             elem_slice: slice::from_raw_parts(elements, nelems),
             null_slice: slice::from_raw_parts(nulls, nelems),
@@ -107,9 +107,10 @@ impl<'a, T: FromDatum> Array<'a, T> {
         }
     }
 
-    pub fn into_array_type(self) -> *const pg_sys::ArrayType {
-        let ptr = if let Some(at) = self.array_type {
-            at.as_ptr()
+    pub fn into_array_type(mut self) -> *const pg_sys::ArrayType {
+        let at = mem::take(&mut self.raw);
+        let ptr = if let Some(at) = at {
+            at.into_raw().as_ptr()
         } else {
             ptr::null()
         };
@@ -140,8 +141,9 @@ impl<'a, T: FromDatum> Array<'a, T> {
     ///
     /// This function will panic when called if the array contains any SQL NULL values.
     pub fn iter_deny_null(&self) -> ArrayTypedIterator<'_, T> {
-        if let Some(at) = self.array_type {
-            if unsafe { pg_sys::array_contains_nulls(at.as_ptr()) } {
+        if let Some(at) = &self.raw {
+            // SAFETY: if Some, then the ArrayType is from Postgres
+            if unsafe { at.any_nulls() } {
                 panic!("array contains NULL");
             }
         } else {
@@ -274,19 +276,16 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
         } else {
             let ptr = datum.ptr_cast();
             let array = pg_sys::pg_detoast_datum(datum.ptr_cast()) as *mut pg_sys::ArrayType;
-            let array_ref = array.as_ref().expect("ArrayType * was NULL");
+            let raw =
+                RawArray::from_ptr(NonNull::new(array).expect("detoast returned null ArrayType*"));
 
             // outvals for get_typlenbyvalalign()
             let mut typlen = 0;
             let mut typbyval = false;
             let mut typalign = 0;
+            let oid = raw.oid();
 
-            pg_sys::get_typlenbyvalalign(
-                array_ref.elemtype,
-                &mut typlen,
-                &mut typbyval,
-                &mut typalign,
-            );
+            pg_sys::get_typlenbyvalalign(oid, &mut typlen, &mut typbyval, &mut typalign);
 
             // outvals for deconstruct_array()
             let mut elements = ptr::null_mut();
@@ -300,7 +299,7 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
             // So either we don't use this, we use it more conditionally, or something.
             pg_sys::deconstruct_array(
                 array,
-                array_ref.elemtype,
+                oid,
                 typlen as i32,
                 typbyval,
                 typalign,
@@ -311,7 +310,7 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
 
             Some(Array::from_pg(
                 NonNull::new(ptr),
-                NonNull::new(array),
+                Some(raw),
                 elements,
                 nulls,
                 nelems as usize,

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -9,7 +9,6 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::{array::RawArray, pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 use bitvec::slice::BitSlice;
-use core::ops::Index;
 use core::ptr::NonNull;
 use serde::Serializer;
 use std::marker::PhantomData;
@@ -160,7 +159,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
 
         let null_slice = raw
             .null_bits()
-            .map(|nn| NullKind::Bits(unsafe { &*nn.as_ptr() }))
+            .map(|nonnull| NullKind::Bits(unsafe { &*nonnull.as_ptr() }))
             .unwrap_or(NullKind::Strict(nelems));
 
         Array {

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -26,8 +26,9 @@ pub struct Array<'a, T: FromDatum> {
     _marker: PhantomData<T>,
 }
 
-// FIXME: When Array::over gets removed, this enum can be dropped,
+// FIXME: When Array::over gets removed, this enum can probably be dropped
 // since we won't be entertaining ArrayTypes which don't use bitslices anymore.
+// However, we could also use a static resolution? Hard to say what's best.
 enum NullKind<'a> {
     Bits(&'a BitSlice<u8>),
     Bytes(&'a [bool]),
@@ -43,9 +44,9 @@ impl<'a> From<&'a [bool]> for NullKind<'a> {
 impl NullKind<'_> {
     fn get(&self, index: usize) -> Option<bool> {
         match self {
-            Self::Bits(b1) => b1.get(index).map(|b| *b),
-            Self::Bytes(b8) => b8.get(index).map(|b| !b),
-            Self::Strict(len) => index.le(len).then(|| true)
+            Self::Bits(b1) => b1.get(index).map(|b| !b),
+            Self::Bytes(b8) => b8.get(index).map(|b| *b),
+            Self::Strict(len) => index.le(len).then(|| false),
         }
     }
 }
@@ -150,60 +151,18 @@ impl<'a, T: FromDatum> Array<'a, T> {
 
         // Check our RawArray len impl for correctness.
         assert_eq!(nelems, len);
-        let raw = RawArray::from_ptr(NonNull::new_unchecked(array));
+        let mut raw = RawArray::from_ptr(NonNull::new_unchecked(array));
+
+        let null_slice = raw
+            .null_bits()
+            .map(|nn| NullKind::Bits(unsafe { &*nn.as_ptr() }))
+            .unwrap_or(NullKind::Strict(nelems));
 
         Array {
             _ptr,
             raw: Some(raw),
             nelems,
             elem_slice: slice::from_raw_parts(elements, nelems),
-            null_slice: slice::from_raw_parts(nulls, nelems).into(),
-            _marker: PhantomData,
-        }
-    }
-
-    unsafe fn direct_from(
-        _ptr: Option<NonNull<pg_sys::varlena>>,
-        mut raw: RawArray,
-        typlen: libc::c_int,
-        typbyval: bool,
-        typalign: libc::c_char,
-    ) -> Array<'a, T> {
-        let oid = raw.oid();
-        let len = raw.len();
-        // Attempt to handle the array directly.
-        // First, assert on alignment
-        let eval_align = match typalign as u8 {
-            b'c' => 1,
-            b's' => mem::align_of::<libc::c_short>(),
-            b'i' => mem::align_of::<libc::c_int>(),
-            b'd' => mem::align_of::<f64>(),
-            _ => panic!("PGX encountered unfamiliar typalign?"),
-        };
-        let mem_align = mem::align_of::<T>();
-        assert_eq!(
-            eval_align,
-            mem_align,
-            "by-value align mismatch. Postgres said {ch},
-            type was Rust: {rs_ty}, OID#{oid}, Len: {typlen}",
-            ch = char::from(typalign as u8),
-            rs_ty = std::any::type_name::<T>()
-        );
-
-        let elems_raw = raw.data();
-        let nulls_raw = raw.null_bits();
-        let elem_slice = unsafe { &*elems_raw.as_ptr() };
-        let null_slice = match nulls_raw {
-            Ok(raw) => NullKind::Bits(unsafe { &*raw.as_ptr() }),
-            Err(_) => NullKind::Strict(len),
-        };
-
-
-        Array {
-            _ptr,
-            raw: Some(raw),
-            nelems: len,
-            elem_slice,
             null_slice,
             _marker: PhantomData,
         }
@@ -391,13 +350,9 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
             pg_sys::get_typlenbyvalalign(oid, &mut typlen, &mut typbyval, &mut typalign);
             let typlen = typlen as _;
 
-            if typbyval {
-                Some(Array::direct_from(ptr, raw, typlen, typbyval, typalign))
-            } else {
-                Some(Array::deconstruct_from(
-                    ptr, raw, typlen, typbyval, typalign,
-                ))
-            }
+            Some(Array::deconstruct_from(
+                ptr, raw, typlen, typbyval, typalign,
+            ))
         }
     }
 }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -158,7 +158,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
         let mut raw = unsafe { RawArray::from_ptr(NonNull::new_unchecked(array)) };
 
         let null_slice = raw
-            .null_bits()
+            .nulls_bitslice()
             .map(|nonnull| NullKind::Bits(unsafe { &*nonnull.as_ptr() }))
             .unwrap_or(NullKind::Strict(nelems));
 


### PR DESCRIPTION
This is hopefully the penultimate PR in the project to address tcdi/pgx#627.

It lets us start using the ability to handle the bitmaps for the "flat" array repr that Postgres uses internally, directly. It does not really use such, as yet, to completely outmode our usage of `deconstruct_array` where appropriate, because I found larger, more annoying obstacles in the way of changing that (see tcdi/pgx#660). I wanted to introduce this PR first to get some additional eyes on this and because it introduces some additional functionality to our new RawArray type.

cc @mhov