### PR TITLE
Fix invalid SQL generated by `#[pg_extern(create_or_replace)]`

### DIFF
--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -438,6 +438,7 @@ impl ToSql for PgExternEntity {
             } else {
                 let mut retval = extern_attrs
                     .iter()
+                    .filter(|attr| **attr != ExternArgs::CreateOrReplace)
                     .map(|attr| format!("{}", attr).to_uppercase())
                     .collect::<Vec<_>>()
                     .join(" ");


### PR DESCRIPTION
When using the `create_or_replace` attribute, the generated SQL would contain CREATE OR REPLACE twice, e.g.:

```
CREATE OR REPLACE FUNCTION "my_function"() RETURNS INT /* i32 */
CREATE OR REPLACE STRICT
LANGUAGE c /* Rust */
AS 'MODULE_PATHNAME', 'my_function_wrapper';
```

This is because the `create_or_replace` attribute is not removed from the array of attributes before being transformed to SQL.