### PR TITLE
Add a function to run arbitrary sql with arguments.

### DIFF
--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -162,7 +162,7 @@ mod tests {
             vec![
                 (PgBuiltInOids::INT4OID.oid(), i.into_datum()),
                 (PgBuiltInOids::INT8OID.oid(), j.into_datum()),
-            ]
+            ],
         )
     }
 

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -147,6 +147,25 @@ mod tests {
         assert!(Spi::get_one::<i32>("SELECT 1 LIMIT 0").is_none());
     }
 
+    #[pg_test]
+    fn test_spi_run() {
+        Spi::run("SELECT 1")
+    }
+
+    #[pg_test]
+    fn test_spi_run_with_args() {
+        let i = 1 as i32;
+        let j = 2 as i64;
+
+        Spi::run_with_args(
+            "SELECT $1 + $2 = 3",
+            vec![
+                (PgBuiltInOids::INT4OID.oid(), i.into_datum()),
+                (PgBuiltInOids::INT8OID.oid(), j.into_datum()),
+            ]
+        )
+    }
+
     #[pg_extern]
     fn do_panic() {
         panic!("did a panic");

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -171,6 +171,12 @@ impl Spi {
             client.update(query, None, None);
         })
     }
+    
+    fn run_with_args(query: &str, args: Vec<(PgOid, Option<pg_sys::Datum>)>) {
+        Spi::execute(|mut client| {
+            client.update(query, None, Some(args));
+        })
+    }
 
     /// explain a query, returning its result in json form
     pub fn explain(query: &str) -> Json {

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -75,7 +75,7 @@ pub struct SpiTupleTable {
 /// Represents a single `pg_sys::Datum` inside a `SpiHeapTupleData`
 pub struct SpiHeapTupleDataEntry {
     datum: Option<pg_sys::Datum>,
-    type_oid: pg_sys::Oid,
+    pub type_oid: pg_sys::Oid,
 }
 
 /// Represents the set of `pg_sys::Datum`s in a `pg_sys::HeapTuple`

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -172,7 +172,7 @@ impl Spi {
         })
     }
     
-    fn run_with_args(query: &str, args: Vec<(PgOid, Option<pg_sys::Datum>)>) {
+    pub fn run_with_args(query: &str, args: Vec<(PgOid, Option<pg_sys::Datum>)>) {
         Spi::execute(|mut client| {
             client.update(query, None, Some(args));
         })

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -171,7 +171,12 @@ impl Spi {
             client.update(query, None, None);
         })
     }
-    
+
+    /// run an arbitrary SQL statement with args.
+    ///
+    /// ## Safety
+    ///
+    /// The statement runs in read/write mode
     pub fn run_with_args(query: &str, args: Vec<(PgOid, Option<pg_sys::Datum>)>) {
         Spi::execute(|mut client| {
             client.update(query, None, Some(args));


### PR DESCRIPTION
This helps to ensure args are properly encoded, rather than relying on mechanisms like format!() that may be less correct or secure.