### PR TITLE
Require `FromDatum::from_polymorphic_datum`

### DIFF
--- a/pgx-examples/bgworker/src/lib.rs
+++ b/pgx-examples/bgworker/src/lib.rs
@@ -44,7 +44,7 @@ pub extern "C" fn _PG_init() {
 #[pg_guard]
 #[no_mangle]
 pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {
-    let arg = unsafe { i32::from_datum(arg, false, pg_sys::INT4OID) };
+    let arg = unsafe { i32::from_polymorphic_datum(arg, false, pg_sys::INT4OID) };
 
     // these are the signals we want to receive.  If we don't attach the SIGTERM handler, then
     // we'll never be able to exit via an external notification

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -621,7 +621,7 @@ fn impl_postgres_enum(ast: DeriveInput) -> proc_macro2::TokenStream {
     stream.extend(quote! {
         impl ::pgx::datum::FromDatum for #enum_ident {
             #[inline]
-            unsafe fn from_datum(datum: ::pgx::pg_sys::Datum, is_null: bool, typeoid: ::pgx::pg_sys::Oid) -> Option<#enum_ident> {
+            unsafe fn from_polymorphic_datum(datum: ::pgx::pg_sys::Datum, is_null: bool, typeoid: ::pgx::pg_sys::Oid) -> Option<#enum_ident> {
                 if is_null {
                     None
                 } else {

--- a/pgx/src/datum/anyarray.rs
+++ b/pgx/src/datum/anyarray.rs
@@ -37,10 +37,7 @@ impl FromDatum for AnyArray {
     const GET_TYPOID: bool = true;
 
     #[inline]
-    unsafe fn from_datum(
-        _datum: pg_sys::Datum,
-        _is_null: bool,
-    ) -> Option<AnyArray> {
+    unsafe fn from_datum(_datum: pg_sys::Datum, _is_null: bool) -> Option<AnyArray> {
         debug_assert!(false, "Can't create a polymorphic type using from_datum, call FromDatum::from_polymorphic_datum instead");
         None
     }

--- a/pgx/src/datum/anyarray.rs
+++ b/pgx/src/datum/anyarray.rs
@@ -29,7 +29,7 @@ impl AnyArray {
 
     #[inline]
     pub fn into<T: FromDatum>(&self) -> Option<T> {
-        unsafe { T::from_datum(self.datum(), false, self.oid()) }
+        unsafe { T::from_polymorphic_datum(self.datum(), false, self.oid()) }
     }
 }
 
@@ -38,11 +38,11 @@ impl FromDatum for AnyArray {
 
     #[inline]
     unsafe fn from_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        typoid: pg_sys::Oid,
+        _datum: pg_sys::Datum,
+        _is_null: bool,
     ) -> Option<AnyArray> {
-        FromDatum::from_polymorphic_datum(datum, is_null, typoid)
+        debug_assert!(false, "Can't create a polymorphic type using from_datum, call FromDatum::from_polymorphic_datum instead");
+        None
     }
 
     #[inline]

--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -29,7 +29,7 @@ impl AnyElement {
 
     #[inline]
     pub fn into<T: FromDatum>(&self) -> Option<T> {
-        unsafe { T::from_datum(self.datum(), false, self.oid()) }
+        unsafe { T::from_polymorphic_datum(self.datum(), false, self.oid()) }
     }
 }
 
@@ -38,11 +38,11 @@ impl FromDatum for AnyElement {
 
     #[inline]
     unsafe fn from_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        typoid: pg_sys::Oid,
+        _datum: pg_sys::Datum,
+        _is_null: bool,
     ) -> Option<AnyElement> {
-        FromDatum::from_polymorphic_datum(datum, is_null, typoid)
+        debug_assert!(false, "Can't create a polymorphic type using from_datum, call FromDatum::from_polymorphic_datum instead");
+        None
     }
 
     #[inline]

--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -37,10 +37,7 @@ impl FromDatum for AnyElement {
     const GET_TYPOID: bool = true;
 
     #[inline]
-    unsafe fn from_datum(
-        _datum: pg_sys::Datum,
-        _is_null: bool,
-    ) -> Option<AnyElement> {
+    unsafe fn from_datum(_datum: pg_sys::Datum, _is_null: bool) -> Option<AnyElement> {
         debug_assert!(false, "Can't create a polymorphic type using from_datum, call FromDatum::from_polymorphic_datum instead");
         None
     }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -318,7 +318,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
             None
         } else {
             Some(unsafe {
-                T::from_datum(
+                T::from_polymorphic_datum(
                     self.elem_slice[i],
                     self.null_slice.get(i)?,
                     self.raw.as_ref().map(|r| r.oid()).unwrap_or_default(),
@@ -502,18 +502,18 @@ impl<'a, T: FromDatum> Iterator for ArrayIntoIterator<'a, T> {
 
 impl<'a, T: FromDatum> FromDatum for VariadicArray<'a, T> {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         oid: pg_sys::Oid,
     ) -> Option<VariadicArray<'a, T>> {
-        Array::from_datum(datum, is_null, oid).map(Self)
+        Array::from_polymorphic_datum(datum, is_null, oid).map(Self)
     }
 }
 
 impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         _typoid: u32,
@@ -536,7 +536,7 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
 
 impl<T: FromDatum> FromDatum for Vec<T> {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         typoid: pg_sys::Oid,
@@ -544,7 +544,7 @@ impl<T: FromDatum> FromDatum for Vec<T> {
         if is_null {
             None
         } else {
-            let array = Array::<T>::from_datum(datum, is_null, typoid).unwrap();
+            let array = Array::<T>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
             let mut v = Vec::with_capacity(array.len());
 
             for element in array.iter() {
@@ -557,7 +557,7 @@ impl<T: FromDatum> FromDatum for Vec<T> {
 
 impl<T: FromDatum> FromDatum for Vec<Option<T>> {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         typoid: pg_sys::Oid,
@@ -565,7 +565,7 @@ impl<T: FromDatum> FromDatum for Vec<Option<T>> {
         if is_null || datum.is_null() {
             None
         } else {
-            let array = Array::<T>::from_datum(datum, is_null, typoid).unwrap();
+            let array = Array::<T>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
             let mut v = Vec::with_capacity(array.len());
 
             for element in array.iter() {

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -38,7 +38,7 @@ impl IntoDatum for Date {
 }
 
 impl FromDatum for Date {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -38,7 +38,11 @@ impl IntoDatum for Date {
 }
 
 impl FromDatum for Date {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -144,7 +144,11 @@ impl FromDatum for pg_sys::Datum {
 /// for bool
 impl FromDatum for bool {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<bool> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<bool> {
         if is_null {
             None
         } else {
@@ -156,7 +160,11 @@ impl FromDatum for bool {
 /// for `"char"`
 impl FromDatum for i8 {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i8> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<i8> {
         if is_null {
             None
         } else {
@@ -168,7 +176,11 @@ impl FromDatum for i8 {
 /// for smallint
 impl FromDatum for i16 {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i16> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<i16> {
         if is_null {
             None
         } else {
@@ -180,7 +192,11 @@ impl FromDatum for i16 {
 /// for integer
 impl FromDatum for i32 {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i32> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<i32> {
         if is_null {
             None
         } else {
@@ -192,7 +208,11 @@ impl FromDatum for i32 {
 /// for oid
 impl FromDatum for u32 {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<u32> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<u32> {
         if is_null {
             None
         } else {
@@ -204,7 +224,11 @@ impl FromDatum for u32 {
 /// for bigint
 impl FromDatum for i64 {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i64> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<i64> {
         if is_null {
             None
         } else {
@@ -216,7 +240,11 @@ impl FromDatum for i64 {
 /// for real
 impl FromDatum for f32 {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f32> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<f32> {
         if is_null {
             None
         } else {
@@ -228,7 +256,11 @@ impl FromDatum for f32 {
 /// for double precision
 impl FromDatum for f64 {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f64> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<f64> {
         if is_null {
             None
         } else {
@@ -240,7 +272,11 @@ impl FromDatum for f64 {
 /// for text, varchar
 impl<'a> FromDatum for &'a str {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a str> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<&'a str> {
         if is_null || datum.is_null() {
             None
         } else {
@@ -291,15 +327,24 @@ impl FromDatum for String {
 
 impl FromDatum for char {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<char> {
-        FromDatum::from_polymorphic_datum(datum, is_null, typoid).and_then(|s: &str| s.chars().next())
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        typoid: pg_sys::Oid,
+    ) -> Option<char> {
+        FromDatum::from_polymorphic_datum(datum, is_null, typoid)
+            .and_then(|s: &str| s.chars().next())
     }
 }
 
 /// for cstring
 impl<'a> FromDatum for &'a std::ffi::CStr {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a CStr> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<&'a CStr> {
         if is_null || datum.is_null() {
             None
         } else {
@@ -326,7 +371,11 @@ impl<'a> FromDatum for &'a crate::cstr_core::CStr {
 /// for bytea
 impl<'a> FromDatum for &'a [u8] {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<&'a [u8]> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<&'a [u8]> {
         if is_null || datum.is_null() {
             None
         } else {
@@ -363,7 +412,11 @@ impl<'a> FromDatum for &'a [u8] {
 
 impl FromDatum for Vec<u8> {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: u32) -> Option<Vec<u8>> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        typoid: u32,
+    ) -> Option<Vec<u8>> {
         if is_null || datum.is_null() {
             None
         } else {
@@ -383,7 +436,11 @@ impl FromDatum for Vec<u8> {
 /// for NULL -- always converts to a `None`, even if the is_null argument is false
 impl FromDatum for () {
     #[inline]
-    unsafe fn from_polymorphic_datum(_datum: pg_sys::Datum, _is_null: bool, _: pg_sys::Oid) -> Option<()> {
+    unsafe fn from_polymorphic_datum(
+        _datum: pg_sys::Datum,
+        _is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<()> {
         None
     }
 }
@@ -391,7 +448,11 @@ impl FromDatum for () {
 /// for user types
 impl<T> FromDatum for PgBox<T, AllocatedByPostgres> {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self> {
         if is_null || datum.is_null() {
             None
         } else {

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -53,9 +53,12 @@ pub trait FromDatum {
     ///
     /// If, however, you're providing an arbitrary datum value, it needs to be considered unsafe
     /// and that unsafeness should be propagated through your API.
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool) -> Option<Self>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        FromDatum::from_polymorphic_datum(datum, is_null, pg_sys::InvalidOid)
+    }
 
     /// Like `from_datum` for instantiating polymorphic types
     /// which require preserving the dynamic type metadata.
@@ -69,10 +72,7 @@ pub trait FromDatum {
         typoid: pg_sys::Oid,
     ) -> Option<Self>
     where
-        Self: Sized,
-    {
-        FromDatum::from_datum(datum, is_null, typoid)
-    }
+        Self: Sized;
 
     /// Default implementation switched to the specified memory context and then simply calls
     /// `FromDatum::from_datum(...)` from within that context.
@@ -96,7 +96,7 @@ pub trait FromDatum {
     where
         Self: Sized,
     {
-        memory_context.switch_to(|_| FromDatum::from_datum(datum, is_null, typoid))
+        memory_context.switch_to(|_| FromDatum::from_polymorphic_datum(datum, is_null, typoid))
     }
 
     /// `try_from_datum` is a convenience wrapper around `FromDatum::from_datum` that returns a
@@ -120,7 +120,7 @@ pub trait FromDatum {
         } else if !is_null && datum.is_null() && !Self::is_pass_by_value() {
             Err(TryFromDatumError::NullDatumPointer)
         } else {
-            Ok(FromDatum::from_datum(datum, is_null, type_oid))
+            Ok(FromDatum::from_polymorphic_datum(datum, is_null, type_oid))
         }
     }
 }
@@ -128,7 +128,7 @@ pub trait FromDatum {
 /// for pg_sys::Datum
 impl FromDatum for pg_sys::Datum {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         _: pg_sys::Oid,
@@ -144,7 +144,7 @@ impl FromDatum for pg_sys::Datum {
 /// for bool
 impl FromDatum for bool {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<bool> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<bool> {
         if is_null {
             None
         } else {
@@ -156,7 +156,7 @@ impl FromDatum for bool {
 /// for `"char"`
 impl FromDatum for i8 {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i8> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i8> {
         if is_null {
             None
         } else {
@@ -168,7 +168,7 @@ impl FromDatum for i8 {
 /// for smallint
 impl FromDatum for i16 {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i16> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i16> {
         if is_null {
             None
         } else {
@@ -180,7 +180,7 @@ impl FromDatum for i16 {
 /// for integer
 impl FromDatum for i32 {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i32> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i32> {
         if is_null {
             None
         } else {
@@ -192,7 +192,7 @@ impl FromDatum for i32 {
 /// for oid
 impl FromDatum for u32 {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<u32> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<u32> {
         if is_null {
             None
         } else {
@@ -204,7 +204,7 @@ impl FromDatum for u32 {
 /// for bigint
 impl FromDatum for i64 {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i64> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<i64> {
         if is_null {
             None
         } else {
@@ -216,7 +216,7 @@ impl FromDatum for i64 {
 /// for real
 impl FromDatum for f32 {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f32> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f32> {
         if is_null {
             None
         } else {
@@ -228,7 +228,7 @@ impl FromDatum for f32 {
 /// for double precision
 impl FromDatum for f64 {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f64> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<f64> {
         if is_null {
             None
         } else {
@@ -240,7 +240,7 @@ impl FromDatum for f64 {
 /// for text, varchar
 impl<'a> FromDatum for &'a str {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a str> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a str> {
         if is_null || datum.is_null() {
             None
         } else {
@@ -280,26 +280,26 @@ impl<'a> FromDatum for &'a str {
 /// This returns a **copy**, allocated and managed by Rust, of the underlying `varlena` Datum
 impl FromDatum for String {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         typoid: pg_sys::Oid,
     ) -> Option<String> {
-        FromDatum::from_datum(datum, is_null, typoid).map(|s: &str| s.to_owned())
+        FromDatum::from_polymorphic_datum(datum, is_null, typoid).map(|s: &str| s.to_owned())
     }
 }
 
 impl FromDatum for char {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<char> {
-        FromDatum::from_datum(datum, is_null, typoid).and_then(|s: &str| s.chars().next())
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<char> {
+        FromDatum::from_polymorphic_datum(datum, is_null, typoid).and_then(|s: &str| s.chars().next())
     }
 }
 
 /// for cstring
 impl<'a> FromDatum for &'a std::ffi::CStr {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a CStr> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<&'a CStr> {
         if is_null || datum.is_null() {
             None
         } else {
@@ -310,7 +310,7 @@ impl<'a> FromDatum for &'a std::ffi::CStr {
 
 impl<'a> FromDatum for &'a crate::cstr_core::CStr {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         _: pg_sys::Oid,
@@ -326,7 +326,7 @@ impl<'a> FromDatum for &'a crate::cstr_core::CStr {
 /// for bytea
 impl<'a> FromDatum for &'a [u8] {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<&'a [u8]> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<&'a [u8]> {
         if is_null || datum.is_null() {
             None
         } else {
@@ -363,12 +363,12 @@ impl<'a> FromDatum for &'a [u8] {
 
 impl FromDatum for Vec<u8> {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: u32) -> Option<Vec<u8>> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: u32) -> Option<Vec<u8>> {
         if is_null || datum.is_null() {
             None
         } else {
             // Vec<u8> conversion is initially the same as for &[u8]
-            let bytes: Option<&[u8]> = FromDatum::from_datum(datum, is_null, typoid);
+            let bytes: Option<&[u8]> = FromDatum::from_polymorphic_datum(datum, is_null, typoid);
 
             match bytes {
                 // but then we need to convert it into an owned Vec where the backing
@@ -383,7 +383,7 @@ impl FromDatum for Vec<u8> {
 /// for NULL -- always converts to a `None`, even if the is_null argument is false
 impl FromDatum for () {
     #[inline]
-    unsafe fn from_datum(_datum: pg_sys::Datum, _is_null: bool, _: pg_sys::Oid) -> Option<()> {
+    unsafe fn from_polymorphic_datum(_datum: pg_sys::Datum, _is_null: bool, _: pg_sys::Oid) -> Option<()> {
         None
     }
 }
@@ -391,7 +391,7 @@ impl FromDatum for () {
 /// for user types
 impl<T> FromDatum for PgBox<T, AllocatedByPostgres> {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self> {
         if is_null || datum.is_null() {
             None
         } else {

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -10,7 +10,11 @@ Use of this source code is governed by the MIT license that can be found in the 
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 
 impl FromDatum for pg_sys::BOX {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
     where
         Self: Sized,
     {
@@ -40,7 +44,11 @@ impl IntoDatum for pg_sys::BOX {
 }
 
 impl FromDatum for pg_sys::Point {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/geo.rs
+++ b/pgx/src/datum/geo.rs
@@ -10,7 +10,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 use crate::{direct_function_call_as_datum, pg_sys, FromDatum, IntoDatum};
 
 impl FromDatum for pg_sys::BOX {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
     {
@@ -40,7 +40,7 @@ impl IntoDatum for pg_sys::BOX {
 }
 
 impl FromDatum for pg_sys::Point {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -86,7 +86,7 @@ impl<'de> Deserialize<'de> for Inet {
 }
 
 impl FromDatum for Inet {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Inet> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Inet> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -86,7 +86,11 @@ impl<'de> Deserialize<'de> for Inet {
 }
 
 impl FromDatum for Inet {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Inet> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<Inet> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -164,7 +164,7 @@ impl From<Option<pg_sys::Datum>> for Internal {
 
 impl FromDatum for Internal {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Internal> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Internal> {
         Some(Internal(if is_null { None } else { Some(datum) }))
     }
 }

--- a/pgx/src/datum/internal.rs
+++ b/pgx/src/datum/internal.rs
@@ -164,7 +164,11 @@ impl From<Option<pg_sys::Datum>> for Internal {
 
 impl FromDatum for Internal {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Internal> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Internal> {
         Some(Internal(if is_null { None } else { Some(datum) }))
     }
 }

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -13,7 +13,7 @@ use crate::{
 
 impl FromDatum for pg_sys::ItemPointerData {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         _typoid: u32,

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -29,7 +29,11 @@ pub struct JsonString(pub String);
 /// for json
 impl FromDatum for Json {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Json> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Json> {
         if is_null {
             None
         } else {
@@ -45,7 +49,11 @@ impl FromDatum for Json {
 
 /// for jsonb
 impl FromDatum for JsonB {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<JsonB> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<JsonB> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -29,7 +29,7 @@ pub struct JsonString(pub String);
 /// for json
 impl FromDatum for Json {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Json> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Json> {
         if is_null {
             None
         } else {
@@ -45,7 +45,7 @@ impl FromDatum for Json {
 
 /// for jsonb
 impl FromDatum for JsonB {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<JsonB> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<JsonB> {
         if is_null {
             None
         } else {
@@ -83,7 +83,7 @@ impl FromDatum for JsonB {
 /// This returns a **copy**, allocated and managed by Rust, of the underlying `varlena` Datum
 impl FromDatum for JsonString {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         _: pg_sys::Oid,

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -159,7 +159,7 @@ impl From<f64> for Numeric {
 }
 
 impl FromDatum for Numeric {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -159,7 +159,11 @@ impl From<f64> for Numeric {
 }
 
 impl FromDatum for Numeric {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -26,7 +26,7 @@ pub(crate) const USECS_PER_DAY: u64 = USECS_PER_HOUR * 24;
 pub struct Time(pub u64 /* Microseconds since midnight */);
 impl FromDatum for Time {
     #[inline]
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Time> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Time> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -26,7 +26,11 @@ pub(crate) const USECS_PER_DAY: u64 = USECS_PER_HOUR * 24;
 pub struct Time(pub u64 /* Microseconds since midnight */);
 impl FromDatum for Time {
     #[inline]
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Time> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<Time> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -123,7 +123,7 @@ impl IntoDatum for Timestamp {
 }
 
 impl FromDatum for Timestamp {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -123,7 +123,11 @@ impl IntoDatum for Timestamp {
 }
 
 impl FromDatum for Timestamp {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -143,7 +143,7 @@ impl IntoDatum for TimestampWithTimeZone {
 }
 
 impl FromDatum for TimestampWithTimeZone {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -143,7 +143,11 @@ impl IntoDatum for TimestampWithTimeZone {
 }
 
 impl FromDatum for TimestampWithTimeZone {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
     where
         Self: Sized,
     {

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -26,7 +26,7 @@ pub struct TimeWithTimeZone {
 
 impl FromDatum for TimeWithTimeZone {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         typoid: u32,
@@ -36,7 +36,7 @@ impl FromDatum for TimeWithTimeZone {
         } else {
             let timetz = PgBox::from_pg(datum.cast_mut_ptr::<pg_sys::TimeTzADT>());
 
-            let t = Time::from_datum(timetz.time.into(), false, typoid)
+            let t = Time::from_polymorphic_datum(timetz.time.into(), false, typoid)
                 .expect("failed to convert TimeWithTimeZone");
             let tz_secs = timetz.zone;
 

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -49,22 +49,22 @@ where
     A: FromDatum + IntoDatum,
     B: FromDatum + IntoDatum,
 {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
     {
-        let mut vec = Vec::<Option<pg_sys::Datum>>::from_datum(datum, is_null, typoid).unwrap();
+        let mut vec = Vec::<Option<pg_sys::Datum>>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
         let b = vec.pop().unwrap();
         let a = vec.pop().unwrap();
 
         let a_datum = if a.is_some() {
-            A::from_datum(a.unwrap(), false, A::type_oid())
+            A::from_polymorphic_datum(a.unwrap(), false, A::type_oid())
         } else {
             None
         };
 
         let b_datum = if b.is_some() {
-            B::from_datum(b.unwrap(), false, B::type_oid())
+            B::from_polymorphic_datum(b.unwrap(), false, B::type_oid())
         } else {
             None
         };
@@ -79,29 +79,29 @@ where
     B: FromDatum + IntoDatum,
     C: FromDatum + IntoDatum,
 {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
     where
         Self: Sized,
     {
-        let mut vec = Vec::<Option<pg_sys::Datum>>::from_datum(datum, is_null, typoid).unwrap();
+        let mut vec = Vec::<Option<pg_sys::Datum>>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
         let c = vec.pop().unwrap();
         let b = vec.pop().unwrap();
         let a = vec.pop().unwrap();
 
         let a_datum = if a.is_some() {
-            A::from_datum(a.unwrap(), false, A::type_oid())
+            A::from_polymorphic_datum(a.unwrap(), false, A::type_oid())
         } else {
             None
         };
 
         let b_datum = if b.is_some() {
-            B::from_datum(b.unwrap(), false, B::type_oid())
+            B::from_polymorphic_datum(b.unwrap(), false, B::type_oid())
         } else {
             None
         };
 
         let c_datum = if c.is_some() {
-            C::from_datum(c.unwrap(), false, C::type_oid())
+            C::from_polymorphic_datum(c.unwrap(), false, C::type_oid())
         } else {
             None
         };

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -49,11 +49,16 @@ where
     A: FromDatum + IntoDatum,
     B: FromDatum + IntoDatum,
 {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        typoid: pg_sys::Oid,
+    ) -> Option<Self>
     where
         Self: Sized,
     {
-        let mut vec = Vec::<Option<pg_sys::Datum>>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
+        let mut vec =
+            Vec::<Option<pg_sys::Datum>>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
         let b = vec.pop().unwrap();
         let a = vec.pop().unwrap();
 
@@ -79,11 +84,16 @@ where
     B: FromDatum + IntoDatum,
     C: FromDatum + IntoDatum,
 {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, typoid: pg_sys::Oid) -> Option<Self>
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        typoid: pg_sys::Oid,
+    ) -> Option<Self>
     where
         Self: Sized,
     {
-        let mut vec = Vec::<Option<pg_sys::Datum>>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
+        let mut vec =
+            Vec::<Option<pg_sys::Datum>>::from_polymorphic_datum(datum, is_null, typoid).unwrap();
         let c = vec.pop().unwrap();
         let b = vec.pop().unwrap();
         let a = vec.pop().unwrap();

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -38,7 +38,7 @@ impl IntoDatum for Uuid {
 
 impl FromDatum for Uuid {
     #[inline]
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         _typoid: pg_sys::Oid,

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -301,7 +301,11 @@ impl<T> FromDatum for PgVarlena<T>
 where
     T: Copy + Sized,
 {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<Self> {
         if is_null {
             None
         } else {
@@ -349,7 +353,11 @@ impl<'de, T> FromDatum for T
 where
     T: PostgresType + Deserialize<'de>,
 {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<Self> {
         if is_null {
             None
         } else {

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -301,7 +301,7 @@ impl<T> FromDatum for PgVarlena<T>
 where
     T: Copy + Sized,
 {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
         if is_null {
             None
         } else {
@@ -349,7 +349,7 @@ impl<'de, T> FromDatum for T
 where
     T: PostgresType + Deserialize<'de>,
 {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<Self> {
         if is_null {
             None
         } else {

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -98,7 +98,7 @@ mod pg_10_11 {
             if T::GET_TYPOID {
                 T::from_polymorphic_datum(datum, isnull, super::pg_getarg_type(fcinfo, num))
             } else {
-                T::from_datum(datum, isnull, pg_sys::InvalidOid)
+                T::from_datum(datum, isnull)
             }
         }
     }
@@ -144,7 +144,7 @@ mod pg_12_13_14 {
                     super::pg_getarg_type(fcinfo, num),
                 )
             } else {
-                T::from_datum(datum.value, datum.isnull, pg_sys::InvalidOid)
+                T::from_datum(datum.value, datum.isnull)
             }
         }
     }
@@ -279,7 +279,7 @@ pub unsafe fn direct_function_call<R: FromDatum>(
 ) -> Option<R> {
     let datum = direct_function_call_as_datum(func, args);
     match datum {
-        Some(datum) => R::from_datum(datum, false, pg_sys::InvalidOid),
+        Some(datum) => R::from_datum(datum, false),
         None => None,
     }
 }
@@ -316,7 +316,7 @@ pub unsafe fn direct_pg_extern_function_call<R: FromDatum>(
 ) -> Option<R> {
     let datum = direct_pg_extern_function_call_as_datum(func, args);
     match datum {
-        Some(datum) => R::from_datum(datum, false, pg_sys::InvalidOid),
+        Some(datum) => R::from_datum(datum, false),
         None => None,
     }
 }

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -40,7 +40,7 @@ pub struct PgHeapTuple<'a, AllocatedBy: WhoAllocated<pg_sys::HeapTupleData>> {
 }
 
 impl<'a> FromDatum for PgHeapTuple<'a, AllocatedByRust> {
-    unsafe fn from_datum(
+    unsafe fn from_polymorphic_datum(
         composite: pg_sys::Datum,
         is_null: bool,
         _oid: pg_sys::Oid,

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -119,7 +119,7 @@ pub fn heap_getattr<
     if is_null {
         None
     } else {
-        unsafe { T::from_datum(datum, false, typoid.value()) }
+        unsafe { T::from_polymorphic_datum(datum, false, typoid.value()) }
     }
 }
 
@@ -166,7 +166,7 @@ pub struct DatumWithTypeInfo {
 impl DatumWithTypeInfo {
     #[inline]
     pub fn into_value<T: FromDatum>(self) -> T {
-        unsafe { T::from_datum(self.datum, self.is_null, self.typoid.value()).unwrap() }
+        unsafe { T::from_polymorphic_datum(self.datum, self.is_null, self.typoid.value()).unwrap() }
     }
 }
 

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -311,7 +311,7 @@ impl Clone for PgRelation {
 }
 
 impl FromDatum for PgRelation {
-    unsafe fn from_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<PgRelation> {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<PgRelation> {
         if is_null {
             None
         } else {

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -311,7 +311,11 @@ impl Clone for PgRelation {
 }
 
 impl FromDatum for PgRelation {
-    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _typoid: u32) -> Option<PgRelation> {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: u32,
+    ) -> Option<PgRelation> {
         if is_null {
             None
         } else {

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -492,7 +492,7 @@ impl SpiTupleTable {
                         let datum =
                             pg_sys::SPI_getbinval(heap_tuple, tupdesc, ordinal, &mut is_null);
 
-                        T::from_datum(datum, is_null, pg_sys::SPI_gettypeid(tupdesc, ordinal))
+                        T::from_polymorphic_datum(datum, is_null, pg_sys::SPI_gettypeid(tupdesc, ordinal))
                     }
                 },
                 None => panic!("TupDesc is NULL"),
@@ -654,7 +654,7 @@ impl<Datum: IntoDatum + FromDatum> From<Datum> for SpiHeapTupleDataEntry {
 impl SpiHeapTupleDataEntry {
     pub fn value<T: FromDatum>(&self) -> Option<T> {
         match self.datum.as_ref() {
-            Some(datum) => unsafe { T::from_datum(*datum, false, self.type_oid) },
+            Some(datum) => unsafe { T::from_polymorphic_datum(*datum, false, self.type_oid) },
             None => None,
         }
     }

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -492,7 +492,11 @@ impl SpiTupleTable {
                         let datum =
                             pg_sys::SPI_getbinval(heap_tuple, tupdesc, ordinal, &mut is_null);
 
-                        T::from_polymorphic_datum(datum, is_null, pg_sys::SPI_gettypeid(tupdesc, ordinal))
+                        T::from_polymorphic_datum(
+                            datum,
+                            is_null,
+                            pg_sys::SPI_gettypeid(tupdesc, ordinal),
+                        )
                     }
                 },
                 None => panic!("TupDesc is NULL"),


### PR DESCRIPTION
This also implies defaulting `FromDatum::from_datum` which just calls `FromDatum::from_polymorphic_datum` with an InvalidOid. Polymorphic types like AnyElement should generally override this on implementing, and non-polymorphic types should ignore the third parameter, while others may want a pass-through behavior.