### PR TITLE
Paint bikeshed for `Datum::cast_mut_ptr`

### DIFF
--- a/pgx-examples/custom_types/src/lib.rs
+++ b/pgx-examples/custom_types/src/lib.rs
@@ -7,6 +7,8 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
+use pgx::prelude::*;
+
 mod complex;
 mod fixed_size;
 mod generic_enum;

--- a/pgx-examples/custom_types/src/lib.rs
+++ b/pgx-examples/custom_types/src/lib.rs
@@ -7,8 +7,6 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use pgx::prelude::*;
-
 mod complex;
 mod fixed_size;
 mod generic_enum;

--- a/pgx-pg-sys/src/submodules/datum.rs
+++ b/pgx-pg-sys/src/submodules/datum.rs
@@ -48,18 +48,14 @@ impl Datum {
         self.0.addr()
     }
 
-    /// Assume the datum is a pointer and treat it as void*.
-    pub fn to_void(self) -> *mut core::ffi::c_void {
-        self.0.cast()
-    }
-
     /// True if the datum is equal to the null pointer.
     pub fn is_null(self) -> bool {
         self.0.is_null()
     }
 
     /// Assume the datum is a pointer and cast it to point to T.
-    pub fn ptr_cast<T>(self) -> *mut T {
+    /// It is recommended to explicitly use `datum.cast_mut_ptr::<T>()`.
+    pub fn cast_mut_ptr<T>(self) -> *mut T {
         #[allow(unstable_name_collisions)]
         self.0.cast()
     }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -476,8 +476,8 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
         if is_null || datum.is_null() {
             None
         } else {
-            let ptr = datum.ptr_cast();
-            let array = pg_sys::pg_detoast_datum(datum.ptr_cast()) as *mut pg_sys::ArrayType;
+            let ptr = datum.cast_mut_ptr();
+            let array = pg_sys::pg_detoast_datum(datum.cast_mut_ptr()) as *mut pg_sys::ArrayType;
             let raw =
                 RawArray::from_ptr(NonNull::new(array).expect("detoast returned null ArrayType*"));
             let ptr = NonNull::new(ptr);

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -224,7 +224,7 @@ impl<'a> FromDatum for &'a str {
         if is_null || datum.is_null() {
             None
         } else {
-            let varlena = pg_sys::pg_detoast_datum_packed(datum.ptr_cast());
+            let varlena = pg_sys::pg_detoast_datum_packed(datum.cast_mut_ptr());
             Some(text_to_rust_str_unchecked(varlena))
         }
     }
@@ -243,7 +243,7 @@ impl<'a> FromDatum for &'a str {
         } else {
             memory_context.switch_to(|_| {
                 // this gets the varlena Datum copied into this memory context
-                let detoasted = pg_sys::pg_detoast_datum_copy(datum.ptr_cast());
+                let detoasted = pg_sys::pg_detoast_datum_copy(datum.cast_mut_ptr());
 
                 // and we need to unpack it (if necessary), which will decompress it too
                 let varlena = pg_sys::pg_detoast_datum_packed(detoasted);
@@ -283,7 +283,7 @@ impl<'a> FromDatum for &'a std::ffi::CStr {
         if is_null || datum.is_null() {
             None
         } else {
-            Some(std::ffi::CStr::from_ptr(datum.ptr_cast()))
+            Some(std::ffi::CStr::from_ptr(datum.cast_mut_ptr()))
         }
     }
 }
@@ -298,7 +298,7 @@ impl<'a> FromDatum for &'a crate::cstr_core::CStr {
         if is_null || datum.is_null() {
             None
         } else {
-            Some(crate::cstr_core::CStr::from_ptr(datum.ptr_cast()))
+            Some(crate::cstr_core::CStr::from_ptr(datum.cast_mut_ptr()))
         }
     }
 }
@@ -310,7 +310,7 @@ impl<'a> FromDatum for &'a [u8] {
         if is_null || datum.is_null() {
             None
         } else {
-            let varlena = pg_sys::pg_detoast_datum_packed(datum.ptr_cast());
+            let varlena = pg_sys::pg_detoast_datum_packed(datum.cast_mut_ptr());
             Some(varlena_to_byte_slice(varlena))
         }
     }
@@ -329,7 +329,7 @@ impl<'a> FromDatum for &'a [u8] {
         } else {
             memory_context.switch_to(|_| {
                 // this gets the varlena Datum copied into this memory context
-                let detoasted = pg_sys::pg_detoast_datum_copy(datum.ptr_cast());
+                let detoasted = pg_sys::pg_detoast_datum_copy(datum.cast_mut_ptr());
 
                 // and we need to unpack it (if necessary), which will decompress it too
                 let varlena = pg_sys::pg_detoast_datum_packed(detoasted);
@@ -375,7 +375,7 @@ impl<T> FromDatum for PgBox<T, AllocatedByPostgres> {
         if is_null || datum.is_null() {
             None
         } else {
-            Some(PgBox::<T>::from_pg(datum.ptr_cast()))
+            Some(PgBox::<T>::from_pg(datum.cast_mut_ptr()))
         }
     }
 
@@ -392,7 +392,7 @@ impl<T> FromDatum for PgBox<T, AllocatedByPostgres> {
             if is_null || datum.is_null() {
                 None
             } else {
-                let copied = context.copy_ptr_into(datum.ptr_cast(), std::mem::size_of::<T>());
+                let copied = context.copy_ptr_into(datum.cast_mut_ptr(), std::mem::size_of::<T>());
                 Some(PgBox::<T>::from_pg(copied))
             }
         })

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -17,7 +17,7 @@ impl FromDatum for pg_sys::BOX {
         if is_null {
             None
         } else {
-            let the_box = datum.ptr_cast::<pg_sys::BOX>();
+            let the_box = datum.cast_mut_ptr::<pg_sys::BOX>();
             Some(the_box.read())
         }
     }
@@ -47,7 +47,7 @@ impl FromDatum for pg_sys::Point {
         if is_null {
             None
         } else {
-            let point: *mut Self = datum.ptr_cast();
+            let point: *mut Self = datum.cast_mut_ptr();
             Some(point.read())
         }
     }

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -71,7 +71,7 @@ impl<'de> Deserialize<'de> for Inet {
                         let datum = Inet(v.clone()).into_datum().unwrap();
 
                         // and don't leak the 'inet' datum Postgres created
-                        pg_sys::pfree(datum.to_void());
+                        pg_sys::pfree(datum.cast_mut_ptr());
 
                         // we have it as a valid String
                         Ok(Inet(v.clone()))

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -60,7 +60,7 @@ impl Internal {
     #[inline(always)]
     pub unsafe fn get<T>(&self) -> Option<&T> {
         self.0
-            .and_then(|datum| (datum.to_void() as *const T).as_ref())
+            .and_then(|datum| (datum.cast_mut_ptr::<T>() as *const T).as_ref())
     }
 
     /// Initializes the internal with `value`, then returns a mutable reference to it.
@@ -79,7 +79,7 @@ impl Internal {
             PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(value),
         );
         let ptr = self.0.insert(datum);
-        &mut *(ptr.ptr_cast::<T>())
+        &mut *(ptr.cast_mut_ptr::<T>())
     }
 
     /// Return a reference to the memory pointed to by this [`Internal`], as `Some(&mut T)`, unless the
@@ -91,7 +91,8 @@ impl Internal {
     /// your responsibility.
     #[inline(always)]
     pub unsafe fn get_mut<T>(&self) -> Option<&mut T> {
-        self.0.and_then(|datum| (datum.ptr_cast::<T>()).as_mut())
+        self.0
+            .and_then(|datum| (datum.cast_mut_ptr::<T>()).as_mut())
     }
 
     /// Initializes the internal with `value` if it is not initialized, then returns a mutable reference to
@@ -144,7 +145,7 @@ impl Internal {
                 .into();
             datum
         });
-        &mut *(ptr.ptr_cast::<T>())
+        &mut *(ptr.cast_mut_ptr::<T>())
     }
 
     /// Returns the contained `Option<pg_sys::Datum>`

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -21,7 +21,7 @@ impl FromDatum for pg_sys::ItemPointerData {
         if is_null {
             None
         } else {
-            let tid = datum.ptr_cast();
+            let tid = datum.cast_mut_ptr();
             let (blockno, offno) = item_pointer_get_both(*tid);
             let mut tid_copy = pg_sys::ItemPointerData::default();
 

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -33,7 +33,7 @@ impl FromDatum for Json {
         if is_null {
             None
         } else {
-            let varlena = pg_sys::pg_detoast_datum(datum.ptr_cast());
+            let varlena = pg_sys::pg_detoast_datum(datum.cast_mut_ptr());
             let len = varsize_any_exhdr(varlena);
             let data = vardata_any(varlena);
             let slice = std::slice::from_raw_parts(data as *const u8, len);
@@ -49,7 +49,7 @@ impl FromDatum for JsonB {
         if is_null {
             None
         } else {
-            let varlena = datum.ptr_cast();
+            let varlena = datum.cast_mut_ptr();
             let detoasted = pg_sys::pg_detoast_datum_packed(varlena);
 
             let cstr = direct_function_call::<&std::ffi::CStr>(
@@ -91,7 +91,7 @@ impl FromDatum for JsonString {
         if is_null {
             None
         } else {
-            let varlena = datum.ptr_cast();
+            let varlena = datum.cast_mut_ptr();
             let detoasted = pg_sys::pg_detoast_datum_packed(varlena);
             let len = varsize_any_exhdr(detoasted);
             let data = vardata_any(detoasted);

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -84,7 +84,7 @@ impl<'de> Deserialize<'de> for Numeric {
                         let datum = Numeric(v.clone()).into_datum().unwrap();
 
                         // and don't leak the NumericData datum Postgres created
-                        pg_sys::pfree(datum.to_void());
+                        pg_sys::pfree(datum.cast_mut_ptr());
 
                         // we have it as a valid String
                         Ok(Numeric(v.clone()))

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -34,7 +34,7 @@ impl FromDatum for TimeWithTimeZone {
         if is_null {
             None
         } else {
-            let timetz = PgBox::from_pg(datum.ptr_cast::<pg_sys::TimeTzADT>());
+            let timetz = PgBox::from_pg(datum.cast_mut_ptr::<pg_sys::TimeTzADT>());
 
             let t = Time::from_datum(timetz.time.into(), false, typoid)
                 .expect("failed to convert TimeWithTimeZone");

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -46,7 +46,8 @@ impl FromDatum for Uuid {
         if is_null {
             None
         } else {
-            let bytes = std::slice::from_raw_parts(datum.to_void() as *const u8, UUID_BYTES_LEN);
+            let bytes =
+                std::slice::from_raw_parts(datum.cast_mut_ptr::<u8>() as *const u8, UUID_BYTES_LEN);
             if let Ok(uuid) = Uuid::from_slice(bytes) {
                 Some(uuid)
             } else {

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -164,10 +164,10 @@ where
     /// This function is considered unsafe as it cannot guarantee the provided `pg_sys::Datum` is a
     /// valid `*mut pg_sys::varlena`.
     pub unsafe fn from_datum(datum: pg_sys::Datum) -> Self {
-        let ptr = pg_sys::pg_detoast_datum(datum.ptr_cast());
+        let ptr = pg_sys::pg_detoast_datum(datum.cast_mut_ptr());
         let len = varsize_any(ptr);
 
-        if ptr == datum.ptr_cast() {
+        if ptr == datum.cast_mut_ptr() {
             // no detoasting happened so we're using borrowed memory
             let leaked = Box::leak(Box::new(PallocdVarlena { ptr, len }));
             PgVarlena {
@@ -320,7 +320,7 @@ where
         } else {
             memory_context.switch_to(|_| {
                 // this gets the varlena Datum copied into this memory context
-                let detoasted = pg_sys::pg_detoast_datum_copy(datum.ptr_cast());
+                let detoasted = pg_sys::pg_detoast_datum_copy(datum.cast_mut_ptr());
 
                 // and we need to unpack it (if necessary), which will decompress it too
                 let varlena = pg_sys::pg_detoast_datum_packed(detoasted);
@@ -353,7 +353,7 @@ where
         if is_null {
             None
         } else {
-            cbor_decode(datum.ptr_cast())
+            cbor_decode(datum.cast_mut_ptr())
         }
     }
 
@@ -366,7 +366,7 @@ where
         if is_null {
             None
         } else {
-            cbor_decode_into_context(memory_context, datum.ptr_cast())
+            cbor_decode_into_context(memory_context, datum.cast_mut_ptr())
         }
     }
 }

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -190,7 +190,7 @@ use std::ops::DerefMut;
 #[inline]
 pub fn pg_getarg_pointer<T>(fcinfo: pg_sys::FunctionCallInfo, num: usize) -> Option<*mut T> {
     match pg_getarg_datum(fcinfo, num) {
-        Some(datum) => Some(datum.ptr_cast::<T>()),
+        Some(datum) => Some(datum.cast_mut_ptr::<T>()),
         None => None,
     }
 }

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -222,7 +222,8 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
     /// This function is unsafe as we cannot guarantee that the provided Datum is a valid [pg_sys::HeapTupleHeader]
     /// pointer.
     pub unsafe fn from_composite_datum(composite: pg_sys::Datum) -> Self {
-        let htup_header = pg_sys::pg_detoast_datum(composite.ptr_cast()) as pg_sys::HeapTupleHeader;
+        let htup_header =
+            pg_sys::pg_detoast_datum(composite.cast_mut_ptr()) as pg_sys::HeapTupleHeader;
         let tup_type = crate::heap_tuple_header_get_type_id(htup_header);
         let tup_typmod = crate::heap_tuple_header_get_typmod(htup_header);
         let tupdesc = pg_sys::lookup_rowtype_tupdesc(tup_type, tup_typmod);

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -22,7 +22,7 @@ pub fn composite_row_type_make_tuple(
     row: pg_sys::Datum,
 ) -> PgBox<pg_sys::HeapTupleData, AllocatedByRust> {
     let htup_header =
-        unsafe { pg_sys::pg_detoast_datum_packed(row.ptr_cast()) } as pg_sys::HeapTupleHeader;
+        unsafe { pg_sys::pg_detoast_datum_packed(row.cast_mut_ptr()) } as pg_sys::HeapTupleHeader;
     let mut tuple = PgBox::<pg_sys::HeapTupleData>::alloc0();
 
     tuple.t_len = heap_tuple_header_get_datum_length(htup_header) as u32;


### PR DESCRIPTION
Before 0.5.0 goes gold, paint a bikeshed:
- With [`pointer::cast_{const, mut}` stabilizing in 1.65.0](https://github.com/rust-lang/rust/issues/92675),`Datum::ptr_cast` seems off. Instead, follow the ordering implied by `cast_mut`, `as_mut`, and `as_mut_ptr`: cast, mutability, then `_ptr` or rarely `_ref` for pointer-kind. This gives us `Datum::cast_mut_ptr::<T>` instead.
- `Datum::to_void` was used too rarely to warrant a unique fn, and `cast_mut_ptr` is more correct in 2 of those cases. Drop it.

Also, add some further verbiage about reference safety.