### PR TITLE
Add example type which implements `PostgresOrd`

### DIFF
--- a/pgx-examples/custom_types/src/lib.rs
+++ b/pgx-examples/custom_types/src/lib.rs
@@ -11,6 +11,7 @@ mod complex;
 mod fixed_size;
 mod generic_enum;
 mod hstore_clone;
+mod ordered;
 
 pgx::pg_module_magic!();
 

--- a/pgx-examples/custom_types/src/ordered.rs
+++ b/pgx-examples/custom_types/src/ordered.rs
@@ -19,7 +19,7 @@ use pgx::pg_schema;
     PartialOrd,
     PostgresType,
     PostgresEq,
-    PostgresOrd,
+    PostgresOrd
 )]
 pub struct OrderedThing {
     item: String,
@@ -30,11 +30,7 @@ pub struct OrderedThing {
 impl Ord for OrderedThing {
     fn cmp(&self, other: &Self) -> Ordering {
         fn starts_lower(thing: &OrderedThing) -> bool {
-            thing
-                .item
-                .chars()
-                .next()
-                .map_or(false, |c| c.is_lowercase())
+            thing.item.chars().next().map_or(false, |c| c.is_lowercase())
         }
         if starts_lower(self) {
             if starts_lower(other) {
@@ -72,18 +68,10 @@ mod tests {
         assert_eq!(
             items,
             Some(vec![
-                OrderedThing {
-                    item: "Foo".to_string()
-                },
-                OrderedThing {
-                    item: "Bar".to_string()
-                },
-                OrderedThing {
-                    item: "bar".to_string()
-                },
-                OrderedThing {
-                    item: "foo".to_string()
-                },
+                OrderedThing { item: "Foo".to_string() },
+                OrderedThing { item: "Bar".to_string() },
+                OrderedThing { item: "bar".to_string() },
+                OrderedThing { item: "foo".to_string() },
             ])
         )
     }

--- a/pgx-examples/custom_types/src/ordered.rs
+++ b/pgx-examples/custom_types/src/ordered.rs
@@ -1,0 +1,90 @@
+use pgx::{
+    commutator, hashes, join, merges, negator, opname, pg_extern, pg_guard, pg_operator, pg_sys,
+    restrict, PostgresEq, PostgresOrd, PostgresType,
+};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+#[cfg(any(test, feature = "pg_test"))]
+use pgx::pg_schema;
+
+// Demonstrates that Postgres-defined ordering works.
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    PostgresType,
+    PostgresEq,
+    PostgresOrd,
+)]
+pub struct OrderedThing {
+    item: String,
+}
+
+// A silly yet consistent ordering. Strings which start with lowercase letters are sorted normally,
+// but strings which start with non-lowercase letters are sorted backwards.
+impl Ord for OrderedThing {
+    fn cmp(&self, other: &Self) -> Ordering {
+        fn starts_lower(thing: &OrderedThing) -> bool {
+            thing
+                .item
+                .chars()
+                .next()
+                .map_or(false, |c| c.is_lowercase())
+        }
+        if starts_lower(self) {
+            if starts_lower(other) {
+                self.item.cmp(&other.item)
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        } else {
+            if starts_lower(other) {
+                std::cmp::Ordering::Less
+            } else {
+                self.item.cmp(&other.item).reverse()
+            }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use crate::ordered::OrderedThing;
+    use pgx::prelude::*;
+
+    #[pg_test]
+    fn test_ordering_via_spi() {
+        let items = Spi::get_one::<Vec<OrderedThing>>(
+            "SELECT array_agg(i ORDER BY i) FROM (VALUES \
+                ('{\"item\":\"foo\"}'::OrderedThing), \
+                ('{\"item\":\"bar\"}'::OrderedThing), \
+                ('{\"item\":\"Foo\"}'::OrderedThing), \
+                ('{\"item\":\"Bar\"}'::OrderedThing))\
+                items(i);",
+        );
+
+        assert_eq!(
+            items,
+            Some(vec![
+                OrderedThing {
+                    item: "Foo".to_string()
+                },
+                OrderedThing {
+                    item: "Bar".to_string()
+                },
+                OrderedThing {
+                    item: "bar".to_string()
+                },
+                OrderedThing {
+                    item: "foo".to_string()
+                },
+            ])
+        )
+    }
+}


### PR DESCRIPTION
This PR adds a type which implements `PostgresOrd` to the `custom_types` module. This will cause failures if the ordering constraints fixed in #722 regress again, rather than let those problems go unnoticed.