### PR TITLE
Eliminate tuple udf

### DIFF
--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -43,7 +43,7 @@ pub fn pg_guard(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // process top-level functions
         // these functions get wrapped as public extern "C" functions with #[no_mangle] so they
         // can also be called from C code
-        Item::Fn(func) => rewriter.item_fn(func, None, false, false, false).0.into(),
+        Item::Fn(func) => rewriter.item_fn(func, None, false, false, false).into(),
         _ => {
             panic!("#[pg_guard] can only be applied to extern \"C\" blocks and top-level functions")
         }
@@ -589,7 +589,7 @@ fn rewrite_item_fn(
     // make the function 'extern "C"' because this is for the #[pg_extern[ macro
     func.sig.abi = Some(syn::parse_str("extern \"C\"").unwrap());
     let func_span = func.span();
-    let (rewritten_func, need_wrapper) = rewriter.item_fn(
+    let rewritten_func = rewriter.item_fn(
         func,
         Some(sql_graph_entity_submission),
         true,
@@ -597,22 +597,15 @@ fn rewrite_item_fn(
         no_guard,
     );
 
-    if need_wrapper {
-        quote_spanned! {func_span=>
-            #[no_mangle]
-            #[doc(hidden)]
-            pub extern "C" fn #finfo_name() -> &'static pg_sys::Pg_finfo_record {
-                const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
-                &V1_API
-            }
-
-            #rewritten_func
+    quote_spanned! {func_span=>
+        #[no_mangle]
+        #[doc(hidden)]
+        pub extern "C" fn #finfo_name() -> &'static pg_sys::Pg_finfo_record {
+            const V1_API: pg_sys::Pg_finfo_record = pg_sys::Pg_finfo_record { api_version: 1 };
+            &V1_API
         }
-    } else {
-        quote_spanned! {func_span=>
 
-            #rewritten_func
-        }
+        #rewritten_func
     }
 }
 

--- a/pgx-utils/src/rewriter.rs
+++ b/pgx-utils/src/rewriter.rs
@@ -46,14 +46,11 @@ impl PgGuardRewriter {
         rewrite_args: bool,
         is_raw: bool,
         no_guard: bool,
-    ) -> (proc_macro2::TokenStream, bool) {
+    ) -> proc_macro2::TokenStream {
         if rewrite_args {
             self.item_fn_with_rewrite(func, entity_submission, is_raw, no_guard)
         } else {
-            (
-                self.item_fn_without_rewrite(func, entity_submission, no_guard),
-                true,
-            )
+            self.item_fn_without_rewrite(func, entity_submission, no_guard)
         }
     }
 
@@ -63,7 +60,7 @@ impl PgGuardRewriter {
         entity_submission: Option<&PgExtern>,
         is_raw: bool,
         no_guard: bool,
-    ) -> (proc_macro2::TokenStream, bool) {
+    ) -> proc_macro2::TokenStream {
         // remember the original visibility and signature classifications as we want
         // to use those for the outer function
         let vis = func.vis.clone();
@@ -121,22 +118,19 @@ impl PgGuardRewriter {
             #[allow(unused_variables)]
         };
         match return_type_kind {
-            CategorizedType::Default => (
-                PgGuardRewriter::impl_standard_udf(
-                    func_span,
-                    prolog,
-                    vis,
-                    func_name_wrapper,
-                    generics,
-                    func_call,
-                    rewritten_return_type,
-                    entity_submission,
-                    no_guard,
-                ),
-                true,
+            CategorizedType::Default => PgGuardRewriter::impl_standard_udf(
+                func_span,
+                prolog,
+                vis,
+                func_name_wrapper,
+                generics,
+                func_call,
+                rewritten_return_type,
+                entity_submission,
+                no_guard,
             ),
 
-            CategorizedType::Iterator(types) if types.len() == 1 => (
+            CategorizedType::Iterator(types) if types.len() == 1 => {
                 PgGuardRewriter::impl_setof_srf(
                     types,
                     func_span,
@@ -147,11 +141,10 @@ impl PgGuardRewriter {
                     func_call,
                     entity_submission,
                     false,
-                ),
-                true,
-            ),
+                )
+            }
 
-            CategorizedType::OptionalIterator(types) if types.len() == 1 => (
+            CategorizedType::OptionalIterator(types) if types.len() == 1 => {
                 PgGuardRewriter::impl_setof_srf(
                     types,
                     func_span,
@@ -162,11 +155,10 @@ impl PgGuardRewriter {
                     func_call,
                     entity_submission,
                     true,
-                ),
-                true,
-            ),
+                )
+            }
 
-            CategorizedType::Tuple(types) | CategorizedType::Iterator(types) => (
+            CategorizedType::Tuple(types) | CategorizedType::Iterator(types) => {
                 PgGuardRewriter::impl_table_srf(
                     types,
                     func_span,
@@ -177,22 +169,18 @@ impl PgGuardRewriter {
                     func_call,
                     entity_submission,
                     false,
-                ),
-                true,
-            ),
+                )
+            }
 
-            CategorizedType::OptionalIterator(types) => (
-                PgGuardRewriter::impl_table_srf(
-                    types,
-                    func_span,
-                    prolog,
-                    vis,
-                    func_name_wrapper,
-                    generics,
-                    func_call,
-                    entity_submission,
-                    true,
-                ),
+            CategorizedType::OptionalIterator(types) => PgGuardRewriter::impl_table_srf(
+                types,
+                func_span,
+                prolog,
+                vis,
+                func_name_wrapper,
+                generics,
+                func_call,
+                entity_submission,
                 true,
             ),
         }


### PR DESCRIPTION
There's a lot of song and dance about how functions which return a single tuple are turned into something that Postgres can call. This eliminates that: when a function which returns a tuple is discovered, the `func_call` is rewritten into an iterator on the spot, and then it's treated as if it were a function which returns an iterator (and thus passes through the `impl_table_srf` function). This removes:
* the `impl_tuple_udf` function
* the tuple return type of `item_fn`
* the edge case of "this might not need a `pg_guard`"