### PR TITLE
Deprecate `Array<'a, T>::as_slice`

### DIFF
--- a/pgx-examples/arrays/src/lib.rs
+++ b/pgx-examples/arrays/src/lib.rs
@@ -14,21 +14,18 @@ pg_module_magic!();
 
 #[pg_extern]
 fn sq_euclid_pgx(a: Array<f32>, b: Array<f32>) -> f32 {
-    a.as_slice()
-        .iter()
-        .zip(b.as_slice().iter())
+    a.iter_deny_null()
+        .zip(b.iter_deny_null())
         .map(|(a, b)| (a - b) * (a - b))
         .sum()
 }
 
 #[pg_extern(immutable, parallel_safe)]
 fn approx_distance_pgx(compressed: Array<i64>, distances: Array<f64>) -> f64 {
-    let distances = distances.as_slice();
     compressed
-        .as_slice()
-        .iter()
+        .iter_deny_null()
         .map(|cc| {
-            let d = distances[*cc as usize];
+            let d = distances.get(cc as usize).unwrap().unwrap();
             pgx::info!("cc={}, d={}", cc, d);
             d
         })

--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -10,6 +10,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 mod datum;
 pub mod guard;
 mod oids;
+mod polyfill;
 pub mod setjmp;
 mod tupdesc;
 mod utils;
@@ -21,6 +22,7 @@ pub use datum::Datum;
 pub use datum::NullableDatum;
 pub use guard::*;
 pub use oids::*;
+pub use polyfill::*;
 pub use tupdesc::*;
 pub use utils::*;
 

--- a/pgx-pg-sys/src/submodules/polyfill.rs
+++ b/pgx-pg-sys/src/submodules/polyfill.rs
@@ -1,0 +1,10 @@
+// Constants defined in PG13+
+mod typalign {
+    pub const TYPALIGN_CHAR: u8 = b'c';
+    pub const TYPALIGN_SHORT: u8 = b's';
+    pub const TYPALIGN_INT: u8 = b'i';
+    pub const TYPALIGN_DOUBLE: u8 = b'd';
+}
+
+#[cfg(any(feature = "pg10", feature = "pg11", feature = "pg12"))]
+pub use typalign::*;

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -398,7 +398,8 @@ mod tests {
     #[pg_test]
     #[should_panic]
     fn test_arr_sort_uniq_with_null() {
-        let _result = Spi::get_one::<Vec<i32>>("SELECT arr_sort_uniq(ARRAY[3,2,NULL,2,1]::integer[])");
+        let _result =
+            Spi::get_one::<Vec<i32>>("SELECT arr_sort_uniq(ARRAY[3,2,NULL,2,1]::integer[])");
         // No assert because we're testing for the panic.
     }
 }

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -33,12 +33,14 @@ fn sum_array_i64(values: Array<i64>) -> i64 {
     values.iter().map(|v| v.unwrap_or(0i64)).sum()
 }
 
-#[pg_extern(name = "sum_array_siced")]
+#[pg_extern(name = "sum_array_sliced")]
+#[allow(deprecated)]
 fn sum_array_i32_sliced(values: Array<i32>) -> i32 {
     values.as_slice().iter().sum()
 }
 
 #[pg_extern(name = "sum_array_sliced")]
+#[allow(deprecated)]
 fn sum_array_i64_sliced(values: Array<i64>) -> i64 {
     values.as_slice().iter().sum()
 }
@@ -49,6 +51,7 @@ fn count_true(values: Array<bool>) -> i32 {
 }
 
 #[pg_extern]
+#[allow(deprecated)]
 fn count_true_sliced(values: Array<bool>) -> i32 {
     values.as_slice().iter().filter(|b| **b).count() as i32
 }

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -394,4 +394,11 @@ mod tests {
         let result = Spi::get_one::<Vec<i32>>("SELECT arr_sort_uniq(ARRAY[3,2,2,1]::integer[])");
         assert_eq!(result, Some(vec![1, 2, 3]));
     }
+
+    #[pg_test]
+    #[should_panic]
+    fn test_arr_sort_uniq_with_null() {
+        let _result = Spi::get_one::<Vec<i32>>("SELECT arr_sort_uniq(ARRAY[3,2,NULL,2,1]::integer[])");
+        // No assert because we're testing for the panic.
+    }
 }

--- a/pgx/src/array.rs
+++ b/pgx/src/array.rs
@@ -320,4 +320,17 @@ impl RawArray {
             ))
         }
     }
+
+    /// # Safety
+    /// See the entire thing just above. You're now instantly asserting validity for the slice.
+    pub(crate) unsafe fn assume_init_data_slice<T>(&self) -> &[T] {
+        // SAFETY: Assertion made by caller
+        unsafe {
+            &*NonNull::new_unchecked(slice_from_raw_parts_mut(
+                pgx_ARR_DATA_PTR(self.ptr.as_ptr()).cast(),
+                self.len,
+            ))
+            .as_ptr()
+        }
+    }
 }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -183,6 +183,15 @@ impl<'a, T: FromDatum> Array<'a, T> {
         ptr.unwrap_or(ptr::null())
     }
 
+    // # Panics
+    //
+    // Panics if it detects the slightest misalignment between types.
+    #[deprecated(
+        since = "0.5.0",
+        note = "it is virtually impossible to offer this function safely due to mismatches between Postgres and Rust\n\
+        even `unsafe fn as_slice(&self) -> &[T]` would not be sound for all `&[T]`\n
+        if you are sure your usage is sound, consider RawArray's functions"
+    )]
     pub fn as_slice(&self) -> &[T] {
         let sizeof_type = mem::size_of::<T>();
         let sizeof_datums = mem::size_of_val(self.elem_slice);

--- a/pgx/src/layout.rs
+++ b/pgx/src/layout.rs
@@ -1,0 +1,118 @@
+/*!
+Code for interfacing with the layout in memory (and on disk?) of various data types within Postgres.
+Prefer to minimize exposing the contents of this module to public callers of the pgx library:
+This is not a mature module yet so prefer to avoid exposing the contents to public callers of pgx,
+as this is error-prone stuff to tamper with. It is easy to corrupt the database if an error is made.
+Yes, even though its main block of code duplicates htup::DatumWithTypeInfo.
+
+Technically, they can always use CFFI to corrupt the database if they know how to use the C API,
+but that's why we should keep the conversation between the programmer and their own `unsafe`.
+We don't want programmers trusting our implementation farther than we have solidly evaluated it.
+Some may be better off extending the pgx bindings themselves, doing their own layout checks, etc.
+When PGX is a bit more mature in its soundness, and we better understand what our callers expect,
+then we may want to offer more help.
+*/
+use crate::pg_sys::{self, TYPALIGN_CHAR, TYPALIGN_DOUBLE, TYPALIGN_INT, TYPALIGN_SHORT};
+use core::mem;
+
+/// Postgres type information, corresponds to part of a row in pg_type
+/// This layout describes T, not &T, even if passbyval: false, which would mean the datum array is effectively &[&T]
+#[derive(Debug, Clone)]
+pub(crate) struct Layout {
+    // We could add more fields to this if we are curious enough, as the function we call pulls an entire row
+    pub align: Align,    // typalign
+    pub size: Size,      // typlen
+    pub passbyval: bool, // typbyval
+}
+
+impl Layout {
+    /**
+    Give an Oid and get its Layout.
+
+    # Panics
+
+    May elog if the tuple for the type in question cannot be acquired.
+    This should almost never happen in practice (alloc error?).
+    */
+    pub(crate) fn lookup_oid(oid: pg_sys::Oid) -> Layout {
+        let (mut typalign, mut typlen, mut passbyval) = Default::default();
+        // Postgres doesn't document any safety conditions. It probably is a safe function in the Rust sense.
+        unsafe { pg_sys::get_typlenbyvalalign(oid, &mut typlen, &mut passbyval, &mut typalign) };
+        Layout {
+            align: Align::try_from(typalign).unwrap(),
+            size: Size::try_from(typlen).unwrap(),
+            passbyval,
+        }
+    }
+}
+
+#[repr(usize)]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Align {
+    Byte = mem::align_of::<u8>(),
+    Short = mem::align_of::<libc::c_short>(),
+    Int = mem::align_of::<libc::c_int>(),
+    Double = mem::align_of::<f64>(),
+}
+
+impl TryFrom<libc::c_char> for Align {
+    type Error = ();
+
+    fn try_from(cchar: libc::c_char) -> Result<Align, ()> {
+        match cchar as u8 {
+            TYPALIGN_CHAR => Ok(Align::Byte),
+            TYPALIGN_SHORT => Ok(Align::Short),
+            TYPALIGN_INT => Ok(Align::Int),
+            TYPALIGN_DOUBLE => Ok(Align::Double),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Align {
+    pub(crate) fn as_typalign(&self) -> libc::c_char {
+        (match self {
+            Align::Byte => TYPALIGN_CHAR,
+            Align::Short => TYPALIGN_SHORT,
+            Align::Int => TYPALIGN_INT,
+            Align::Double => TYPALIGN_DOUBLE,
+        }) as _
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Size {
+    CStr,
+    Varlena,
+    Fixed(u16),
+}
+
+impl TryFrom<i16> for Size {
+    type Error = ();
+    fn try_from(int2: i16) -> Result<Size, ()> {
+        match int2 {
+            -2 => Ok(Size::CStr),
+            -1 => Ok(Size::Varlena),
+            v @ 0.. => Ok(Size::Fixed(v as u16)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Size {
+    pub(crate) fn as_typlen(&self) -> i16 {
+        match self {
+            Self::CStr => -2,
+            Self::Varlena => -1,
+            Self::Fixed(v) => *v as _,
+        }
+    }
+
+    pub(crate) fn try_as_usize(&self) -> Option<usize> {
+        match self {
+            Self::CStr => None,
+            Self::Varlena => None,
+            Self::Fixed(v) => Some(*v as _),
+        }
+    }
+}

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -69,6 +69,8 @@ pub mod xid;
 #[doc(hidden)]
 pub use once_cell;
 
+mod layout;
+
 pub use aggregate::*;
 pub use atomics::*;
 pub use callbacks::*;


### PR DESCRIPTION
This marks the formal beginning of the deprecation process for the `Array<'_, T>::as_slice` function. As currently implemented, it cannot be safe without inducing at minimum these panics, which means it must be `unsafe`, which would already be a breaking change to introduce. And this does not actually make it fully correct, either, but we can expect code "in the wild" probably exercises this function as it is fairly idiomatic to use in Rust, so removing it abruptly without offering these directions would make the upgrade path for 0.5.0 even more annoying.

I expect we can introduce a new variant of this function in the future which offers a very similar interface and is either safe or `unsafe` (and arguably RawArray offers the `unsafe` version already), but I expect that to not happen before 0.6.1 or 0.7.0, as it involves some fairly sweeping structural changes in PGX.