### PR TITLE
Set locale to C.UTF-8 when creating database clusters

### DIFF
--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -12,7 +12,9 @@ use crate::command::version::pgx_default;
 use crate::CommandExecute;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
-use pgx_pg_config::{prefix_path, PgConfig, PgConfigSelector, Pgx, SUPPORTED_MAJOR_VERSIONS};
+use pgx_pg_config::{
+    prefix_path, PgConfig, PgConfigSelector, Pgx, C_LOCALE_FLAGS, SUPPORTED_MAJOR_VERSIONS,
+};
 use rayon::prelude::*;
 
 use std::collections::HashMap;
@@ -428,7 +430,12 @@ fn is_root_user() -> bool {
 pub(crate) fn initdb(bindir: &PathBuf, datadir: &PathBuf) -> eyre::Result<()> {
     println!(" {} data directory at {}", "Initializing".bold().green(), datadir.display());
     let mut command = std::process::Command::new(format!("{}/initdb", bindir.display()));
-    command.stdout(Stdio::piped()).stderr(Stdio::piped()).arg("-D").arg(&datadir);
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(C_LOCALE_FLAGS)
+        .arg("-D")
+        .arg(&datadir);
 
     let command_str = format!("{:?}", command);
     tracing::debug!(command = %command_str, "Running");

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -22,6 +22,13 @@ use url::Url;
 pub static BASE_POSTGRES_PORT_NO: u16 = 28800;
 pub static BASE_POSTGRES_TESTING_PORT_NO: u16 = 32200;
 
+#[cfg(target_os = "macos")]
+/// The flags to specify to get a "C.UTF-8" locale on this system.
+pub const C_LOCALE_FLAGS: &[&str] = &["--locale=C", "--lc-ctype=UTF-8"];
+#[cfg(not(target_os = "macos"))]
+/// The flags to specify to get a "C.UTF-8" locale on this system.
+pub const C_LOCALE_FLAGS: &[&str] = &["--locale=C.UTF-8"];
+
 // These methods were originally in `pgx-utils`, but in an effort to consolidate
 // dependencies, the decision was made to package them into wherever made the
 // most sense. In this case, it made the most sense to put them into this

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -13,7 +13,7 @@ use eyre::{eyre, WrapErr};
 use once_cell::sync::Lazy;
 use owo_colors::OwoColorize;
 use pgx::prelude::*;
-use pgx_pg_config::{createdb, get_target_dir, PgConfig, Pgx};
+use pgx_pg_config::{createdb, get_target_dir, PgConfig, Pgx, C_LOCALE_FLAGS};
 use postgres::error::DbError;
 use std::collections::HashMap;
 use std::fmt::Write as _;
@@ -389,6 +389,7 @@ fn initdb(postgresql_conf: Vec<&'static str>) -> eyre::Result<()> {
             Command::new(pg_config.initdb_path().wrap_err("unable to determine initdb path")?);
 
         command
+            .args(C_LOCALE_FLAGS)
             .arg("-D")
             .arg(pgdata.to_str().unwrap())
             .stdout(Stdio::inherit())


### PR DESCRIPTION
Fixes #691 by setting the locale to `C.UTF-8` when creating databases.

On macOS the `C.UTF-8` locale doesn't exist so the locale is set to `C` and the `CTYPE` to `UTF-8`, which has the same effect as setting the locale to `C.UTF-8` on other operating systems.

Note that testing this requires creating a new database cluster. I tested this by:
- reinstalling cargo-pgx
- deleting `~/.pgx`
- rerunning `cargo pgx init` to get a new database cluster
- cleaning the target directory of any repos you want to test this on