### PR TITLE
Remove TimestampTz source mapping

### DIFF
--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -157,7 +157,6 @@ pub static DEFAULT_RUST_SOURCE_TO_SQL: Lazy<HashSet<RustSourceOnlySqlMapping>> =
     let mut m = HashSet::new();
 
     map_source_only!(m, pg_sys::Oid, "Oid");
-    map_source_only!(m, pg_sys::TimestampTz, "timestamp with time zone");
 
     m
 });


### PR DESCRIPTION
This seems to be purely a legacy curiosity.