### PR TITLE
Specify logging config options when starting postgres from test framework

### DIFF
--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -498,6 +498,10 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
                 .expect("unable to determine test port")
                 .to_string(),
         )
+        .arg("-c")
+        .arg("log_destination=stderr")
+        .arg("-c")
+        .arg("logging_collector=off")
         .stdout(Stdio::inherit())
         .stderr(Stdio::piped());
 

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -498,10 +498,13 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
                 .expect("unable to determine test port")
                 .to_string(),
         )
-        .arg("-c")
-        .arg("log_destination=stderr")
-        .arg("-c")
-        .arg("logging_collector=off")
+        // Redirecting logs to files can hang the test framework, override it
+        .args([
+            "-c",
+            "log_destination=stderr",
+            "-c",
+            "logging_collector=off",
+        ])
         .stdout(Stdio::inherit())
         .stderr(Stdio::piped());
 


### PR DESCRIPTION
In postgres installations which have logging options which redirect output to files (`logging_collector = on`), the test framework will hang indefinitely waiting for `database system is ready to accept connections` line.