### PR TITLE
Stop binding system headers and a few other things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -37,7 +37,7 @@ pgx-utils = { path = "../pgx-utils/", version = "=0.5.0-beta.1" }
 sptr = "0.3"
 
 [build-dependencies]
-bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
 build-deps = "0.1.4"
 owo-colors = "3.5.0"
 num_cpus = "1.13.1"

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -549,7 +549,8 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .blocklist_function(".*(set|long)jmp")
         .blocklist_function("pg_re_throw")
         .blocklist_item("CONFIGURE_ARGS") // configuration during build is hopefully irrelevant
-        .blocklist_item("_*(HAVE|have)_.*") // these are for C's use
+        .blocklist_item("(_*HAVE|__have)_.*") // header tracking metadata
+        .blocklist_item("_[A-Z_]+_H") // more header metadata
         .blocklist_item("__[A-Z].*") // these are reserved and unused by Postgres
         .blocklist_item("__darwin.*") // this should always be Apple's names
         .blocklist_function("float[48].*") // Rust has plenty of float handling

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -553,6 +553,8 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .blocklist_item("_[A-Z_]+_H") // more header metadata
         .blocklist_item("__[A-Z].*") // these are reserved and unused by Postgres
         .blocklist_item("__darwin.*") // this should always be Apple's names
+        .blocklist_function("pq(Strerror|Get.*)") // wrappers around platform functions: user can call those themselves
+        .blocklist_item(".*pthread.*)") // shims for pthreads on non-pthread systems, just use std::thread
         .blocklist_function("float[48].*") // Rust has plenty of float handling
         .blocklist_item(".*[vV][aA]_(list|LIST|start|START|end|END|copy|COPY).*") // do not need va_list anything!
         .blocklist_function("(pg_|p)v(sn?|f)?printf")

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -555,6 +555,10 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .blocklist_item("_*(HAVE|have)_.*") // these are for C's use
         .blocklist_item("__[A-Z].*") // these are reserved
         .blocklist_function("float[48].*") // Rust has plenty of float handling
+        .blocklist_item(".*[vV][aA]_(list|LIST|start|START|end|END|copy|COPY).*") // do not need va_list anything!
+        .blocklist_function("(pg_|p)v(sn?|f)?printf")
+        .blocklist_function("appendStringInfoVA")
+        .blocklist_file("stdarg.h")
         .size_t_is_usize(true)
         .rustfmt_bindings(false)
         .derive_debug(true)

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -537,27 +537,27 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .clang_arg(&format!("-I{}", includedir_server.display()))
         .parse_callbacks(Box::new(PgxOverrides::default()))
         .allowlist_file(".*confdefs.h")
-        .allowlist_file(".*([fF]uncs|mgr).h")
-        .allowlist_file(".*htup(_details)?.h")
+        .allowlist_file(".*(?:[fF]uncs|mgr).h")
+        .allowlist_file(".*htup(?:_details)?.h")
         .allowlist_file(".*syscache.h")
         .allowlist_file(".*mcxt.h")
-        .allowlist_file(".*(storage|catalog|access|commands|executor|adt|optimizer|rewrite|postmaster|tcop|replication|nodes|postgres|parse|pg_|item|heap).*")
+        .allowlist_file(".*(?:storage|catalog|access|commands|executor|adt|optimizer|rewrite|postmaster|tcop|replication|nodes|postgres|parse|pg_|item|heap).*")
         .allowlist_var("SIG.*")
         .blocklist_type("(Nullable)?Datum") // manually wrapping datum types for correctness
         .blocklist_function("varsize_any") // pgx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
-        .blocklist_function("(query|expression)_tree_walker")
-        .blocklist_function(".*(set|long)jmp")
+        .blocklist_function("(?:query|expression)_tree_walker")
+        .blocklist_function(".*(?:set|long)jmp")
         .blocklist_function("pg_re_throw")
         .blocklist_item("CONFIGURE_ARGS") // configuration during build is hopefully irrelevant
-        .blocklist_item("(_*HAVE|__have)_.*") // header tracking metadata
+        .blocklist_item("_*(?:HAVE|have)_.*") // header tracking metadata
         .blocklist_item("_[A-Z_]+_H") // more header metadata
         .blocklist_item("__[A-Z].*") // these are reserved and unused by Postgres
         .blocklist_item("__darwin.*") // this should always be Apple's names
-        .blocklist_function("pq(Strerror|Get.*)") // wrappers around platform functions: user can call those themselves
+        .blocklist_function("pq(?:Strerror|Get.*)") // wrappers around platform functions: user can call those themselves
         .blocklist_item(".*pthread.*)") // shims for pthreads on non-pthread systems, just use std::thread
         .blocklist_function("float[48].*") // Rust has plenty of float handling
-        .blocklist_item(".*[vV][aA]_(list|LIST|start|START|end|END|copy|COPY).*") // do not need va_list anything!
-        .blocklist_function("(pg_|p)v(sn?|f)?printf")
+        .blocklist_item(".*(?i:va)_(?i:list|start|end|copy).*") // do not need va_list anything!
+        .blocklist_function("(?:pg_|p)v(?:sn?|f)?printf")
         .blocklist_function("appendStringInfoVA")
         .blocklist_file("stdarg.h")
         .size_t_is_usize(true)

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -542,7 +542,6 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .allowlist_file(".*syscache.h")
         .allowlist_file(".*mcxt.h")
         .allowlist_file(".*(storage|catalog|access|commands|executor|adt|optimizer|rewrite|postmaster|tcop|replication|nodes|postgres|parse|pg_|item|heap).*")
-        .allowlist_function("memcpy")
         .allowlist_var("SIG.*")
         .blocklist_type("Datum") // manually wrapping datum types for correctness
         .blocklist_type("NullableDatum")

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -543,13 +543,10 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .allowlist_file(".*mcxt.h")
         .allowlist_file(".*(storage|catalog|access|commands|executor|adt|optimizer|rewrite|postmaster|tcop|replication|nodes|postgres|parse|pg_|item|heap).*")
         .allowlist_var("SIG.*")
-        .blocklist_type("Datum") // manually wrapping datum types for correctness
-        .blocklist_type("NullableDatum")
+        .blocklist_type("(Nullable)?Datum") // manually wrapping datum types for correctness
         .blocklist_function("varsize_any") // pgx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
-        .blocklist_function("query_tree_walker")
-        .blocklist_function("expression_tree_walker")
-        .blocklist_function(".*setjmp")
-        .blocklist_function(".*longjmp")
+        .blocklist_function("(query|expression)_tree_walker")
+        .blocklist_function(".*(set|long)jmp")
         .blocklist_function("pg_re_throw")
         .blocklist_item("CONFIGURE_ARGS") // configuration during build is hopefully irrelevant
         .blocklist_item("_*(HAVE|have)_.*") // these are for C's use

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -550,7 +550,8 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .blocklist_function("pg_re_throw")
         .blocklist_item("CONFIGURE_ARGS") // configuration during build is hopefully irrelevant
         .blocklist_item("_*(HAVE|have)_.*") // these are for C's use
-        .blocklist_item("__[A-Z].*") // these are reserved
+        .blocklist_item("__[A-Z].*") // these are reserved and unused by Postgres
+        .blocklist_item("__darwin.*") // this should always be Apple's names
         .blocklist_function("float[48].*") // Rust has plenty of float handling
         .blocklist_item(".*[vV][aA]_(list|LIST|start|START|end|END|copy|COPY).*") // do not need va_list anything!
         .blocklist_function("(pg_|p)v(sn?|f)?printf")


### PR DESCRIPTION
Use an allowlist that covers the various Postgres source folders, and blocklist a number of things that only C would be interested in. This reduces the generated bindings by about half a megabyte each.

This partially follows up on tcdi/pgx#730.
Is this what you meant, Thom?