### PR TITLE
Don't use incorrect rust-version metadata

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["database", "postgres", "postgresql", "extension"]
 readme = "README.md"
 exclude = [ "*.png" ]
 edition = "2021"
-rust-version = "1.58"
 
 [dependencies]
 atty = "0.2.14"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -2,7 +2,6 @@
 name = "{name}"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pgx_demo"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -2,7 +2,6 @@
 name = "aggregate"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/arrays/Cargo.toml
+++ b/pgx-examples/arrays/Cargo.toml
@@ -2,7 +2,6 @@
 name = "arrays"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/bad_ideas/Cargo.toml
+++ b/pgx-examples/bad_ideas/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bad_ideas"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/bgworker/Cargo.toml
+++ b/pgx-examples/bgworker/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bgworker"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/bytea/Cargo.toml
+++ b/pgx-examples/bytea/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bytea"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/composite_type/Cargo.toml
+++ b/pgx-examples/composite_type/Cargo.toml
@@ -2,7 +2,6 @@
 name = "composite_type"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/custom_sql/Cargo.toml
+++ b/pgx-examples/custom_sql/Cargo.toml
@@ -2,7 +2,6 @@
 name = "custom_sql"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -2,7 +2,6 @@
 name = "custom_types"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/errors/Cargo.toml
+++ b/pgx-examples/errors/Cargo.toml
@@ -2,7 +2,6 @@
 name = "errors"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/nostd/Cargo.toml
+++ b/pgx-examples/nostd/Cargo.toml
@@ -2,7 +2,6 @@
 name = "nostd"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/operators/Cargo.toml
+++ b/pgx-examples/operators/Cargo.toml
@@ -2,7 +2,6 @@
 name = "operators"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/schemas/Cargo.toml
+++ b/pgx-examples/schemas/Cargo.toml
@@ -2,7 +2,6 @@
 name = "schemas"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/shmem/Cargo.toml
+++ b/pgx-examples/shmem/Cargo.toml
@@ -2,7 +2,6 @@
 name = "shmem"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/spi/Cargo.toml
+++ b/pgx-examples/spi/Cargo.toml
@@ -2,7 +2,6 @@
 name = "spi"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/srf/Cargo.toml
+++ b/pgx-examples/srf/Cargo.toml
@@ -2,7 +2,6 @@
 name = "srf"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/strings/Cargo.toml
+++ b/pgx-examples/strings/Cargo.toml
@@ -2,7 +2,6 @@
 name = "strings"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/triggers/Cargo.toml
+++ b/pgx-examples/triggers/Cargo.toml
@@ -2,7 +2,6 @@
 name = "triggers"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-examples/versioned_so/Cargo.toml
+++ b/pgx-examples/versioned_so/Cargo.toml
@@ -2,7 +2,6 @@
 name = "versioned_so"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-macros"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 proc-macro = true

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/zombodb/pgx"
 #documentation = "https://docs.rs/pgx-utils"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.58"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-pg-sys"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.58"
 
 [features]
 default = [ ]

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-tests"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = [ "cdylib", "lib" ]

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/zombodb/pgx"
 documentation = "https://docs.rs/pgx-utils"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.58"
 
 [dependencies]
 seq-macro = "0.3"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 readme = "../README.md"
 edition = "2021"
-rust-version = "1.58"
 
 [lib]
 crate-type = [ "rlib" ]


### PR DESCRIPTION
This removes the rust-version field from the tomls in the repo, as it has fallen behind (again) as we still have no enforcement mechanism for its correctness and it cannot be expected to "stay put" without naturally drifting over time due to Rust usage evolving.