### PR TITLE
Recommend `cargo install --locked`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,9 @@ After cloning the repository, mostly you can use similar flows as in the README.
 However, if there are any differences in `cargo pgx` since the last release, then
 the first and most drastic difference in the developer environment vs. the user environment is that you will have to run
 ```bash
-cargo install cargo-pgx --path ./cargo-pgx --force
+cargo install cargo-pgx --path ./cargo-pgx \
+    --force \
+    --locked # This forces usage of the repo's lockfile
 cargo pgx init # This might take a while. Consider getting a drink.
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14bf7b4f565e5e717d7a7a65b2a05c0b8c96e4db636d6f780f03b15108cdd1b"
+checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
 dependencies = [
  "critical-section",
 ]
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ scl enable devtoolset-7 bash
 First install the `cargo-pgx` sub-command and initialize the development environment:
 
 ```bash
-cargo install cargo-pgx
+cargo install --locked cargo-pgx
 cargo pgx init
 ```
 
@@ -151,7 +151,7 @@ You can upgrade your current `cargo-pgx` installation by passing the `--force` f
 to `cargo install`:
 
 ```bash
-cargo install --force cargo-pgx
+cargo install --force --locked cargo-pgx
 ```
 
 As new Postgres versions are supported by `pgx`, you can re-run the `pgx init` process to download and compile them:

--- a/articles/postgresql-aggregates-with-rust.md
+++ b/articles/postgresql-aggregates-with-rust.md
@@ -209,7 +209,7 @@ figure out if something is missing from error messages and then discover the req
 Install `cargo-pgx` then initialize its development PostgreSQL installations (used for `cargo pgx test` and `cargo pgx run`):
 
 ```bash
-$ cargo install cargo-pgx
+$ cargo install --locked cargo-pgx
 $ cargo pgx init
 # ...
 ```

--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -11,7 +11,7 @@ A video walkthrough of its abilities can be found here: https://www.twitch.tv/vi
 Install via crates.io:
 
 ```shell script
-$ cargo install cargo-pgx
+$ cargo install --locked cargo-pgx
 ```
 
 As new versions of `pgx` are released, you'll want to make sure you run this command again to update it.


### PR DESCRIPTION
Otherwise Cargo will try to select "whatever seems compatible" in terms of crates when they install, which can in rare cases result in them trying to pull in versions which the Rust toolchain we intend to build with cannot actually compile. This was used to solve a dependency/version problem a while ago in tcdi/plrust#73 and it seems like a better recommendation for our users in general.