### PR TITLE
Block FATAL or PANIC in plrust via elog or ereport

### DIFF
--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = [ "rlib" ]
 
 [features]
 default = [ ]
+plrust = ["postgrestd"]
 postgrestd = ["pgx-pg-sys/postgrestd"]
 pg10 = [ "pgx-pg-sys/pg10" ]
 pg11 = [ "pgx-pg-sys/pg11" ]

--- a/pgx/src/log.rs
+++ b/pgx/src/log.rs
@@ -456,6 +456,19 @@ pub fn elog(level: PgLogLevel, message: &str) {
     use std::ffi::CString;
     use std::os::raw::c_char;
 
+    #[cfg(feature = "postgrestd")]
+    let level = {
+        use PgLogLevel::*;
+
+        // PL/Rust isn't permitted to abort the entire database.
+        match level {
+            level @ (DEBUG1 | DEBUG2 | DEBUG3 | DEBUG4 | DEBUG5 | LOG | LOG_SERVER_ONLY | INFO
+            | NOTICE | WARNING | ERROR) => level,
+            FATAL => ERROR,
+            PANIC => ERROR,
+        }
+    };
+
     unsafe {
         extern "C" {
             fn pgx_elog(level: i32, message: *const c_char);
@@ -489,6 +502,19 @@ pub fn ereport(
     use std::ffi::CStr;
     use std::ffi::CString;
     use std::os::raw::c_char;
+
+    #[cfg(feature = "postgrestd")]
+    let level = {
+        use PgLogLevel::*;
+
+        // PL/Rust isn't permitted to abort the entire database.
+        match level {
+            level @ (DEBUG1 | DEBUG2 | DEBUG3 | DEBUG4 | DEBUG5 | LOG | LOG_SERVER_ONLY | INFO
+            | NOTICE | WARNING | ERROR) => level,
+            FATAL => ERROR,
+            PANIC => ERROR,
+        }
+    };
 
     extern "C" {
         fn pgx_ereport(

--- a/pgx/src/log.rs
+++ b/pgx/src/log.rs
@@ -456,7 +456,7 @@ pub fn elog(level: PgLogLevel, message: &str) {
     use std::ffi::CString;
     use std::os::raw::c_char;
 
-    #[cfg(feature = "postgrestd")]
+    #[cfg(feature = "plrust")]
     let level = {
         use PgLogLevel::*;
 
@@ -503,7 +503,7 @@ pub fn ereport(
     use std::ffi::CString;
     use std::os::raw::c_char;
 
-    #[cfg(feature = "postgrestd")]
+    #[cfg(feature = "plrust")]
     let level = {
         use PgLogLevel::*;
 


### PR DESCRIPTION
Maybe this should be a different `cfg`, since really this is a plrust security level restriction, and postgrestd itself (for example) would be fine doing this itself internally.

Not sure.