### PR TITLE
Fixing release scripts 0.5.0 beta.1

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -11,10 +11,10 @@
 DIR=`pwd`
 set -x
 
+cd $DIR/pgx-pg-config && cargo publish && sleep 30
 cd $DIR/pgx-utils && cargo publish && sleep 30
 cd $DIR/pgx-macros && cargo publish && sleep 30
 cd $DIR/pgx-pg-sys && cargo publish --no-verify && sleep 30
 cd $DIR/pgx && cargo publish --no-verify && sleep 30
 cd $DIR/pgx-tests && cargo publish --no-verify && sleep 30
-cd $DIR/cargo-pgx && cargo publish
-
+cd $DIR/cargo-pgx && cargo publish # cargo-pgx last so the templates are correct

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -62,13 +62,16 @@ SEMVER_REGEX="(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*
 
 for cargo_toml in ${CARGO_TOMLS_TO_SED[@]}; do
     for dependency in ${DEPENDENCIES_TO_UPDATE[@]}; do
-        rg --passthru --no-line-number --multiline --multiline-dotall "(?P<prefix>^${dependency}.*\")(?P<pin>=?)${SEMVER_REGEX}(?P<postfix>\".*$)" -r "\${prefix}=${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
+        rg --passthru --no-line-number \
+        "(?P<prefix>^${dependency}.*\")(?P<pin>=?)${SEMVER_REGEX}(?P<postfix>\".*$)" \
+        -r "\${prefix}=${VERSION}\${postfix}" \
+        ${cargo_toml} > ${cargo_toml}.tmp || true
         mv ${cargo_toml}.tmp ${cargo_toml}
     done
 done
 
 for cargo_toml in ${CARGO_TOMLS_TO_BUMP[@]}; do
-    rg --passthru -N "(?P<prefix>^version = \")${SEMVER_REGEX}(?P<postfix>\"$)" -r "\${prefix}${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
+    rg --passthru --no-line-number "(?P<prefix>^version = \")${SEMVER_REGEX}(?P<postfix>\"$)" -r "\${prefix}${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
     mv ${cargo_toml}.tmp ${cargo_toml}
 done
 

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -62,9 +62,7 @@ SEMVER_REGEX="(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*
 
 for cargo_toml in ${CARGO_TOMLS_TO_SED[@]}; do
     for dependency in ${DEPENDENCIES_TO_UPDATE[@]}; do
-        rg --passthru --no-line-number \
-        --multiline --multiline-dotall \
-        "(?P<prefix>^${dependency}.*\")(?P<pin>=?)${SEMVER_REGEX}(?P<postfix>\".*$)" -r "\${prefix}=${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
+        rg --passthru --no-line-number --multiline --multiline-dotall "(?P<prefix>^${dependency}.*\")(?P<pin>=?)${SEMVER_REGEX}(?P<postfix>\".*$)" -r "\${prefix}=${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
         mv ${cargo_toml}.tmp ${cargo_toml}
     done
 done

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -29,7 +29,6 @@ if ! cargo set-version --help &> /dev/null; then
     exit 1
 fi
 
-HEAD=$(git rev-parse HEAD)
 VERSION=$1
 
 # Use `cargo set-version` to update all main project files
@@ -61,13 +60,8 @@ function update_extras() {
 
     # ordered in a topological fashion starting from the workspace root Cargo.toml
     # this isn't always necessary, but it's nice to use a mostly-consistent ordering
-    CARGO_TOMLS_TO_BUMP=(
-        ./Cargo.toml
-    )
-
     CARGO_TOMLS_TO_SED=(
         ./Cargo.toml
-        ./pgx-examples/*/Cargo.toml
         ./cargo-pgx/src/templates/cargo_toml
         ./nix/templates/default/Cargo.toml
     )
@@ -94,10 +88,6 @@ function update_extras() {
         done
     done
 
-    for cargo_toml in ${CARGO_TOMLS_TO_BUMP[@]}; do
-        rg --passthru --no-line-number "(?P<prefix>^version = \")${SEMVER_REGEX}(?P<postfix>\"$)" -r "\${prefix}${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
-        mv ${cargo_toml}.tmp ${cargo_toml}
-    done
 }
 
 update_main_files $VERSION

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -10,6 +10,7 @@
 
 # requires:
 # * ripgrep
+# * Cargo extension 'cargo-edit'
 
 if [ "x$1" == "x" ]; then
     echo "usage:  ./update-verions.sh <VERSION>"
@@ -18,62 +19,89 @@ fi
 
 set -ex
 
+if ! which rg &> /dev/null; then
+    echo "Command `rg` (ripgrep) was not found. Please install it and try again."
+    exit 1
+fi
+
+if ! cargo set-version --help &> /dev/null; then
+    echo "Cargo extension `cargo-edit` is not installed. Please install it by running: cargo install cargo-edit"
+    exit 1
+fi
+
 HEAD=$(git rev-parse HEAD)
 VERSION=$1
 
-# ordered in a topological fashion starting from the workspace root Cargo.toml
-# this isn't always necessary, but it's nice to use a mostly-consistent ordering
-CARGO_TOMLS_TO_BUMP=(
-    ./Cargo.toml
-    ./pgx-pg-config/Cargo.toml
-    ./pgx-utils/Cargo.toml
-    ./cargo-pgx/Cargo.toml
-    ./pgx-macros/Cargo.toml
-    ./pgx-pg-sys/Cargo.toml
-    ./pgx/Cargo.toml
-    ./pgx-tests/Cargo.toml
-)
+# Use `cargo set-version` to update all main project files
+function update_main_files() {
+    local version=$1
 
-CARGO_TOMLS_TO_SED=(
-    ./Cargo.toml
-    ./pgx-pg-config/Cargo.toml
-    ./pgx-utils/Cargo.toml
-    ./cargo-pgx/Cargo.toml
-    ./pgx-macros/Cargo.toml
-    ./pgx-pg-sys/Cargo.toml
-    ./pgx/Cargo.toml
-    ./pgx-tests/Cargo.toml
-    ./pgx-examples/*/Cargo.toml
-    ./cargo-pgx/src/templates/cargo_toml
-    ./nix/templates/default/Cargo.toml
-)
+    EXCLUDE_PACKAGES=()
 
-DEPENDENCIES_TO_UPDATE=(
-    "pgx-pg-config"
-    "pgx-utils"
-    "cargo-pgx"
-    "pgx-macros"
-    "pgx-pgx-sys"
-    "pgx"
-    "pgx-tests"
-)
+    # Add additional packages to ignore by using the following syntax:
+    # EXCLUDE_PACKAGES+=('foo' 'bar' 'baz')
 
-SEMVER_REGEX="(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+    # Ignore all packages in pgx-examples/
+    for file in $(find pgx-examples/ -type f -name "Cargo.toml"); do
+        EXCLUDE_PACKAGES+=($(cat $file | rg --multiline '\[package\](.*\n)(?:[^\[]*\n)*name\s?=\s?"(?P<name>[-_a-z]*)"(.*\n)*' -r "\${name}"))
+    done
 
-for cargo_toml in ${CARGO_TOMLS_TO_SED[@]}; do
-    for dependency in ${DEPENDENCIES_TO_UPDATE[@]}; do
-        rg --passthru --no-line-number \
-        "(?P<prefix>^${dependency}.*\")(?P<pin>=?)${SEMVER_REGEX}(?P<postfix>\".*$)" \
-        -r "\${prefix}=${VERSION}\${postfix}" \
-        ${cargo_toml} > ${cargo_toml}.tmp || true
+    echo "Excluding the following packages:"
+    for p in "${EXCLUDE_PACKAGES[@]}"; do
+        echo " * $p"
+    done
+    echo ""
+
+    cargo set-version $(echo "${EXCLUDE_PACKAGES[@]/#/--exclude }") --workspace $version
+}
+
+# This is a legacy holdover for updating extra toml files throughout various crates
+function update_extras() {
+    local version=$1
+
+    # ordered in a topological fashion starting from the workspace root Cargo.toml
+    # this isn't always necessary, but it's nice to use a mostly-consistent ordering
+    CARGO_TOMLS_TO_BUMP=(
+        ./Cargo.toml
+    )
+
+    CARGO_TOMLS_TO_SED=(
+        ./Cargo.toml
+        ./pgx-examples/*/Cargo.toml
+        ./cargo-pgx/src/templates/cargo_toml
+        ./nix/templates/default/Cargo.toml
+    )
+
+    DEPENDENCIES_TO_UPDATE=(
+        "pgx-pg-config"
+        "pgx-utils"
+        "cargo-pgx"
+        "pgx-macros"
+        "pgx-pgx-sys"
+        "pgx"
+        "pgx-tests"
+    )
+
+    SEMVER_REGEX="(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+
+    for cargo_toml in ${CARGO_TOMLS_TO_SED[@]}; do
+        for dependency in ${DEPENDENCIES_TO_UPDATE[@]}; do
+            rg --passthru --no-line-number \
+            "(?P<prefix>^${dependency}.*\")(?P<pin>=?)${SEMVER_REGEX}(?P<postfix>\".*$)" \
+            -r "\${prefix}=${VERSION}\${postfix}" \
+            ${cargo_toml} > ${cargo_toml}.tmp || true
+            mv ${cargo_toml}.tmp ${cargo_toml}
+        done
+    done
+
+    for cargo_toml in ${CARGO_TOMLS_TO_BUMP[@]}; do
+        rg --passthru --no-line-number "(?P<prefix>^version = \")${SEMVER_REGEX}(?P<postfix>\"$)" -r "\${prefix}${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
         mv ${cargo_toml}.tmp ${cargo_toml}
     done
-done
+}
 
-for cargo_toml in ${CARGO_TOMLS_TO_BUMP[@]}; do
-    rg --passthru --no-line-number "(?P<prefix>^version = \")${SEMVER_REGEX}(?P<postfix>\"$)" -r "\${prefix}${VERSION}\${postfix}" ${cargo_toml} > ${cargo_toml}.tmp || true
-    mv ${cargo_toml}.tmp ${cargo_toml}
-done
+update_main_files $VERSION
+update_extras $VERSION
 
 cargo generate-lockfile
 

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -20,12 +20,12 @@ fi
 set -ex
 
 if ! which rg &> /dev/null; then
-    echo "Command `rg` (ripgrep) was not found. Please install it and try again."
+    echo "Command \`rg\` (ripgrep) was not found. Please install it and try again."
     exit 1
 fi
 
 if ! cargo set-version --help &> /dev/null; then
-    echo "Cargo extension `cargo-edit` is not installed. Please install it by running: cargo install cargo-edit"
+    echo "Cargo extension \`cargo-edit\` is not installed. Please install it by running: cargo install cargo-edit"
     exit 1
 fi
 
@@ -41,17 +41,15 @@ function update_main_files() {
     # EXCLUDE_PACKAGES+=('foo' 'bar' 'baz')
 
     # Ignore all packages in pgx-examples/
-    for file in $(find pgx-examples/ -type f -name "Cargo.toml"); do
-        EXCLUDE_PACKAGES+=($(cat $file | rg --multiline '\[package\](.*\n)(?:[^\[]*\n)*name\s?=\s?"(?P<name>[-_a-z]*)"(.*\n)*' -r "\${name}"))
+    for file in ./pgx-examples/**/Cargo.toml; do
+        EXCLUDE_PACKAGES+=("$(rg --multiline '\[package\](.*\n)(?:[^\[]*\n)*name\s?=\s?"(?P<name>[-_a-z]*)"(.*\n)*' -r "\${name}" "$file")")
     done
 
     echo "Excluding the following packages:"
-    for p in "${EXCLUDE_PACKAGES[@]}"; do
-        echo " * $p"
-    done
-    echo ""
+    echo "${EXCLUDE_PACKAGES[@]}"
 
-    cargo set-version $(echo "${EXCLUDE_PACKAGES[@]/#/--exclude }") --workspace $version
+    # shellcheck disable=2068 # allow the shell to split --exclude from each EXCLUDE_PACKAGES value
+    cargo set-version ${EXCLUDE_PACKAGES[@]/#/--exclude } --workspace "$version"
 }
 
 # This is a legacy holdover for updating extra toml files throughout various crates

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -12,8 +12,8 @@
 # * ripgrep
 # * Cargo extension 'cargo-edit'
 
-if [ "x$1" == "x" ]; then
-    echo "usage:  ./update-verions.sh <VERSION>"
+if [ "$1" == "" ]; then
+    echo "usage:  ./update-versions.sh <VERSION>"
     exit 1
 fi
 
@@ -82,7 +82,7 @@ function update_extras() {
         for dependency in ${DEPENDENCIES_TO_UPDATE[@]}; do
             rg --passthru --no-line-number \
             "(?P<prefix>^${dependency}.*\")(?P<pin>=?)${SEMVER_REGEX}(?P<postfix>\".*$)" \
-            -r "\${prefix}=${VERSION}\${postfix}" \
+            -r "\${prefix}=${version}\${postfix}" \
             ${cargo_toml} > ${cargo_toml}.tmp || true
             mv ${cargo_toml}.tmp ${cargo_toml}
         done


### PR DESCRIPTION
So these don't quite work yet because when I run them

```
error: no matching package found
searched package name: `pgx`
prerelease package needs to be specified explicitly
pgx = { version = "0.5.0-beta.1" }
location searched: ~/tcdi/pgx/pgx
required by package `pgx-tests v0.5.0-beta.1 (~/tcdi/pgx/pgx-tests)`
```

Any suggestions?