### PR TITLE
Introduce `#[pg_extern(create_or_replace)]`

### DIFF
--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -29,6 +29,7 @@ pub mod __reexports {
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, PartialOrd, Ord)]
 pub enum ExternArgs {
+    CreateOrReplace,
     Immutable,
     Strict,
     Stable,
@@ -48,6 +49,7 @@ pub enum ExternArgs {
 impl core::fmt::Display for ExternArgs {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            ExternArgs::CreateOrReplace => write!(f, "CREATE OR REPLACE"),
             ExternArgs::Immutable => write!(f, "IMMUTABLE"),
             ExternArgs::Strict => write!(f, "STRICT"),
             ExternArgs::Stable => write!(f, "STABLE"),
@@ -69,6 +71,7 @@ impl core::fmt::Display for ExternArgs {
 impl ToTokens for ExternArgs {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
+            ExternArgs::CreateOrReplace => tokens.append(format_ident!("CreateOrReplace")),
             ExternArgs::Immutable => tokens.append(format_ident!("Immutable")),
             ExternArgs::Strict => tokens.append(format_ident!("Strict")),
             ExternArgs::Stable => tokens.append(format_ident!("Stable")),
@@ -148,6 +151,7 @@ pub fn parse_extern_attributes(attr: TokenStream) -> HashSet<ExternArgs> {
             TokenTree::Ident(i) => {
                 let name = i.to_string();
                 match name.as_str() {
+                    "create_or_replace" => args.insert(ExternArgs::CreateOrReplace),
                     "immutable" => args.insert(ExternArgs::Immutable),
                     "strict" => args.insert(ExternArgs::Strict),
                     "stable" => args.insert(ExternArgs::Stable),

--- a/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
@@ -23,8 +23,7 @@ pub enum Attribute {
     Volatile,
     Raw,
     NoGuard,
-    /// CREATE OR REPLACE FUNCTION
-    OrReplace,
+    CreateOrReplace,
     ParallelSafe,
     ParallelUnsafe,
     ParallelRestricted,
@@ -45,7 +44,7 @@ impl Attribute {
             Attribute::Volatile => quote! { ::pgx::utils::ExternArgs::Volatile },
             Attribute::Raw => quote! { ::pgx::utils::ExternArgs::Raw },
             Attribute::NoGuard => quote! { ::pgx::utils::ExternArgs::NoGuard },
-            Attribute::OrReplace => quote! { ::pgx::utils::ExternArgs::OrReplace },
+            Attribute::CreateOrReplace => quote! { ::pgx::utils::ExternArgs::CreateOrReplace },
             Attribute::ParallelSafe => {
                 quote! { ::pgx::utils::ExternArgs::ParallelSafe }
             }
@@ -91,7 +90,7 @@ impl ToTokens for Attribute {
             Attribute::Volatile => quote! { volatile },
             Attribute::Raw => quote! { raw },
             Attribute::NoGuard => quote! { no_guard },
-            Attribute::OrReplace => quote! { or_replace },
+            Attribute::CreateOrReplace => quote! { create_or_replace },
             Attribute::ParallelSafe => {
                 quote! { parallel_safe }
             }
@@ -139,7 +138,7 @@ impl Parse for Attribute {
             "volatile" => Self::Volatile,
             "raw" => Self::Raw,
             "no_guard" => Self::NoGuard,
-            "or_replace" => Self::OrReplace,
+            "create_or_replace" => Self::CreateOrReplace,
             "parallel_safe" => Self::ParallelSafe,
             "parallel_unsafe" => Self::ParallelUnsafe,
             "parallel_restricted" => Self::ParallelRestricted,

--- a/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/attribute.rs
@@ -23,6 +23,8 @@ pub enum Attribute {
     Volatile,
     Raw,
     NoGuard,
+    /// CREATE OR REPLACE FUNCTION
+    OrReplace,
     ParallelSafe,
     ParallelUnsafe,
     ParallelRestricted,
@@ -43,6 +45,7 @@ impl Attribute {
             Attribute::Volatile => quote! { ::pgx::utils::ExternArgs::Volatile },
             Attribute::Raw => quote! { ::pgx::utils::ExternArgs::Raw },
             Attribute::NoGuard => quote! { ::pgx::utils::ExternArgs::NoGuard },
+            Attribute::OrReplace => quote! { ::pgx::utils::ExternArgs::OrReplace },
             Attribute::ParallelSafe => {
                 quote! { ::pgx::utils::ExternArgs::ParallelSafe }
             }
@@ -88,6 +91,7 @@ impl ToTokens for Attribute {
             Attribute::Volatile => quote! { volatile },
             Attribute::Raw => quote! { raw },
             Attribute::NoGuard => quote! { no_guard },
+            Attribute::OrReplace => quote! { or_replace },
             Attribute::ParallelSafe => {
                 quote! { parallel_safe }
             }
@@ -135,6 +139,7 @@ impl Parse for Attribute {
             "volatile" => Self::Volatile,
             "raw" => Self::Raw,
             "no_guard" => Self::NoGuard,
+            "or_replace" => Self::OrReplace,
             "parallel_safe" => Self::ParallelSafe,
             "parallel_unsafe" => Self::ParallelUnsafe,
             "parallel_restricted" => Self::ParallelRestricted,

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -119,7 +119,7 @@ impl ToSql for PgExternEntity {
                                 LANGUAGE c /* Rust */\n\
                                 AS '{module_pathname}', '{unaliased_name}_wrapper';\
                             ",
-            or_replace = if extern_attrs.contains(&ExternArgs::OrReplace) { "OR REPLACE" } else { "" },
+            or_replace = if extern_attrs.contains(&ExternArgs::CreateOrReplace) { "OR REPLACE" } else { "" },
             schema = self
                 .schema
                 .map(|schema| format!("{}.", schema))

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -113,12 +113,13 @@ impl ToSql for PgExternEntity {
 
         let fn_sql = format!(
             "\
-                                CREATE FUNCTION {schema}\"{name}\"({arguments}) {returns}\n\
+                                CREATE {or_replace} FUNCTION {schema}\"{name}\"({arguments}) {returns}\n\
                                 {extern_attrs}\
                                 {search_path}\
                                 LANGUAGE c /* Rust */\n\
                                 AS '{module_pathname}', '{unaliased_name}_wrapper';\
                             ",
+            or_replace = "",
             schema = self
                 .schema
                 .map(|schema| format!("{}.", schema))

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -119,7 +119,7 @@ impl ToSql for PgExternEntity {
                                 LANGUAGE c /* Rust */\n\
                                 AS '{module_pathname}', '{unaliased_name}_wrapper';\
                             ",
-            or_replace = "",
+            or_replace = if extern_attrs.contains(&ExternArgs::OrReplace) { "OR REPLACE" } else { "" },
             schema = self
                 .schema
                 .map(|schema| format!("{}.", schema))


### PR DESCRIPTION
This is a followup to #554 which fixed #506, and an alternative solution to the problem raised by #584 that allows users to fix things in a more targeted manner, albeit at the requirement of a source-level change. As it is a fairly simple edit, and introduces a functionality we likely want anyways, I think this is a reasonable alternative solution.