### PR TITLE
Rewrite Spi{Ok,Error} without num-traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,17 +679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
-dependencies = [
- "num-traits",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "env_proxy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,15 +1231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,11 +1396,9 @@ dependencies = [
  "atomic-traits",
  "bitflags",
  "cstr_core",
- "enum-primitive-derive",
  "eyre",
  "heapless",
  "libc",
- "num-traits",
  "once_cell",
  "pgx-macros",
  "pgx-pg-sys",

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -33,8 +33,6 @@ rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 cstr_core = "0.2.5"
-enum-primitive-derive = "0.2.2"
-num-traits = "0.2.15"
 seahash = "4.1.0"
 libc = "0.2.126"
 pgx-macros = { path = "../pgx-macros/", version = "=0.5.0-beta.0" }

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -25,8 +25,6 @@ Use of this source code is governed by the MIT license that can be found in the 
 #![allow(clippy::cast_ptr_alignment)]
 extern crate pgx_macros;
 
-extern crate num_traits;
-
 #[macro_use]
 extern crate bitflags;
 

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -18,6 +18,7 @@ use std::ops::{Index, IndexMut};
 /// These match the Postgres `#define`d constants prefixed `SPI_OK_*` that you can find in `pg_sys`.
 #[derive(Debug, PartialEq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum SpiOk {
     Connect = 1,
     Finish = 2,
@@ -36,7 +37,7 @@ pub enum SpiOk {
     RelRegister = 15,
     RelUnregister = 16,
     TdRegister = 17,
-    #[cfg(feature = "pg15")]
+    /// Added in Postgres 15
     Merge = 18,
 }
 

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -36,6 +36,8 @@ pub enum SpiOk {
     RelRegister = 15,
     RelUnregister = 16,
     TdRegister = 17,
+    #[cfg(feature = "pg15")]
+    Merge = 18,
 }
 
 /// These match the Postgres `#define`d constants prefixed `SPI_ERROR_*` that you can find in `pg_sys`.

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -78,7 +78,7 @@ impl TryFrom<libc::c_int> for SpiOk {
                 // SAFETY: These values are described in SpiError, thus they are inbounds for transmute
                 unsafe { mem::transmute::<i32, SpiError>(err) },
             )),
-            ok @ 1..=17 => Ok(
+            ok @ 1..=18 => Ok(
                 //SAFETY: These values are described in SpiOk, thus they are inbounds for transmute
                 unsafe { mem::transmute::<i32, SpiOk>(ok) },
             ),

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -10,20 +10,20 @@ Use of this source code is governed by the MIT license that can be found in the 
 //! Safe access to Postgres' *Server Programming Interface* (SPI).
 
 use crate::{pg_sys, FromDatum, IntoDatum, Json, PgMemoryContexts, PgOid};
-use enum_primitive_derive::*;
-use num_traits::FromPrimitive;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::mem;
 use std::ops::{Index, IndexMut};
 
-#[derive(Debug, Primitive)]
+#[derive(Debug, PartialEq)]
+#[repr(i32)]
 pub enum SpiOk {
     Connect = 1,
     Finish = 2,
     Fetch = 3,
     Utility = 4,
     Select = 5,
-    Selinto = 6,
+    SelInto = 6,
     Insert = 7,
     Delete = 8,
     Update = 9,
@@ -37,25 +37,61 @@ pub enum SpiOk {
     TdRegister = 17,
 }
 
-#[derive(Debug, Primitive)]
+#[derive(Debug, PartialEq)]
+#[repr(i32)]
 pub enum SpiError {
-    // NB:  These are #define'd as negative, but we redefine them as positive so that
-    // #[derive(Primitive)] will work.  We just need to negate result codes from the
-    // various SPI_xxx functions when looking for errors
-    Connect = 1,
-    Copy = 2,
-    Opunknown = 3,
-    Unconnected = 4,
+    Null = 0,
+    Connect = -1,
+    Copy = -2,
+    OpUnknown = -3,
+    Unconnected = -4,
     #[allow(dead_code)]
-    Cursor = 5, /* not used anymore */
-    Argument = 6,
-    Param = 7,
-    Transaction = 8,
-    Noattribute = 9,
-    Nooutfunc = 10,
-    Typunknown = 11,
-    RelDuplicate = 12,
-    RelNotFound = 13,
+    Cursor = -5, /* not used anymore */
+    Argument = -6,
+    Param = -7,
+    Transaction = -8,
+    NoAttribute = -9,
+    NoOutFunc = -10,
+    TypUnknown = -11,
+    RelDuplicate = -12,
+    RelNotFound = -13,
+}
+
+#[derive(Debug)]
+pub struct UnknownVariant;
+
+impl TryFrom<libc::c_int> for SpiOk {
+    // Yes, this gives us nested results.
+    type Error = Result<SpiError, UnknownVariant>;
+
+    fn try_from(code: libc::c_int) -> Result<SpiOk, Result<SpiError, UnknownVariant>> {
+        // Cast to assure that we're obeying repr rules even on platforms where c_ints are not 4 bytes wide,
+        // as we don't support any but we may wish to in the future.
+        match code as i32 {
+            err @ -13..=0 => Err(Ok(
+                // SAFETY: These values are described in SpiError, thus they are inbounds for transmute
+                unsafe { mem::transmute::<i32, SpiError>(err) },
+            )),
+            ok @ 1..=17 => Ok(
+                //SAFETY: These values are described in SpiOk, thus they are inbounds for transmute
+                unsafe { mem::transmute::<i32, SpiOk>(ok) },
+            ),
+            _unknown => Err(Err(UnknownVariant)),
+        }
+    }
+}
+
+impl TryFrom<libc::c_int> for SpiError {
+    // Yes, this gives us nested results.
+    type Error = Result<SpiOk, UnknownVariant>;
+
+    fn try_from(code: libc::c_int) -> Result<SpiError, Result<SpiOk, UnknownVariant>> {
+        match SpiOk::try_from(code) {
+            Ok(ok) => Err(Ok(ok)),
+            Err(Ok(err)) => Ok(err),
+            Err(Err(unknown)) => Err(Err(unknown)),
+        }
+    }
 }
 
 pub struct Spi;
@@ -267,18 +303,10 @@ impl Spi {
     }
 
     pub fn check_status(status_code: i32) -> SpiOk {
-        if status_code > 0 {
-            let status_enum = SpiOk::from_i32(status_code);
-            match status_enum {
-                Some(ok) => ok,
-                None => panic!("unrecognized SPI status code {}", status_code),
-            }
-        } else {
-            let status_enum = SpiError::from_i32(-status_code);
-            match status_enum {
-                Some(e) => panic!("{:?}", e),
-                None => panic!("unrecognized SPI status code {}", status_code),
-            }
+        match SpiOk::try_from(status_code) {
+            Ok(ok) => ok,
+            Err(Err(UnknownVariant)) => panic!("unrecognized SPI status code: {status_code}"),
+            Err(Ok(code)) => panic!("{code:?}"),
         }
     }
 }
@@ -505,26 +533,26 @@ impl SpiHeapTupleData {
     ///
     /// The ordinal position is 1-based.
     ///
-    /// If the specified ordinal is out of bounds a `Err(SpiError::Noattribute)` is returned
+    /// If the specified ordinal is out of bounds a `Err(SpiError::NoAttribute)` is returned
     pub fn by_ordinal(
         &self,
         ordinal: usize,
     ) -> std::result::Result<&SpiHeapTupleDataEntry, SpiError> {
         match self.entries.get(&ordinal) {
             Some(datum) => Ok(datum),
-            None => Err(SpiError::Noattribute),
+            None => Err(SpiError::NoAttribute),
         }
     }
 
     /// Get a typed Datum value from this HeapTuple by its field name.  
     ///
-    /// If the specified name does not exist a `Err(SpiError::Noattribute)` is returned
+    /// If the specified name does not exist a `Err(SpiError::NoAttribute)` is returned
     pub fn by_name(&self, name: &str) -> std::result::Result<&SpiHeapTupleDataEntry, SpiError> {
         use crate::pg_sys::AsPgCStr;
         unsafe {
             let fnumber = pg_sys::SPI_fnumber(self.tupdesc, name.as_pg_cstr());
             if fnumber == pg_sys::SPI_ERROR_NOATTRIBUTE {
-                Err(SpiError::Noattribute)
+                Err(SpiError::NoAttribute)
             } else {
                 self.by_ordinal(fnumber as usize)
             }
@@ -535,20 +563,20 @@ impl SpiHeapTupleData {
     ///
     /// The ordinal position is 1-based.
     ///
-    /// If the specified ordinal is out of bounds a `Err(SpiError::Noattribute)` is returned
+    /// If the specified ordinal is out of bounds a `Err(SpiError::NoAttribute)` is returned
     pub fn by_ordinal_mut(
         &mut self,
         ordinal: usize,
     ) -> std::result::Result<&mut SpiHeapTupleDataEntry, SpiError> {
         match self.entries.get_mut(&ordinal) {
             Some(datum) => Ok(datum),
-            None => Err(SpiError::Noattribute),
+            None => Err(SpiError::NoAttribute),
         }
     }
 
     /// Get a mutable typed Datum value from this HeapTuple by its field name.  
     ///
-    /// If the specified name does not exist a `Err(SpiError::Noattribute)` is returned
+    /// If the specified name does not exist a `Err(SpiError::NoAttribute)` is returned
     pub fn by_name_mut(
         &mut self,
         name: &str,
@@ -557,7 +585,7 @@ impl SpiHeapTupleData {
         unsafe {
             let fnumber = pg_sys::SPI_fnumber(self.tupdesc, name.as_pg_cstr());
             if fnumber == pg_sys::SPI_ERROR_NOATTRIBUTE {
-                Err(SpiError::Noattribute)
+                Err(SpiError::NoAttribute)
             } else {
                 self.by_ordinal_mut(fnumber as usize)
             }
@@ -566,7 +594,7 @@ impl SpiHeapTupleData {
 
     /// Set a datum value for the specified ordinal position
     ///
-    /// If the specified ordinal is out of bounds a `Err(SpiError::Noattribute)` is returned
+    /// If the specified ordinal is out of bounds a `Err(SpiError::NoAttribute)` is returned
     pub fn set_by_ordinal<T: IntoDatum + FromDatum>(
         &mut self,
         ordinal: usize,
@@ -574,7 +602,7 @@ impl SpiHeapTupleData {
     ) -> std::result::Result<(), SpiError> {
         unsafe {
             if ordinal < 1 || ordinal > self.tupdesc.as_ref().unwrap().natts as usize {
-                Err(SpiError::Noattribute)
+                Err(SpiError::NoAttribute)
             } else {
                 self.entries.insert(
                     ordinal,
@@ -590,7 +618,7 @@ impl SpiHeapTupleData {
 
     /// Set a datum value for the specified field name
     ///
-    /// If the specified name does not exist a `Err(SpiError::Noattribute)` is returned
+    /// If the specified name does not exist a `Err(SpiError::NoAttribute)` is returned
     pub fn set_by_name<T: IntoDatum + FromDatum>(
         &mut self,
         name: &str,
@@ -600,7 +628,7 @@ impl SpiHeapTupleData {
         unsafe {
             let fnumber = pg_sys::SPI_fnumber(self.tupdesc, name.as_pg_cstr());
             if fnumber == pg_sys::SPI_ERROR_NOATTRIBUTE {
-                Err(SpiError::Noattribute)
+                Err(SpiError::NoAttribute)
             } else {
                 self.set_by_ordinal(fnumber as usize, datum)
             }


### PR DESCRIPTION
This thins our dependency tree with fairly light lifting.
It also makes it much harder to make mistakes,
as we no longer rely on the odd split of needing negative values
in order to do the status code check properly.