### PR TITLE
`#[derive(Deserialize)]` Timestamps

### DIFF
--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -11,9 +11,10 @@ use crate::{pg_sys, FromDatum, FromTimeError, IntoDatum, TimestampWithTimeZone};
 use pgx_utils::sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
+use serde::Deserialize;
 use std::ffi::CStr;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[repr(transparent)]
 pub struct Timestamp(pg_sys::Timestamp);
 

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -11,6 +11,7 @@ use crate::{pg_sys, FromDatum, IntoDatum};
 use pgx_utils::sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
+use serde::Deserialize;
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::ops::Sub;
@@ -25,7 +26,7 @@ const PG_EPOCH_DATETIME: time::PrimitiveDateTime = date!(2000 - 01 - 01).midnigh
 const MIN_TIMESTAMP_USEC: i64 = -211_813_488_000_000_000;
 const END_TIMESTAMP_USEC: i64 = 9_223_371_331_200_000_000 - 1; // dec by 1 to accommodate exclusive range match pattern
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[repr(transparent)]
 pub struct TimestampWithTimeZone(pg_sys::TimestampTz);
 


### PR DESCRIPTION
PGX should offer proper deserialization from strings at some point, however, this doesn't need to be more complicated because the only user is deserializing from integer data at the moment, and PGX did not previously directly `impl Deserialize`, nor did PGX enable the serde feature of the time crate.

It is mildly unfortunate that this means serde doesn't round trip, currently, but it is preferable to have a working type over not. This is necessary as previously, PGX's type mappings were more compatible with the `pg_sys::Timestamp{,Tz}` types.