### PR TITLE
Make syntect an optional dependency, only used by cargo-pgx

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -24,7 +24,7 @@ owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
 pgx-pg-config = { path = "../pgx-pg-config", version = "=0.5.0" }
-pgx-utils = { path = "../pgx-utils", version = "=0.5.0" }
+pgx-utils = { path = "../pgx-utils", version = "=0.5.0", features = ["syntax-highlighting"] }
 prettyplease = "0.1.20"
 proc-macro2 = { version = "1.0.46", features = [ "span-locations" ] }
 quote = "1.0.21"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -10,13 +10,16 @@ documentation = "https://docs.rs/pgx-utils"
 readme = "README.md"
 edition = "2021"
 
+[features]
+syntax-highlighting = ["dep:syntect", "dep:owo-colors"]
+
 [dependencies]
 seq-macro = "0.3"
 cstr_core = "0.2"
 atty = "0.2.14"
 convert_case = "0.5.0"
 eyre = "0.6.8"
-owo-colors = "3.5.0"
+owo-colors = { version = "3.5.0", optional = true }
 petgraph = "0.6.2"
 proc-macro2 = { version = "1.0.46", features = [ "span-locations" ] }
 quote = "1.0.21"
@@ -25,7 +28,7 @@ serde = { version = "1.0.145", features = [ "derive" ] }
 serde_derive = "1.0.145"
 serde_json = "1.0.85"
 syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
-syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"] }
+syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"], optional = true }
 unescape = "0.1.0"
 tracing = "0.1.37"
 tracing-error = "0.2.0"


### PR DESCRIPTION
This moves the `syntect` usage of `pgx-utils` into a new `syntax-highlighting` feature, which only `cargo-pgx` enables, allowing users of `pgx` to avoid a build-time dep on `syntect` (which can take around 20s to build).

It also pulls `owo-colors` into the same feature, since it wasn't used otherwise. (I think we still have this in our build tree though, so this is mostly about avoiding deps we don't need)