### PR TITLE
Increases verbosity of pgx-tests in various places

### DIFF
--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -127,8 +127,7 @@ pub(crate) fn install_extension(
     let build_command_messages =
         build_command_stream.collect::<Result<Vec<_>, std::io::Error>>()?;
 
-    println!();
-    println!("installing extension");
+    println!("{} extension", "  Installing".bold().green(),);
     let pkgdir = make_relative(pg_config.pkglibdir()?);
     let extdir = make_relative(pg_config.extension_dir()?);
     let shlibpath = find_library_file(&manifest, &build_command_messages)?;
@@ -287,8 +286,14 @@ pub(crate) fn build_extension(
     let command = command.stderr(Stdio::inherit());
     let command_str = format!("{:?}", command);
     println!(
-        "building extension with features `{}`\n{}",
-        features_arg, command_str
+        "{} extension with features {}",
+        "    Building".bold().green(),
+        features_arg.cyan()
+    );
+    println!(
+        "{} command {}",
+        "     Running".bold().green(),
+        command_str.cyan()
     );
     let cargo_output = command
         .output()

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -455,9 +455,7 @@ pub fn createdb(
     let command_str = format!("{:?}", command);
 
     let child = command.spawn().wrap_err_with(|| {
-        format!(
-            "Failed to spawn process for creating database using command: '{command_str}': "
-        )
+        format!("Failed to spawn process for creating database using command: '{command_str}': ")
     })?;
 
     let output = child.wait_with_output().wrap_err_with(|| {

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -456,15 +456,13 @@ pub fn createdb(
 
     let child = command.spawn().wrap_err_with(|| {
         format!(
-            "Failed to spawn process for creating database using command: '{}': ",
-            command_str
+            "Failed to spawn process for creating database using command: '{command_str}': "
         )
     })?;
 
     let output = child.wait_with_output().wrap_err_with(|| {
         format!(
-            "Failed waiting for spawned process attempting to create database using command: '{}': ",
-            command_str
+            "failed waiting for spawned process to create database using command: '{command_str}': "
         )
     })?;
 

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -451,9 +451,22 @@ pub fn createdb(
         .arg(dbname)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+
     let command_str = format!("{:?}", command);
 
-    let output = command.output()?;
+    let child = command.spawn().wrap_err_with(|| {
+        format!(
+            "Failed to spawn process for creating database using command: '{}': ",
+            command_str
+        )
+    })?;
+
+    let output = child.wait_with_output().wrap_err_with(|| {
+        format!(
+            "Failed waiting for spawned process attempting to create database using command: '{}': ",
+            command_str
+        )
+    })?;
 
     if !output.status.success() {
         return Err(eyre!(

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -491,7 +491,7 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
     // add a shutdown hook so we can terminate it when the test framework exits
     add_shutdown_hook(move || unsafe {
         let message_string = std::ffi::CString::new(
-            format!("Stopping Postgres PID {}\n\n", pgpid)
+            format!("stopping postgres (pid={pgpid})\n")
                 .bold()
                 .blue()
                 .to_string(),

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -211,9 +211,7 @@ fn initialize_test_framework(
         // This used to immediately throw an std::process::exit(1), but it
         // would consume both stdout and stderr, resulting in error messages
         // not being displayed unless you were running tests with --nocapture.
-        panic!(
-            "Could not obtain test mutex. Please check for errors in pervious tests to find the root cause."
-        );
+        panic!("Could not obtain test mutex. A previous test may have hard-aborted while holding it.");
     });
 
     if !state.installed {


### PR DESCRIPTION
It was brought up in issue https://github.com/tcdi/pgx/issues/324 that any errors in pgx-tests that resulted from a failed `CREATE EXTENSION` call were not propagated properly back to the user. While some of it could be displayed by running the test with the `--nocapture` flag, it's less than ideal since normal Rust tests would at least output something more meaningful instead of simply saying "failed" as it does in this case.

Upon inspection it turns out that there were other places where more verbose output should be warranted. These changes aims to make other errors more visible as well and include other small tweaks along the way.

Also note that these changes can also be referenced as part of https://github.com/tcdi/pgx/issues/612
