### PR TITLE
Fix undefined behaviour when loading control file

### DIFF
--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -14,7 +14,7 @@ Install via crates.io:
 $ cargo install --locked cargo-pgx
 ```
 
-As new versions of `pgx` are released, you'll want to make sure you run this command again to update it.
+As new versions of `pgx` are released, you'll want to make sure you run this command again to update it. You should also reinstall `cargo-pgx` whenever you update `rustc` so that the same compiler is used to build `cargo-pgx` and your Postgres extensions. You can force `cargo` to reinstall an existing crate by passing `--force`.
 
 ## Usage
 

--- a/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/mod.rs
@@ -631,7 +631,7 @@ impl PgAggregate {
         let entity_item_fn: ItemFn = parse_quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 let submission = ::pgx::utils::sql_entity_graph::PgAggregateEntity {
                     full_path: ::core::any::type_name::<#target_ident>(),
                     module_path: module_path!(),

--- a/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/mod.rs
@@ -100,7 +100,7 @@ impl ToTokens for ExtensionSqlFile {
         let inv = quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;
                 use alloc::vec;
@@ -207,7 +207,7 @@ impl ToTokens for ExtensionSql {
         );
         let inv = quote! {
             #[no_mangle]
-            pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;
                 use alloc::vec;

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -278,7 +278,7 @@ impl ToTokens for PgExtern {
         let inv = quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 use core::any::TypeId;
                 extern crate alloc;
                 use alloc::vec::Vec;

--- a/pgx-utils/src/sql_entity_graph/pg_trigger/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_trigger/mod.rs
@@ -66,7 +66,7 @@ impl PgTrigger {
         let tokens = quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 use core::any::TypeId;
                 extern crate alloc;
                 use alloc::vec::Vec;

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
@@ -117,7 +117,7 @@ impl ToTokens for PostgresEnum {
         let inv = quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;
                 use alloc::vec;

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/mod.rs
@@ -111,7 +111,7 @@ impl ToTokens for PostgresHash {
         let inv = quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 use core::any::TypeId;
                 extern crate alloc;
                 use alloc::vec::Vec;

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/mod.rs
@@ -111,7 +111,7 @@ impl ToTokens for PostgresOrd {
         let inv = quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 use core::any::TypeId;
                 extern crate alloc;
                 use alloc::vec::Vec;

--- a/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
@@ -161,7 +161,7 @@ impl ToTokens for PostgresType {
         let inv = quote! {
             #[no_mangle]
             #[doc(hidden)]
-            pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+            pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;
                 use alloc::vec;

--- a/pgx-utils/src/sql_entity_graph/schema/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/mod.rs
@@ -75,7 +75,7 @@ impl ToTokens for Schema {
         updated_content.push(syn::parse_quote! {
                 #[no_mangle]
                 #[doc(hidden)]
-                pub extern "C" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
+                pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::utils::sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;
                 use alloc::vec;

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -411,7 +411,8 @@ macro_rules! pg_sql_graph_magic {
     () => {
         #[no_mangle]
         #[doc(hidden)]
-        pub extern "C" fn __pgx_sql_mappings() -> ::pgx::utils::sql_entity_graph::RustToSqlMapping {
+        #[rustfmt::skip] // explict extern "Rust" is more clear here
+        pub extern "Rust" fn __pgx_sql_mappings() -> ::pgx::utils::sql_entity_graph::RustToSqlMapping {
             ::pgx::utils::sql_entity_graph::RustToSqlMapping {
                 rust_type_id_to_sql: ::pgx::DEFAULT_RUST_TYPE_ID_TO_SQL.clone(),
                 rust_source_to_sql: ::pgx::DEFAULT_RUST_SOURCE_TO_SQL.clone(),
@@ -423,7 +424,8 @@ macro_rules! pg_sql_graph_magic {
         // A marker which must exist in the root of the extension.
         #[no_mangle]
         #[doc(hidden)]
-        pub extern "C" fn __pgx_marker(
+        #[rustfmt::skip] // explict extern "Rust" is more clear here
+        pub extern "Rust" fn __pgx_marker(
         ) -> ::pgx::utils::__reexports::eyre::Result<::pgx::utils::sql_entity_graph::ControlFile> {
             use ::core::convert::TryFrom;
             use ::pgx::utils::__reexports::eyre::WrapErr;


### PR DESCRIPTION
The type of `__pgx_marker` is `extern "C" fn() -> eyre::Result<ControlFile>`, but it was incorrectly called as `extern "C" fn() -> SqlGraphEntity` in `cargo-pgx`, which is undefined behavior since it's UB to assume that a valid value for an `eyre::Result` is also a valid value for a `SqlGraphEntity`. On my M1 macOS device the undefined behavior results in an unconditional `Failed to get control file information` panic. This PR fixes that.

The only reason this ever worked was because on some platforms `eyre::Result<ControlFile>` and `SqlGraphEntity` both can have a `ControlFile` after a 1 byte long prefix. And it happened to be the case that `Result::Ok` and `SqlGraphEntity::ExtensionRoot` both correpond to a prefix of `0`.

I've also wrote [a similar fix for the same issue 0.4](https://github.com/Smittyvb/pgx/commit/25b6a31298dfcdc641fcfd3583f089b274fdcb26), I can make a PR against `master` with that commit if you want to backport this to the 0.4.x release series.