### PR TITLE
Match the Postgres repr in Time and TimeWithTimeZone

### DIFF
--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -35,6 +35,11 @@ fn accept_time_with_time_zone(t: TimeWithTimeZone) -> TimeWithTimeZone {
 }
 
 #[pg_extern]
+fn convert_timetz_to_time(t: TimeWithTimeZone) -> Time {
+    t.to_utc().into()
+}
+
+#[pg_extern]
 fn accept_timestamp(t: Timestamp) -> Timestamp {
     t
 }
@@ -126,6 +131,7 @@ mod serialization_tests {
     use serde_json::*;
 
     #[test]
+    #[allow(deprecated)]
     fn test_time_with_timezone_serialization() {
         let time_with_timezone = TimeWithTimeZone::new(
             time::Time::from_hms(12, 23, 34).unwrap(),
@@ -133,8 +139,8 @@ mod serialization_tests {
         );
         let json = json!({ "time W/ Zone test": time_with_timezone });
 
-        // we automatically converted to UTC upon construction in ::new()
-        assert_eq!(10, time_with_timezone.hour());
+        let (h, ..) = time_with_timezone.to_utc().to_hms_micro();
+        assert_eq!(10, h);
 
         // b/c we always want our times output in UTC
         assert_eq!(json!({"time W/ Zone test":"10:23:34-00"}), json);
@@ -166,6 +172,7 @@ mod tests {
     }
 
     #[pg_test]
+    #[allow(deprecated)]
     fn test_time_serialization() {
         let time = Time::new(time::Time::from_hms(0, 0, 0).unwrap());
         let json = json!({ "time test": time });
@@ -254,12 +261,20 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_accept_time_with_time_zone_now() {
-        let result = Spi::get_one::<bool>(
-            "SELECT accept_time_with_time_zone(now()::time with time zone at time zone 'America/Denver') = now()::time with time zone at time zone 'utc';",
+    fn test_convert_time_with_time_zone_now() {
+        // This test used to simply compare for equality in Postgres, assert on the bool
+        // however, failed `=` in Postgres doesn't say much if it fails.
+        // Thus this esoteric formulation: it derives a delta if there is one.
+        let result = Spi::get_one::<Time>(
+            "SELECT (
+                convert_timetz_to_time(now()::time with time zone at time zone 'America/Denver')
+                - convert_timetz_to_time(now()::time with time zone at time zone 'utc')
+                + 'allballs'::time
+            );",
         )
         .expect("failed to get SPI result");
-        assert!(result)
+
+        assert_eq!(result, Time::ALLBALLS)
     }
 
     #[pg_test]

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -98,6 +98,7 @@ impl Time {
     }
 }
 
+#[cfg(feature = "time-crate")]
 impl TryFrom<time::Time> for Time {
     type Error = FromTimeError;
     fn try_from(t: time::Time) -> Result<Time, Self::Error> {

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::{pg_sys, FromDatum, IntoDatum, TimestampConversionError, TimestampWithTimeZone};
+use crate::{pg_sys, FromDatum, IntoDatum, FromTimeError, TimestampWithTimeZone};
 use std::ffi::CStr;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -61,7 +61,7 @@ impl From<Timestamp> for i64 {
 }
 
 impl TryFrom<pg_sys::Timestamp> for Timestamp {
-    type Error = TimestampConversionError;
+    type Error = FromTimeError;
 
     fn try_from(value: pg_sys::Timestamp) -> Result<Self, Self::Error> {
         TryInto::<TimestampWithTimeZone>::try_into(value).map(|tstz| tstz.into())
@@ -69,7 +69,7 @@ impl TryFrom<pg_sys::Timestamp> for Timestamp {
 }
 
 impl TryFrom<pg_sys::Datum> for Timestamp {
-    type Error = TimestampConversionError;
+    type Error = FromTimeError;
 
     fn try_from(datum: pg_sys::Datum) -> Result<Self, Self::Error> {
         (datum.value() as pg_sys::Timestamp).try_into()
@@ -77,7 +77,7 @@ impl TryFrom<pg_sys::Datum> for Timestamp {
 }
 
 impl TryFrom<time::OffsetDateTime> for Timestamp {
-    type Error = TimestampConversionError;
+    type Error = FromTimeError;
 
     fn try_from(offset: time::OffsetDateTime) -> Result<Self, Self::Error> {
         TryInto::<TimestampWithTimeZone>::try_into(offset).map(|tstz| tstz.into())
@@ -85,7 +85,7 @@ impl TryFrom<time::OffsetDateTime> for Timestamp {
 }
 
 impl TryFrom<Timestamp> for time::PrimitiveDateTime {
-    type Error = TimestampConversionError;
+    type Error = FromTimeError;
 
     fn try_from(ts: Timestamp) -> Result<Self, Self::Error> {
         let tstz: TimestampWithTimeZone = ts.into();
@@ -94,7 +94,7 @@ impl TryFrom<Timestamp> for time::PrimitiveDateTime {
 }
 
 impl TryFrom<time::PrimitiveDateTime> for Timestamp {
-    type Error = TimestampConversionError;
+    type Error = FromTimeError;
 
     fn try_from(datetime: time::PrimitiveDateTime) -> Result<Self, Self::Error> {
         TryInto::<TimestampWithTimeZone>::try_into(datetime).map(|tstz| tstz.into())
@@ -102,7 +102,7 @@ impl TryFrom<time::PrimitiveDateTime> for Timestamp {
 }
 
 impl TryFrom<Timestamp> for time::OffsetDateTime {
-    type Error = TimestampConversionError;
+    type Error = FromTimeError;
     fn try_from(ts: Timestamp) -> Result<Self, Self::Error> {
         let tstz: TimestampWithTimeZone = ts.into();
         tstz.try_into()

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::{pg_sys, FromDatum, IntoDatum, FromTimeError, TimestampWithTimeZone};
+use crate::{pg_sys, FromDatum, FromTimeError, IntoDatum, TimestampWithTimeZone};
 use std::ffi::CStr;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -7,12 +7,13 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::datum::time::USECS_PER_SEC;
 use crate::{pg_sys, FromDatum, IntoDatum};
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::ops::Sub;
 use time::{macros::date, UtcOffset};
+
+pub(crate) const USECS_PER_SEC: i64 = 1_000_000;
 
 const PG_EPOCH_OFFSET: time::OffsetDateTime = date!(2000 - 01 - 01).midnight().assume_utc();
 const PG_EPOCH_DATETIME: time::PrimitiveDateTime = date!(2000 - 01 - 01).midnight();
@@ -162,8 +163,14 @@ pub enum TimestampConversionError {
     Infinity,
     #[error("time::PrimitiveDateTime was unable to convert this timestamp")]
     TimeCrate,
-    #[error("usec outside of PG's defined Timestamp range")]
+    #[error("microseconds outside of target microsecond range")]
     OutOfRangeMicroseconds,
+    #[error("hours outside of target range")]
+    HourOverflow,
+    #[error("minutes outside of target range")]
+    MinuteOverflow,
+    #[error("seconds outside of target range")]
+    SecondOverflow,
 }
 
 impl serde::Serialize for TimestampWithTimeZone {

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -9,7 +9,6 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::datum::time::Time;
 use crate::{pg_sys, FromDatum, IntoDatum, PgBox};
-use std::ops::{Deref, DerefMut};
 use time::format_description::FormatItem;
 
 #[derive(Debug)]
@@ -55,19 +54,6 @@ impl TimeWithTimeZone {
     pub fn new(mut time: time::Time, at_tz_offset: time::UtcOffset) -> Self {
         time -= time::Duration::seconds(at_tz_offset.whole_seconds() as i64);
         TimeWithTimeZone(Time(time))
-    }
-}
-
-impl Deref for TimeWithTimeZone {
-    type Target = time::Time;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl DerefMut for TimeWithTimeZone {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -7,7 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::datum::time::{hms_micro_to_pgtime, Time, USECS_PER_DAY};
+use crate::datum::time::{Time, USECS_PER_DAY};
 use crate::{pg_sys, FromDatum, IntoDatum, PgBox};
 use time::format_description::FormatItem;
 
@@ -62,7 +62,7 @@ impl TimeWithTimeZone {
     )]
     pub fn new(time: time::Time, at_tz_offset: time::UtcOffset) -> Self {
         let (h, m, s, micro) = time.as_hms_micro();
-        let t = hms_micro_to_pgtime(h, m, s, micro).unwrap();
+        let t = Time::from_hms_micro(h, m, s, micro).unwrap();
         // Flip the sign, because time::Time uses the ISO sign convention
         let tz_secs = -at_tz_offset.whole_seconds();
         TimeWithTimeZone { t, tz_secs }


### PR DESCRIPTION
By using a Rust-side repr that more closely reflects the internal implementation of Postgres, we head off various issues we potentially could encounter with not being able to reflect the full range that Postgres can in its implementation of these types, versus the edges that `time` types runs up against (e.g. not having the concept of a temporal "infinity" or "-infinity"). These last two types do not have quite the same problems per se, but we previously were discarding information to achieve a goal in serialization, when that can be done by simply altering the way the type is serialized.

This completes https://github.com/tcdi/pgx/issues/618 for all of the Postgres temporal types, reducing the likelihood of a forced breakage in the future if the `time` crate alters its implementation. We also avoid the overhead of calling potentially costly conversion functions that was noted in https://github.com/tcdi/pgx/issues/504 until such points as serialization.