### PR TITLE
Updates versions script because of #645

### DIFF
--- a/update-versions.sh
+++ b/update-versions.sh
@@ -48,6 +48,7 @@ DEPENDENCIES_TO_UPDATE=(
     "pgx"
     "pgx-tests"
     "pgx-macros"
+    "pgx-pg-config"
     "pgx-pgx-sys"
     "pgx-utils"
     "cargo-pgx"


### PR DESCRIPTION
We want to be sure any new crates need to also be part of the release process. https://github.com/tcdi/pgx/pull/645 adds a new crate that needs to be considered for release.