### PR TITLE
Use `unguarded_switch_to` with `postgrestd` as intended

### DIFF
--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -382,7 +382,7 @@ impl PgMemoryContexts {
     pub fn leak_trivial_alloc<T>(&mut self, v: T) -> *mut T {
         #[cfg(feature = "postgrestd")]
         {
-            self.switch_to(|_cx| Box::leak(Box::new(v)))
+            self.unguarded_switch_to(|_cx| Box::leak(Box::new(v)))
         }
         #[cfg(not(feature = "postgrestd"))]
         {


### PR DESCRIPTION
This was missed during merging #615, it is necessary to get PL/Rust back to work, though the PL/Rust repo also needs some updates.