### PR TITLE
Allow denying unsafe ops in PGX-using crates

### DIFF
--- a/pgx-pg-sys/src/submodules/guard.rs
+++ b/pgx-pg-sys/src/submodules/guard.rs
@@ -6,14 +6,14 @@ All rights reserved.
 
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
-
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(non_snake_case)]
 
 use crate::FlushErrorState;
 use std::any::Any;
 use std::cell::Cell;
 use std::mem;
-use std::panic::catch_unwind;
+use std::panic::{catch_unwind, RefUnwindSafe, UnwindSafe};
 
 extern "C" {
     fn pg_re_throw();
@@ -110,11 +110,13 @@ impl<T> PgTryResult<T> {
     ///
     /// Doing so can potentially leave Postgres in an undefined state and ultimately cause it
     /// to crash.
+    // Maybe not actually unsafe? Depends on why an error is reached.
     pub unsafe fn unwrap_or(self, value: T) -> T {
         match self.0 {
             Ok(result) => result,
             Err(_) => {
-                FlushErrorState();
+                // SAFETY: Caller asserts it is okay to avoid rethrowing an ERROR.
+                unsafe { FlushErrorState() };
                 value
             }
         }
@@ -129,6 +131,7 @@ impl<T> PgTryResult<T> {
     ///
     /// Ignoring a caught error can leave Postgres in an undefined state and ultimately cause it
     /// to crash.
+    // Maybe not actually unsafe? Depends on why an error is reached.
     pub unsafe fn unwrap_or_else<F>(self, cleanup: F) -> T
     where
         F: FnOnce() -> T,
@@ -136,7 +139,8 @@ impl<T> PgTryResult<T> {
         match self.0 {
             Ok(result) => result,
             Err(_) => {
-                FlushErrorState();
+                // SAFETY: Caller asserts it is okay to avoid rethrowing an ERROR.
+                unsafe { FlushErrorState() };
                 cleanup()
             }
         }
@@ -189,7 +193,7 @@ impl<T> PgTryResult<T> {
 /// before they're converted into Postgres ERRORs
 pub fn guard<Func, R>(f: Func) -> R
 where
-    Func: FnOnce() -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
+    Func: FnOnce() -> R + UnwindSafe + RefUnwindSafe,
 {
     pg_try(f).unwrap()
 }
@@ -198,14 +202,14 @@ where
 /// performing cleanup work before the caught error is rethrown
 pub fn pg_try<Try, R>(try_func: Try) -> PgTryResult<R>
 where
-    Try: FnOnce() -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
+    Try: FnOnce() -> R + UnwindSafe + RefUnwindSafe,
 {
     try_guard(try_func)
 }
 
 fn try_guard<Try, R>(try_func: Try) -> PgTryResult<R>
 where
-    Try: FnOnce() -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
+    Try: FnOnce() -> R + UnwindSafe + RefUnwindSafe,
 {
     // run try_func() in a catch_unwind, as we never want a Rust panic! to leak
     // from this function.  It's imperative that we nevery try to panic! across

--- a/pgx-pg-sys/src/submodules/setjmp.rs
+++ b/pgx-pg-sys/src/submodules/setjmp.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 /**
 Given a closure that is assumed to be a wrapped Postgres `extern "C"` function, [pg_guard_ffi_boundary]
 works with the Postgres and C runtimes to create a "barrier" that allows Rust to catch Postgres errors
@@ -45,7 +46,8 @@ being converted into a transaction-aborting Postgres `ERROR` by PGX.
 **/
 #[inline(always)]
 pub(crate) unsafe fn pg_guard_ffi_boundary<T, F: FnOnce() -> T>(f: F) -> T {
-    pg_guard_ffi_boundary_impl(f)
+    // SAFETY: Caller promises not to call us from anything but the main thread.
+    unsafe { pg_guard_ffi_boundary_impl(f) }
 }
 
 #[cfg(not(feature = "postgrestd"))]
@@ -54,32 +56,35 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
     //! This is the version that uses sigsetjmp and all that, for "normal" Rust/PGX interfaces.
     use crate as pg_sys;
 
-    // This should really, really not be done in a multithreaded context
-    let prev_exception_stack = pg_sys::PG_exception_stack;
-    let prev_error_context_stack = pg_sys::error_context_stack;
-    let mut jump_buffer = std::mem::MaybeUninit::uninit();
-    let jump_value = crate::sigsetjmp(jump_buffer.as_mut_ptr(), 0);
+    // SAFETY: This should really, really not be done in a multithreaded context as it
+    // accesses multiple `static mut`. The ultimate caller asserts this is the main thread.
+    unsafe {
+        let prev_exception_stack = pg_sys::PG_exception_stack;
+        let prev_error_context_stack = pg_sys::error_context_stack;
+        let mut jump_buffer = std::mem::MaybeUninit::uninit();
+        let jump_value = crate::sigsetjmp(jump_buffer.as_mut_ptr(), 0);
 
-    let result = if jump_value == 0 {
-        // first time through, not as the result of a longjmp
-        pg_sys::PG_exception_stack = jump_buffer.as_mut_ptr();
+        let result = if jump_value == 0 {
+            // first time through, not as the result of a longjmp
+            pg_sys::PG_exception_stack = jump_buffer.as_mut_ptr();
 
-        // execute the closure, which will be a wrapped internal Postgres function
-        f()
-    } else {
-        // we're back here b/c of a longjmp originating in Postgres
-        // as such, we need to put Postgres' understanding of its exception/error state back together
+            // execute the closure, which will be a wrapped internal Postgres function
+            f()
+        } else {
+            // we're back here b/c of a longjmp originating in Postgres
+            // as such, we need to put Postgres' understanding of its exception/error state back together
+            pg_sys::PG_exception_stack = prev_exception_stack;
+            pg_sys::error_context_stack = prev_error_context_stack;
+
+            // and ultimately we panic
+            std::panic::panic_any(pg_sys::JumpContext {});
+        };
+
         pg_sys::PG_exception_stack = prev_exception_stack;
         pg_sys::error_context_stack = prev_error_context_stack;
 
-        // and ultimately we panic
-        std::panic::panic_any(pg_sys::JumpContext {});
-    };
-
-    pg_sys::PG_exception_stack = prev_exception_stack;
-    pg_sys::error_context_stack = prev_error_context_stack;
-
-    result
+        result
+    }
 }
 
 #[cfg(feature = "postgrestd")]

--- a/pgx-utils/src/rewriter.rs
+++ b/pgx-utils/src/rewriter.rs
@@ -78,7 +78,7 @@ impl PgGuardRewriter {
             #vis #sig {
                 #[allow(non_snake_case)]
                 #func
-                pg_sys::guard::guard( || #func_name(#arg_list) )
+                pg_sys::guard::guard( #[allow(unused_unsafe)] || unsafe { #func_name(#arg_list) } )
             }
         }
     }

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -488,7 +488,6 @@ impl PgExtern {
                         let mut funcctx: ::pgx::PgBox<pg_sys::FuncCallContext>;
                         let mut iterator_holder: ::pgx::PgBox<IteratorHolder<#retval_ty_resolved>>;
 
-                        // SAFETY: I know what I'm doing. Scout's honor!
                         unsafe {
                             if ::pgx::srf_is_first_call(#fcinfo_ident) {
                                 funcctx = pgx::srf_first_call_init(#fcinfo_ident);
@@ -590,7 +589,6 @@ impl PgExtern {
                         let mut funcctx: pgx::PgBox<pg_sys::FuncCallContext>;
                         let mut iterator_holder: pgx::PgBox<IteratorHolder<#retval_tys_tuple>>;
 
-                        // SAFETY: I know what I'm doing. Scout's honor!
                         unsafe {
                             if ::pgx::srf_is_first_call(#fcinfo_ident) {
                                 funcctx = ::pgx::srf_first_call_init(#fcinfo_ident);

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -459,6 +459,7 @@ impl PgExtern {
                 let funcctx_ident = syn::Ident::new("funcctx", self.func.sig.span());
                 let retval_ty_resolved = retval_ty.original_ty;
                 let result_handler = if optional {
+                    // don't need unsafe annotations because of the larger unsafe block coming up
                     quote_spanned! { self.func.sig.span() =>
                         let #result_ident = match pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).switch_to(|_| { #func_name(#(#arg_pats),*) }) {
                             Some(result) => result,
@@ -478,6 +479,7 @@ impl PgExtern {
                     #[no_mangle]
                     #[doc(hidden)]
                     #[pg_guard]
+                    #[warn(unsafe_op_in_unsafe_fn)]
                     pub unsafe extern "C" fn #func_name_wrapper #func_generics(#fcinfo_ident: ::pgx::pg_sys::FunctionCallInfo) -> ::pgx::pg_sys::Datum {
                         struct IteratorHolder<'__pgx_internal_lifetime, T: std::panic::UnwindSafe + std::panic::RefUnwindSafe> {
                             iter: *mut SetOfIterator<'__pgx_internal_lifetime, T>,
@@ -486,29 +488,33 @@ impl PgExtern {
                         let mut funcctx: ::pgx::PgBox<pg_sys::FuncCallContext>;
                         let mut iterator_holder: ::pgx::PgBox<IteratorHolder<#retval_ty_resolved>>;
 
-                        if ::pgx::srf_is_first_call(#fcinfo_ident) {
-                            funcctx = pgx::srf_first_call_init(#fcinfo_ident);
-                            funcctx.user_fctx = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).palloc_struct::<IteratorHolder<#retval_ty_resolved>>() as *mut ::core::ffi::c_void;
+                        // SAFETY: I know what I'm doing. Scout's honor!
+                        unsafe {
+                            if ::pgx::srf_is_first_call(#fcinfo_ident) {
+                                funcctx = pgx::srf_first_call_init(#fcinfo_ident);
+                                funcctx.user_fctx = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).palloc_struct::<IteratorHolder<#retval_ty_resolved>>() as *mut ::core::ffi::c_void;
+                                iterator_holder = pgx::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_ty_resolved>);
 
+                                #( #arg_fetches )*
+                                #result_handler
+
+                                iterator_holder.iter = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).leak_trivial_alloc(result);
+                            }
+
+                            funcctx = pgx::srf_per_call_setup(#fcinfo_ident);
                             iterator_holder = pgx::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_ty_resolved>);
-
-                            #( #arg_fetches )*
-                            #result_handler
-
-                            iterator_holder.iter = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).leak_trivial_alloc(result);
                         }
 
-                        funcctx = pgx::srf_per_call_setup(#fcinfo_ident);
-                        iterator_holder = pgx::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_ty_resolved>);
-
-                        let mut iter = Box::from_raw(iterator_holder.iter);
+                        // SAFETY: should have been set up correctly on this or previous call
+                        let mut iter = unsafe { Box::from_raw(iterator_holder.iter) };
                         match iter.next() {
                             Some(result) => {
-                                // we need to leak the boxed iterator so that it's not freed by rust and we can
+                                // we need to leak the boxed iterator so that it's not freed by Rust and we can
                                 // continue to use it
                                 Box::leak(iter);
 
-                                pgx::srf_return_next(#fcinfo_ident, &mut funcctx);
+                                // SAFETY: what is an srf if it does not return?
+                                unsafe { pgx::srf_return_next(#fcinfo_ident, &mut funcctx) };
                                 match pgx::datum::IntoDatum::into_datum(result) {
                                     Some(datum) => datum,
                                     None => pgx::pg_return_null(#fcinfo_ident),
@@ -519,7 +525,8 @@ impl PgExtern {
                                 // function is going to properly drop it for us
                                 Box::leak(iter);
 
-                                pgx::srf_return_done(#fcinfo_ident, &mut funcctx);
+                                // SAFETY: seem to be finished
+                                unsafe { pgx::srf_return_done(#fcinfo_ident, &mut funcctx) };
                                 pgx::pg_return_null(#fcinfo_ident)
                             },
                         }
@@ -549,10 +556,12 @@ impl PgExtern {
                         }
                     )*
 
-                    let heap_tuple = pgx::pg_sys::heap_form_tuple(#funcctx_ident.tuple_desc, datums.as_mut_ptr(), nulls.as_mut_ptr());
+                    // SAFETY: just went to considerable trouble to make sure these are well-formed for a tuple
+                    let heap_tuple = unsafe { pgx::pg_sys::heap_form_tuple(#funcctx_ident.tuple_desc, datums.as_mut_ptr(), nulls.as_mut_ptr()) };
                 };
 
                 let result_handler = if optional {
+                    // don't need unsafe annotations because of the larger unsafe block coming up
                     quote_spanned! { self.func.sig.span() =>
                         let #result_ident = match pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).switch_to(|_| { #func_name(#(#arg_pats),*) }) {
                             Some(result) => result,
@@ -572,6 +581,7 @@ impl PgExtern {
                     #[no_mangle]
                     #[doc(hidden)]
                     #[pg_guard]
+                    #[warn(unsafe_op_in_unsafe_fn)]
                     pub unsafe extern "C" fn #func_name_wrapper #func_generics(#fcinfo_ident: ::pgx::pg_sys::FunctionCallInfo) -> ::pgx::pg_sys::Datum {
                         struct IteratorHolder<'__pgx_internal_lifetime, T: std::panic::UnwindSafe + std::panic::RefUnwindSafe> {
                             iter: *mut ::pgx::iter::TableIterator<'__pgx_internal_lifetime, T>,
@@ -580,31 +590,35 @@ impl PgExtern {
                         let mut funcctx: pgx::PgBox<pg_sys::FuncCallContext>;
                         let mut iterator_holder: pgx::PgBox<IteratorHolder<#retval_tys_tuple>>;
 
-                        if ::pgx::srf_is_first_call(#fcinfo_ident) {
-                            funcctx = ::pgx::srf_first_call_init(#fcinfo_ident);
-                            funcctx.user_fctx = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).palloc_struct::<IteratorHolder<#retval_tys_tuple>>() as *mut ::core::ffi::c_void;
-                            funcctx.tuple_desc = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).switch_to(|_| {
-                                let mut tupdesc: *mut pgx::pg_sys::TupleDescData = std::ptr::null_mut();
+                        // SAFETY: I know what I'm doing. Scout's honor!
+                        unsafe {
+                            if ::pgx::srf_is_first_call(#fcinfo_ident) {
+                                funcctx = ::pgx::srf_first_call_init(#fcinfo_ident);
+                                funcctx.user_fctx = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).palloc_struct::<IteratorHolder<#retval_tys_tuple>>() as *mut ::core::ffi::c_void;
+                                funcctx.tuple_desc = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).switch_to(|_| {
+                                    let mut tupdesc: *mut pgx::pg_sys::TupleDescData = std::ptr::null_mut();
 
-                                /* Build a tuple descriptor for our result type */
-                                if pgx::pg_sys::get_call_result_type(#fcinfo_ident, std::ptr::null_mut(), &mut tupdesc) != pgx::pg_sys::TypeFuncClass_TYPEFUNC_COMPOSITE {
-                                    pgx::error!("return type must be a row type");
-                                }
+                                    /* Build a tuple descriptor for our result type */
+                                    if pgx::pg_sys::get_call_result_type(#fcinfo_ident, std::ptr::null_mut(), &mut tupdesc) != pgx::pg_sys::TypeFuncClass_TYPEFUNC_COMPOSITE {
+                                        pgx::error!("return type must be a row type");
+                                    }
 
-                                pgx::pg_sys::BlessTupleDesc(tupdesc)
-                            });
+                                    pgx::pg_sys::BlessTupleDesc(tupdesc)
+                                });
+                                iterator_holder = pgx::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_tys_tuple>);
+
+                                #( #arg_fetches )*
+                                #result_handler
+
+                                iterator_holder.iter = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).leak_and_drop_on_delete(result);
+                            }
+
+                            funcctx = pgx::srf_per_call_setup(#fcinfo_ident);
                             iterator_holder = pgx::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_tys_tuple>);
-
-                            #( #arg_fetches )*
-                            #result_handler
-
-                            iterator_holder.iter = pgx::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).leak_and_drop_on_delete(result);
                         }
 
-                        funcctx = pgx::srf_per_call_setup(#fcinfo_ident);
-                        iterator_holder = pgx::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_tys_tuple>);
-
-                        let mut iter = Box::from_raw(iterator_holder.iter);
+                        // SAFETY: should have been set up correctly on this or previous call
+                        let mut iter = unsafe { Box::from_raw(iterator_holder.iter) };
                         match iter.next() {
                             Some(result) => {
                                 // we need to leak the boxed iterator so that it's not freed by rust and we can
@@ -614,7 +628,8 @@ impl PgExtern {
                                 #create_heap_tuple
 
                                 let datum = pgx::heap_tuple_get_datum(heap_tuple);
-                                pgx::srf_return_next(#fcinfo_ident, &mut funcctx);
+                                // SAFETY: what is an srf if it does not return?
+                                unsafe { pgx::srf_return_next(#fcinfo_ident, &mut funcctx) };
                                 pgx::pg_sys::Datum::from(datum)
                             },
                             None => {
@@ -622,7 +637,8 @@ impl PgExtern {
                                 // function is going to properly drop it for us
                                 Box::leak(iter);
 
-                                pgx::srf_return_done(#fcinfo_ident, &mut funcctx);
+                                // SAFETY: seem to be finished
+                                unsafe { pgx::srf_return_done(#fcinfo_ident, &mut funcctx) };
                                 pgx::pg_return_null(#fcinfo_ident)
                             },
                         }

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -404,7 +404,8 @@ impl PgExtern {
                             #arg_fetches
                         )*
 
-                        #func_name(#(#arg_pats),*)
+                        #[allow(unused_unsafe)] // unwrapped fn might be unsafe
+                        unsafe { #func_name(#(#arg_pats),*) }
                     }
             },
             Returning::Type(retval_ty) => {
@@ -443,7 +444,8 @@ impl PgExtern {
                             #arg_fetches
                         )*
 
-                        let #result_ident = #func_name(#(#arg_pats),*);
+                        #[allow(unused_unsafe)] // unwrapped fn might be unsafe
+                        let #result_ident = unsafe { #func_name(#(#arg_pats),*) };
 
                         #retval_transform
                     }


### PR DESCRIPTION
The most basic element that attempts to reinforce PGX's safety guarantees are various bits of "guard" code combined with code that handles the PostgreSQL function call interface for programmers, rather than allowing them to do it themselves. Rust RFC 2585 allows using `unsafe { }` blocks inside `unsafe fn`, allowing adding tightly, narrowly-scoped information on safety, even inside an `unsafe fn`. However, this can't be done at the crate level if the crate is expanded by macros to include "sloppy" code: the lint fires after the macro expansion. These two facts are rather at odds: PGX should make it easier to write code for PostgreSQL, including `unsafe` code or heavily linted code, not harder.

To fix this, use `unsafe { }` throughout macro-expanded code with a combination of `#[allow(unused_unsafe)]` and `#[warn(unsafe_op_in_unsafe_fn)]` on various items to prevent these lints from improperly firing. Some experimentation was done with a "user" crate (plrust) to help validate this approach.