### PR TITLE
Add a test which calls a user-defined function with NULL argument

### DIFF
--- a/pgx-tests/src/tests/postgres_type_tests.rs
+++ b/pgx-tests/src/tests/postgres_type_tests.rs
@@ -61,6 +61,15 @@ impl InOutFuncs for CustomTextFormatSerializedType {
     }
 }
 
+#[pg_extern(immutable)]
+fn fn_takes_option(input: Option<CustomTextFormatSerializedType>) -> String {
+    input.map_or("nothing".to_string(), |c| {
+        let mut b = StringInfo::new();
+        c.output(&mut b);
+        b.to_string()
+    })
+}
+
 #[derive(Serialize, Deserialize, PostgresType)]
 pub struct JsonType {
     a: f32,
@@ -86,6 +95,20 @@ mod tests {
         assert_eq!(result.a, 1.0);
         assert_eq!(result.b, 2.0);
         assert_eq!(result.c, 3);
+    }
+
+    #[pg_test]
+    fn test_call_with_value() {
+        let result = Spi::get_one::<String>(
+            "SELECT fn_takes_option('1.0,2.0,3'::CustomTextFormatSerializedType);",
+        );
+        assert_eq!("1,2,3", result.unwrap());
+    }
+
+    #[pg_test]
+    fn test_call_with_null() {
+        let result = Spi::get_one::<String>("SELECT fn_takes_option(NULL);");
+        assert_eq!(Some(String::from("nothing")), result);
     }
 
     #[pg_test]


### PR DESCRIPTION
I found this incorrect behavior, but I haven't figured out how to fix it.