### PR TITLE
Prefer `impl From` to `impl Into`

### DIFF
--- a/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
@@ -161,9 +161,9 @@ impl PartialOrd for PgAggregateEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for PgAggregateEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Aggregate(self)
+impl From<PgAggregateEntity> for SqlGraphEntity {
+    fn from(val: PgAggregateEntity) -> Self {
+        SqlGraphEntity::Aggregate(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/control_file.rs
+++ b/pgx-utils/src/sql_entity_graph/control_file.rs
@@ -103,9 +103,9 @@ impl ControlFile {
     }
 }
 
-impl Into<SqlGraphEntity> for ControlFile {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::ExtensionRoot(self)
+impl From<ControlFile> for SqlGraphEntity {
+    fn from(val: ControlFile) -> Self {
+        SqlGraphEntity::ExtensionRoot(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/extension_sql/entity.rs
@@ -45,9 +45,9 @@ impl ExtensionSqlEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for ExtensionSqlEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::CustomSql(self)
+impl From<ExtensionSqlEntity> for SqlGraphEntity {
+    fn from(val: ExtensionSqlEntity) -> Self {
+        SqlGraphEntity::CustomSql(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -80,9 +80,9 @@ impl PartialOrd for PgExternEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for PgExternEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Function(self)
+impl From<PgExternEntity> for SqlGraphEntity {
+    fn from(val: PgExternEntity) -> Self {
+        SqlGraphEntity::Function(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/pg_trigger/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_trigger/entity.rs
@@ -43,9 +43,9 @@ impl PartialOrd for PgTriggerEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for PgTriggerEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Trigger(self)
+impl From<PgTriggerEntity> for SqlGraphEntity {
+    fn from(val: PgTriggerEntity) -> Self {
+        SqlGraphEntity::Trigger(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
@@ -65,9 +65,9 @@ impl PostgresEnumEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for PostgresEnumEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Enum(self)
+impl From<PostgresEnumEntity> for SqlGraphEntity {
+    fn from(val: PostgresEnumEntity) -> Self {
+        SqlGraphEntity::Enum(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
@@ -53,9 +53,9 @@ impl PartialOrd for PostgresHashEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for PostgresHashEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Hash(self)
+impl From<PostgresHashEntity> for SqlGraphEntity {
+    fn from(val: PostgresHashEntity) -> Self {
+        SqlGraphEntity::Hash(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
@@ -73,9 +73,9 @@ impl PartialOrd for PostgresOrdEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for PostgresOrdEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Ord(self)
+impl From<PostgresOrdEntity> for SqlGraphEntity {
+    fn from(val: PostgresOrdEntity) -> Self {
+        SqlGraphEntity::Ord(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
@@ -69,9 +69,9 @@ impl PostgresTypeEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for PostgresTypeEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Type(self)
+impl From<PostgresTypeEntity> for SqlGraphEntity {
+    fn from(val: PostgresTypeEntity) -> Self {
+        SqlGraphEntity::Type(val)
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/schema/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/entity.rs
@@ -41,9 +41,9 @@ impl PartialOrd for SchemaEntity {
     }
 }
 
-impl Into<SqlGraphEntity> for SchemaEntity {
-    fn into(self) -> SqlGraphEntity {
-        SqlGraphEntity::Schema(self)
+impl From<SchemaEntity> for SqlGraphEntity {
+    fn from(val: SchemaEntity) -> Self {
+        SqlGraphEntity::Schema(val)
     }
 }
 

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -114,9 +114,9 @@ impl IntoDatum for Inet {
     }
 }
 
-impl Into<Inet> for String {
-    fn into(self) -> Inet {
-        Inet(self)
+impl From<String> for Inet {
+    fn from(val: String) -> Self {
+        Inet(val)
     }
 }
 

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -98,63 +98,63 @@ impl<'de> Deserialize<'de> for Numeric {
     }
 }
 
-impl Into<Numeric> for i8 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<i8> for Numeric {
+    fn from(val: i8) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for i16 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<i16> for Numeric {
+    fn from(val: i16) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for i32 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<i32> for Numeric {
+    fn from(val: i32) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for i64 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<i64> for Numeric {
+    fn from(val: i64) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for u8 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<u8> for Numeric {
+    fn from(val: u8) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for u16 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<u16> for Numeric {
+    fn from(val: u16) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for u32 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<u32> for Numeric {
+    fn from(val: u32) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for u64 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<u64> for Numeric {
+    fn from(val: u64) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for f32 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<f32> for Numeric {
+    fn from(val: f32) -> Self {
+        Numeric(val.to_string())
     }
 }
 
-impl Into<Numeric> for f64 {
-    fn into(self) -> Numeric {
-        Numeric(format!("{}", self))
+impl From<f64> for Numeric {
+    fn from(val: f64) -> Self {
+        Numeric(val.to_string())
     }
 }
 

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -275,12 +275,12 @@ where
     }
 }
 
-impl<T> Into<Option<pg_sys::Datum>> for PgVarlena<T>
+impl<T> From<PgVarlena<T>> for Option<pg_sys::Datum>
 where
     T: Copy + Sized,
 {
-    fn into(self) -> Option<pg_sys::Datum> {
-        Some(self.into_pg().into())
+    fn from(val: PgVarlena<T>) -> Self {
+        Some(val.into_pg().into())
     }
 }
 

--- a/pgx/src/stringinfo.rs
+++ b/pgx/src/stringinfo.rs
@@ -20,16 +20,16 @@ pub struct StringInfo {
     needs_pfree: bool,
 }
 
-impl Into<pg_sys::StringInfo> for StringInfo {
-    fn into(self) -> pg_sys::StringInfo {
-        self.sid
+impl From<StringInfo> for pg_sys::StringInfo {
+    fn from(val: StringInfo) -> Self {
+        val.sid
     }
 }
 
-impl Into<&'static std::ffi::CStr> for StringInfo {
-    fn into(self) -> &'static std::ffi::CStr {
-        let len = self.len();
-        let ptr = self.into_char_ptr();
+impl From<StringInfo> for &'static std::ffi::CStr {
+    fn from(val: StringInfo) -> Self {
+        let len = val.len();
+        let ptr = val.into_char_ptr();
 
         unsafe {
             std::ffi::CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
@@ -40,10 +40,10 @@ impl Into<&'static std::ffi::CStr> for StringInfo {
     }
 }
 
-impl Into<&'static crate::cstr_core::CStr> for StringInfo {
-    fn into(self) -> &'static crate::cstr_core::CStr {
-        let len = self.len();
-        let ptr = self.into_char_ptr();
+impl From<StringInfo> for &'static crate::cstr_core::CStr {
+    fn from(val: StringInfo) -> Self {
+        let len = val.len();
+        let ptr = val.into_char_ptr();
 
         unsafe {
             crate::cstr_core::CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(


### PR DESCRIPTION
Trivial patch. Just noticed a few of these, and switched them all since it looks odd to me to see `Into` implemented explicitly (and none of them hit the coherence edge-cases where `Into` impl is required).

If you `impl From` you get an `Into` automatically, but the opposite is not true, so this is strictly better (and not a breaking change).

