### PR TITLE
Cleanup the pgx-pg-sys build-dependencies somewhat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,15 +244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-deps"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f14468960818ce4f3e3553c32d524446687884f8e7af5d3e252331d8a87e43"
-dependencies = [
- "glob",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,13 +1425,10 @@ name = "pgx-pg-sys"
 version = "0.5.0-beta.1"
 dependencies = [
  "bindgen",
- "build-deps",
  "color-eyre",
  "eyre",
  "memoffset",
- "num_cpus",
  "once_cell",
- "owo-colors",
  "pgx-macros",
  "pgx-pg-config",
  "pgx-utils",

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -38,9 +38,6 @@ sptr = "0.3"
 
 [build-dependencies]
 bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }
-build-deps = "0.1.4"
-owo-colors = "3.5.0"
-num_cpus = "1.13.1"
 pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.5.0-beta.1" }
 pgx-utils = { path = "../pgx-utils/", version = "=0.5.0-beta.1" }
 proc-macro2 = "1.0.44"

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -7,8 +7,6 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-extern crate build_deps;
-
 use bindgen::callbacks::{DeriveTrait, ImplementsTrait, MacroParsingBehavior};
 use eyre::{eyre, WrapErr};
 use pgx_pg_config::{prefix_path, PgConfig, PgConfigSelector, Pgx, SUPPORTED_MAJOR_VERSIONS};
@@ -112,10 +110,12 @@ fn main() -> color_eyre::Result<()> {
 
     let pgx = Pgx::from_config()?;
 
-    build_deps::rerun_if_changed_paths(&Pgx::config_toml()?.display().to_string()).unwrap();
-    build_deps::rerun_if_changed_paths("include/*").unwrap();
-    build_deps::rerun_if_changed_paths("cshim/pgx-cshim.c").unwrap();
-    build_deps::rerun_if_changed_paths("cshim/Makefile").unwrap();
+    println!(
+        "cargo:rerun-if-changed={}",
+        Pgx::config_toml()?.display().to_string(),
+    );
+    println!("cargo:rerun-if-changed=include");
+    println!("cargo:rerun-if-changed=cshim");
 
     let pg_configs = if std::env::var("PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE")
         .unwrap_or("false".into())


### PR DESCRIPTION
While futzing about with SDK roots, I noticed some low hanging fruit here that bothered me slightly.

For the `build_deps` one (the only one with actual code changes), this doesn't change MSRV -- cargo has allowed a folder to be passed into `cargo:rerun-if-changed` since [1.50](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1500-2021-02-11), and we declare `rust-version = "1.58.0` in some of the toml files.