### PR TITLE
Avoid some dependencies in pgx-pg-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,7 +1438,6 @@ dependencies = [
  "pgx-utils",
  "proc-macro2",
  "quote",
- "rustversion",
  "shlex",
  "sptr",
  "syn",
@@ -1848,12 +1847,6 @@ dependencies = [
  "sct",
  "webpki",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,6 @@ name = "pgx-pg-sys"
 version = "0.5.0"
 dependencies = [
  "bindgen",
- "color-eyre",
  "eyre",
  "memoffset",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "toml",
- "tracing",
  "url",
 ]
 

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -20,5 +20,4 @@ serde = { version = "1.0.145", features = [ "derive" ] }
 serde_derive = "1.0.145"
 serde_json = "1.0.85"
 toml = "0.5.9"
-tracing = "0.1.37"
 url = "2.3.1"

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -348,7 +348,6 @@ impl Pgx {
         }
     }
 
-    #[tracing::instrument(level = "error", skip(self))]
     pub fn get(&self, label: &str) -> eyre::Result<&PgConfig> {
         for pg_config in self.pg_configs.iter() {
             if pg_config.label()? == label {

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -43,5 +43,4 @@ proc-macro2 = "1.0.46"
 quote = "1.0.21"
 syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
-rustversion = "1.0"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -43,6 +43,5 @@ proc-macro2 = "1.0.46"
 quote = "1.0.21"
 syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
-color-eyre = "0.6.2"
 rustversion = "1.0"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -71,7 +71,7 @@ impl bindgen::callbacks::ParseCallbacks for PgxOverrides {
     }
 }
 
-fn main() -> color_eyre::Result<()> {
+fn main() -> eyre::Result<()> {
     if std::env::var("DOCS_RS").unwrap_or("false".into()) == "1" {
         return Ok(());
     }

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -20,10 +20,17 @@ use syn::{ForeignItem, Item};
 #[derive(Debug)]
 struct PgxOverrides(HashSet<String>);
 
-#[rustversion::nightly]
-const IS_NIGHTLY: bool = true;
-#[rustversion::not(nightly)]
-const IS_NIGHTLY: bool = false;
+fn is_nightly() -> bool {
+    let rustc = std::env::var_os("RUSTC").map(PathBuf::from).unwrap_or_else(|| "rustc".into());
+    let output = match std::process::Command::new(rustc).arg("--verbose").output() {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_owned(),
+        _ => return false,
+    };
+    // Output looks like:
+    // - for nightly: `"rustc 1.66.0-nightly (0ca356586 2022-10-06)"`
+    // - for dev (locally built rust toolchain): `"rustc 1.66.0-dev"`
+    output.starts_with("rustc ") && (output.contains("-nightly") || output.contains("-dev"))
+}
 
 impl PgxOverrides {
     fn default() -> Self {
@@ -88,7 +95,7 @@ fn main() -> eyre::Result<()> {
     println!("cargo:rerun-if-env-changed=PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE");
 
     // Do nightly detection to suppress silly warnings.
-    if IS_NIGHTLY {
+    if is_nightly() {
         println!("cargo:rustc-cfg=nightly")
     };
 


### PR DESCRIPTION
1. We were using `color_eyre::Result` despite not configuring `color-eyre`, so this was a pointless dependency.

2. We were using `rustversion` to determine if we're using nightly. This is a proc-macro we were using in `pgx-pg-sys`, which adds an extra build phase to it's build script (to run the proc macro). While switching to the `rustc_version` would have avoided it, it also pulls in a dependency on the `semver` crate -- and really both of these are deps that are just to avoid a small bit of manual parsing of the `rustc --version` output, which is... not very complex to parse.