### PR TITLE
Implement more traits on Datum

### DIFF
--- a/pgx-pg-sys/src/submodules/datum.rs
+++ b/pgx-pg-sys/src/submodules/datum.rs
@@ -133,6 +133,12 @@ impl From<i64> for Datum {
     }
 }
 
+impl From<bool> for Datum {
+    fn from(val: bool) -> Datum {
+        Datum::from(val as usize)
+    }
+}
+
 impl<T> From<*mut T> for Datum {
     fn from(val: *mut T) -> Datum {
         Datum(val.cast())


### PR DESCRIPTION
Implements `From<bool>`, `Eq`, and `Hash` on `Datum`. All of these traits are also implemented on `usize`, so this makes upgrading to pgx 0.5 (where `Datum` is now a `struct`) easier.