### PR TITLE
Allow type structs to be filtered before serialization

### DIFF
--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -741,7 +741,7 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
     // needs custom filtration
     if !args.contains(&PostgresTypeAttribute::FilterDatum) {
         stream.extend(quote! {
-            impl IntoDatumFilter for #name {}
+            impl #generics pgx::IntoDatumFilter for #name #generics {}
         })
     }
 

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -332,12 +332,18 @@ where
     }
 }
 
+pub trait IntoDatumFilter {
+    fn filter_for_datum(self) -> Self where Self: Sized {
+        self
+    }
+}
+
 impl<T> IntoDatum for T
 where
-    T: PostgresType + Serialize,
+    T: PostgresType + Serialize + IntoDatumFilter,
 {
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        Some(cbor_encode(&self) as pg_sys::Datum)
+        Some(cbor_encode(&self.filter_for_datum()) as pg_sys::Datum)
     }
 
     fn type_oid() -> u32 {


### PR DESCRIPTION
In (very) rare circumstances, structs that can be successfully CBOR serialized shouldn't be serialized with everything that was sent in the query, but should instead be stored with only a subset of that data. Instead of having to write an entire custom inoutfuncs set, this patch allows a type to declare that it needs to "filter" the struct before it's turned into a `Datum`, and then implement a trait to do so.