### PR TITLE
Replace `rayon` with `std::thread::scope` in `pgx-pg-sys` build system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,6 @@ dependencies = [
  "pgx-utils",
  "proc-macro2",
  "quote",
- "rayon",
  "rustversion",
  "shlex",
  "sptr",

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -41,7 +41,6 @@ pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.5.0" }
 pgx-utils = { path = "../pgx-utils/", version = "=0.5.0" }
 proc-macro2 = "1.0.46"
 quote = "1.0.21"
-rayon = "1.5.3"
 syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 color-eyre = "0.6.2"

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -12,7 +12,6 @@ use eyre::{eyre, WrapErr};
 use pgx_pg_config::{prefix_path, PgConfig, PgConfigSelector, Pgx, SUPPORTED_MAJOR_VERSIONS};
 use pgx_utils::rewriter::PgGuardRewriter;
 use quote::{quote, ToTokens};
-use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::{Command, Output};
@@ -134,12 +133,24 @@ fn main() -> color_eyre::Result<()> {
         let specific = pgx.get(&found)?;
         vec![specific]
     };
-
-    pg_configs
-        .par_iter()
-        .map(|pg_config| generate_bindings(pg_config, &build_paths, is_for_release))
-        .collect::<eyre::Result<Vec<_>>>()?;
-
+    std::thread::scope(|scope| {
+        // This is pretty much either always 1 (normally) or 5 (for releases),
+        // but in the future if we ever have way more, we should consider
+        // chunking `pg_configs` based on `thread::available_parallelism()`.
+        let threads = pg_configs
+            .iter()
+            .map(|pg_config| {
+                scope.spawn(|| generate_bindings(pg_config, &build_paths, is_for_release))
+            })
+            .collect::<Vec<_>>();
+        // Most of the rest of this is just for better error handling --
+        // `thread::scope` already joins the threads for us before it returns.
+        let results = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("thread panicked while generating bindings"))
+            .collect::<Vec<eyre::Result<_>>>();
+        results.into_iter().try_for_each(|r| r)
+    })?;
     // compile the cshim for each binding
     for pg_config in pg_configs {
         build_shim(&build_paths.shim_src, &build_paths.shim_dst, &pg_config)?;


### PR DESCRIPTION
Rayon is a pretty large dependency (and comes with many dependencies of its own) especially to have as a build 
dependency, since it could be a bottleneck in the overall build process. In practice, we have enough other deps in the build script for this not to make a difference for full rebuilds, but it could for partial rebuilds (if e.g. `syn` is already built but `rayon` is not). Either way, the concrete outcome of this patch is shaving off about 20 dependencies from list that users of `pgx` will inherit from us. While that seems to only be around 10%, these might not otherwise appear in their dependency list at all (unlike many of the others), so this still a wain. Also, we didn't really need rayon here in the first place anyway[^2] (IMO).

I didn't remove it from `cargo-pgx`, since that isn't one of the deps that people inherit from us in their build tree by using `pgx`, so it doesn't matter as much IMO. It'd also be easy to remove there if we want.

The downside: this doesn't cap the number of threads spawned to `std::thread::available_parallelism()`, unlike rayon. This only matters for releases (likely done on machines with more than 5 threads), and is fairly easy[^1] to fix anyway if we decide we need to. In practice, it's likely we'll actually do better than `rayon` (WRT resource usage) on machines with many cores, since by default it uses a thread pool which is sized based on your number of cores, most of which we won't end up using. (We could also have fixed that by manually configuring `rayon` to use a pool with no more than `pg_config.len()` items, but no need).

I also cleaned things up a little while making this change, so that the bindings generation has its own function, and so that the paths we need to pass in are bundled in a little struct (since otherwise there'd be a lot of `&Path` arguments to that function).

[^2]: We use it to `par_iter` over a slice that has either 1 (normally) or 5 (releases) items a single time. Each one is a heavyweight task that takes roughly the same around of time as the others. This means we don't benefit from work stealing or a thread pool around, so it's mostly about ergonomics compared to manual parallelism, and that's a lot smaller of a benefit with `std::thread::scope`.

[^1]: Something like:
	```rs
	let threads = std::thread::available_parallelism().map(|t| t.get()).unwrap_or(1);
	pg_configs.chunks((pg_configs.len() / threads).max(1)).map(|chunk| {
		scope.spawn(|| chunk.try_for_each(|pg_config| ...)))
	})...
	```
	(I was going to handle it but decided it was not worth it)