### PR TITLE
Support `--profile <profile name>` in `cargo-pgx`

### DIFF
--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -315,8 +315,11 @@ OPTIONS:
         --pgcli
             Use an existing `pgcli` on the $PATH [env: PGX_PGCLI=]
 
+        --profile <PROFILE>
+            Specific profile to use (conflicts with `--release`)
+
     -r, --release
-            Compile for release mode (default is debug) [env: PROFILE=]
+            Compile for release mode (default is debug)
 
     -v, --verbose
             Enable info logs, -vv for debug, -vvv for trace
@@ -444,8 +447,11 @@ OPTIONS:
     -p, --package <PACKAGE>
             Package to build (see `cargo help pkgid`)
 
+        --profile <PROFILE>
+            Specific profile to use (conflicts with `--release`)
+
     -r, --release
-            Compile for release mode (default is debug) [env: PROFILE=]
+            Compile for release mode (default is debug)
 
         --test
             Build in test mode (for `cargo pgx test`)
@@ -534,8 +540,11 @@ OPTIONS:
     -p, --package <PACKAGE>
             Package to build (see `cargo help pkgid`)
 
+        --profile <PROFILE>
+            Specific profile to use (conflicts with `--release`)
+
     -r, --release
-            compile for release mode (default is debug) [env: PROFILE=]
+            compile for release mode (default is debug)
 
     -v, --verbose
             Enable info logs, -vv for debug, -vvv for trace
@@ -595,7 +604,7 @@ OPTIONS:
             The `pg_config` path (default is first in $PATH)
 
     -d, --debug
-            Compile for debug mode (default is release) [env: PROFILE=]
+            Compile for debug mode (default is release)
 
         --features <FEATURES>
             Space-separated list of features to activate
@@ -615,6 +624,9 @@ OPTIONS:
 
     -p, --package <PACKAGE>
             Package to build (see `cargo help pkgid`)
+
+        --profile <PROFILE>
+            Specific profile to use (conflicts with `--debug`)
 
         --test
             Build in test mode (for `cargo pgx test`)
@@ -671,8 +683,11 @@ OPTIONS:
     -p, --package <PACKAGE>
             Package to build (see `cargo help pkgid`)
 
+        --profile <PROFILE>
+            Specific profile to use (conflicts with `--release`)
+
     -r, --release
-            Compile for release mode (default is debug) [env: PROFILE=]
+            Compile for release mode (default is debug)
 
         --skip-build
             Skip building a fresh extension shared object

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -29,7 +29,7 @@ pub(crate) struct Install {
     #[clap(long, parse(from_os_str))]
     manifest_path: Option<PathBuf>,
     /// Compile for release mode (default is debug)
-    #[clap(env = "PROFILE", long, short)]
+    #[clap(long, short)]
     release: bool,
     /// Specific profile to use (conflicts with `--release`)
     #[clap(long)]

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -8,6 +8,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::command::get::{find_control_file, get_property};
+use crate::profile::CargoProfile;
 use crate::CommandExecute;
 use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
@@ -30,6 +31,9 @@ pub(crate) struct Install {
     /// Compile for release mode (default is debug)
     #[clap(env = "PROFILE", long, short)]
     release: bool,
+    /// Specific profile to use (conflicts with `--release`)
+    #[clap(long)]
+    profile: Option<String>,
     /// Build in test mode (for `cargo pgx test`)
     #[clap(long)]
     test: bool,
@@ -59,6 +63,7 @@ impl CommandExecute for Install {
             Some(config) => PgConfig::new(PathBuf::from(config)),
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
+        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
 
         let features =
             crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
@@ -68,7 +73,7 @@ impl CommandExecute for Install {
             self.package.as_ref(),
             package_manifest_path,
             &pg_config,
-            self.release,
+            &profile,
             self.test,
             None,
             &features,
@@ -78,7 +83,7 @@ impl CommandExecute for Install {
 
 #[tracing::instrument(skip_all, fields(
     pg_version = %pg_config.version()?,
-    release = is_release,
+    profile = ?profile,
     test = is_test,
     base_directory = tracing::field::Empty,
     features = ?features.features,
@@ -88,7 +93,7 @@ pub(crate) fn install_extension(
     user_package: Option<&String>,
     package_manifest_path: impl AsRef<Path>,
     pg_config: &PgConfig,
-    is_release: bool,
+    profile: &CargoProfile,
     is_test: bool,
     base_directory: Option<PathBuf>,
     features: &clap_cargo::Features,
@@ -110,7 +115,7 @@ pub(crate) fn install_extension(
     let versioned_so = get_property(&package_manifest_path, "module_pathname")?.is_none();
 
     let build_command_output =
-        build_extension(user_manifest_path.as_ref(), user_package, is_release, &features)?;
+        build_extension(user_manifest_path.as_ref(), user_package, &profile, &features)?;
     let build_command_bytes = build_command_output.stdout;
     let build_command_reader = BufReader::new(build_command_bytes.as_slice());
     let build_command_stream = cargo_metadata::Message::parse_stream(build_command_reader);
@@ -163,7 +168,7 @@ pub(crate) fn install_extension(
         user_package,
         &package_manifest_path,
         pg_config,
-        is_release,
+        profile,
         is_test,
         features,
         &extdir,
@@ -211,7 +216,7 @@ fn copy_file(
 pub(crate) fn build_extension(
     user_manifest_path: Option<impl AsRef<Path>>,
     user_package: Option<&String>,
-    is_release: bool,
+    profile: &CargoProfile,
     features: &clap_cargo::Features,
 ) -> eyre::Result<std::process::Output> {
     let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
@@ -228,10 +233,7 @@ pub(crate) fn build_extension(
         command.arg("--package");
         command.arg(user_package);
     }
-
-    if is_release {
-        command.arg("--release");
-    }
+    command.args(profile.cargo_args());
 
     let features_arg = features.features.join(" ");
     if !features_arg.trim().is_empty() {
@@ -287,7 +289,7 @@ fn copy_sql_files(
     user_package: Option<&String>,
     package_manifest_path: impl AsRef<Path>,
     pg_config: &PgConfig,
-    is_release: bool,
+    profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
     extdir: &PathBuf,
@@ -302,7 +304,7 @@ fn copy_sql_files(
         user_manifest_path,
         user_package,
         &package_manifest_path,
-        is_release,
+        profile,
         is_test,
         features,
         Some(&dest),

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -7,9 +7,9 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::command::get::get_property;
 use crate::command::install::install_extension;
 use crate::CommandExecute;
+use crate::{command::get::get_property, profile::CargoProfile};
 use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
 use pgx_pg_config::{get_target_dir, PgConfig};
@@ -28,6 +28,9 @@ pub(crate) struct Package {
     /// Compile for debug mode (default is release)
     #[clap(env = "PROFILE", long, short)]
     debug: bool,
+    /// Specific profile to use (conflicts with `--debug`)
+    #[clap(long)]
+    profile: Option<String>,
     /// Build in test mode (for `cargo pgx test`)
     #[clap(long)]
     test: bool,
@@ -63,11 +66,11 @@ impl CommandExecute for Package {
 
         let features =
             crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
-
+        let profile = CargoProfile::from_flags(!self.debug, self.profile.as_deref())?;
         let out_dir = if let Some(out_dir) = self.out_dir {
             out_dir
         } else {
-            build_base_path(&pg_config, &package_manifest_path, self.debug)?
+            build_base_path(&pg_config, &package_manifest_path, &profile)?
         };
         package_extension(
             self.manifest_path.as_ref(),
@@ -75,7 +78,7 @@ impl CommandExecute for Package {
             &package_manifest_path,
             &pg_config,
             out_dir,
-            self.debug,
+            &profile,
             self.test,
             &features,
         )
@@ -84,7 +87,7 @@ impl CommandExecute for Package {
 
 #[tracing::instrument(level = "error", skip_all, fields(
     pg_version = %pg_config.version()?,
-    release = !is_debug,
+    profile = ?profile,
     test = is_test,
 ))]
 pub(crate) fn package_extension(
@@ -93,7 +96,7 @@ pub(crate) fn package_extension(
     package_manifest_path: impl AsRef<Path>,
     pg_config: &PgConfig,
     out_dir: PathBuf,
-    is_debug: bool,
+    profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
@@ -106,7 +109,7 @@ pub(crate) fn package_extension(
         user_package,
         &package_manifest_path,
         pg_config,
-        !is_debug,
+        profile,
         is_test,
         Some(out_dir),
         features,
@@ -116,13 +119,13 @@ pub(crate) fn package_extension(
 fn build_base_path(
     pg_config: &PgConfig,
     manifest_path: impl AsRef<Path>,
-    is_debug: bool,
+    profile: &CargoProfile,
 ) -> eyre::Result<PathBuf> {
     let mut target_dir = get_target_dir()?;
     let pgver = pg_config.major_version()?;
     let extname = get_property(manifest_path, "extname")?
         .ok_or(eyre!("could not determine extension name"))?;
-    target_dir.push(if is_debug { "debug" } else { "release" });
+    target_dir.push(profile.target_subdir());
     target_dir.push(format!("{}-pg{}", extname, pgver));
     Ok(target_dir)
 }

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -26,7 +26,7 @@ pub(crate) struct Package {
     #[clap(long, parse(from_os_str))]
     manifest_path: Option<PathBuf>,
     /// Compile for debug mode (default is release)
-    #[clap(env = "PROFILE", long, short)]
+    #[clap(long, short)]
     debug: bool,
     /// Specific profile to use (conflicts with `--debug`)
     #[clap(long)]

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -36,7 +36,7 @@ pub(crate) struct Run {
     #[clap(long)]
     manifest_path: Option<String>,
     /// Compile for release mode (default is debug)
-    #[clap(env = "PROFILE", long, short)]
+    #[clap(long, short)]
     release: bool,
     /// Specific profile to use (conflicts with `--release`)
     #[clap(long)]

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -11,6 +11,7 @@ use crate::command::get::get_property;
 use crate::command::install::install_extension;
 use crate::command::start::start_postgres;
 use crate::command::stop::stop_postgres;
+use crate::profile::CargoProfile;
 use crate::CommandExecute;
 use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
@@ -37,6 +38,9 @@ pub(crate) struct Run {
     /// Compile for release mode (default is debug)
     #[clap(env = "PROFILE", long, short)]
     release: bool,
+    /// Specific profile to use (conflicts with `--release`)
+    #[clap(long)]
+    profile: Option<String>,
     #[clap(flatten)]
     features: clap_cargo::Features,
     #[clap(from_global, parse(from_occurrences))]
@@ -93,6 +97,7 @@ impl CommandExecute for Run {
             None => get_property(&package_manifest_path, "extname")?
                 .ok_or(eyre!("could not determine extension name"))?,
         };
+        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
 
         run(
             pg_config,
@@ -100,7 +105,7 @@ impl CommandExecute for Run {
             self.package.as_ref(),
             package_manifest_path,
             &dbname,
-            self.release,
+            &profile,
             self.pgcli,
             &features,
         )
@@ -110,7 +115,7 @@ impl CommandExecute for Run {
 #[tracing::instrument(level = "error", skip_all, fields(
     pg_version = %pg_config.version()?,
     dbname,
-    release = is_release,
+    profile = ?profile,
 ))]
 pub(crate) fn run(
     pg_config: &PgConfig,
@@ -118,7 +123,7 @@ pub(crate) fn run(
     user_package: Option<&String>,
     package_manifest_path: impl AsRef<Path>,
     dbname: &str,
-    is_release: bool,
+    profile: &CargoProfile,
     pgcli: bool,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
@@ -131,7 +136,7 @@ pub(crate) fn run(
         user_package,
         package_manifest_path,
         pg_config,
-        is_release,
+        profile,
         false,
         None,
         features,

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -50,7 +50,7 @@ pub(crate) struct Schema {
     /// Do you want to run against Postgres `pg10`, `pg11`, `pg12`, `pg13`, `pg14`?
     pg_version: Option<String>,
     /// Compile for release mode (default is debug)
-    #[clap(env = "PROFILE", long, short)]
+    #[clap(long, short)]
     release: bool,
     /// Specific profile to use (conflicts with `--release`)
     #[clap(long)]

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -9,6 +9,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 use crate::command::get::{find_control_file, get_property};
 use crate::command::install::format_display_path;
 use crate::pgx_pg_sys_stub::PgxPgSysStub;
+use crate::profile::CargoProfile;
 use crate::CommandExecute;
 use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
@@ -51,6 +52,9 @@ pub(crate) struct Schema {
     /// Compile for release mode (default is debug)
     #[clap(env = "PROFILE", long, short)]
     release: bool,
+    /// Specific profile to use (conflicts with `--release`)
+    #[clap(long)]
+    profile: Option<String>,
     /// The `pg_config` path (default is first in $PATH)
     #[clap(long, short = 'c', parse(from_os_str))]
     pg_config: Option<PathBuf>,
@@ -114,12 +118,14 @@ impl CommandExecute for Schema {
         let features =
             crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
 
+        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
+
         generate_schema(
             &pg_config,
             self.manifest_path.as_ref(),
             self.package.as_ref(),
             package_manifest_path,
-            self.release,
+            &profile,
             self.test,
             &features,
             self.out.as_ref(),
@@ -132,7 +138,7 @@ impl CommandExecute for Schema {
 
 #[tracing::instrument(level = "error", skip_all, fields(
     pg_version = %pg_config.version()?,
-    release = is_release,
+    profile = ?profile,
     test = is_test,
     path = path.as_ref().map(|path| tracing::field::display(path.as_ref().display())),
     dot,
@@ -143,7 +149,7 @@ pub(crate) fn generate_schema(
     user_manifest_path: Option<impl AsRef<Path>>,
     user_package: Option<&String>,
     package_manifest_path: impl AsRef<Path>,
-    is_release: bool,
+    profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
     path: Option<impl AsRef<std::path::Path>>,
@@ -171,7 +177,7 @@ pub(crate) fn generate_schema(
     let flags = std::env::var("PGX_BUILD_FLAGS").unwrap_or_default();
 
     let mut target_dir_with_profile = get_target_dir()?;
-    target_dir_with_profile.push(if is_release { "release" } else { "debug" });
+    target_dir_with_profile.push(profile.target_subdir());
 
     // First, build the SQL generator so we can get a look at the symbol table
     if !skip_build {
@@ -195,9 +201,7 @@ pub(crate) fn generate_schema(
             command.arg(user_manifest_path.as_ref());
         }
 
-        if is_release {
-            command.arg("--release");
-        }
+        command.args(profile.cargo_args());
 
         if let Some(log_level) = &log_level {
             command.env("RUST_LOG", log_level);

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -13,6 +13,7 @@ use pgx_pg_config::{get_target_dir, PgConfig, PgConfigSelector, Pgx};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use crate::profile::CargoProfile;
 use crate::CommandExecute;
 
 /// Run the test suite for this crate
@@ -33,6 +34,9 @@ pub(crate) struct Test {
     /// compile for release mode (default is debug)
     #[clap(env = "PROFILE", long, short)]
     release: bool,
+    /// Specific profile to use (conflicts with `--release`)
+    #[clap(long)]
+    profile: Option<String>,
     /// Don't regenerate the schema
     #[clap(long, short)]
     no_schema: bool,
@@ -61,6 +65,7 @@ impl CommandExecute for Test {
             None => crate::manifest::default_pg_version(&package_manifest)
                 .ok_or(eyre!("No provided `pg$VERSION` flag."))?,
         };
+        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
 
         for pg_config in pgx.iter(PgConfigSelector::new(&pg_version)) {
             let mut testname = self.testname.clone();
@@ -91,7 +96,7 @@ impl CommandExecute for Test {
                 pg_config,
                 self.manifest_path.as_ref(),
                 self.package.as_ref(),
-                self.release,
+                &profile,
                 self.no_schema,
                 &features,
                 testname.clone(),
@@ -105,13 +110,13 @@ impl CommandExecute for Test {
 #[tracing::instrument(skip_all, fields(
     pg_version = %pg_config.version()?,
     testname =  tracing::field::Empty,
-    release = is_release,
+    ?profile,
 ))]
 pub fn test_extension(
     pg_config: &PgConfig,
     user_manifest_path: Option<impl AsRef<Path>>,
     user_package: Option<&String>,
-    is_release: bool,
+    profile: &CargoProfile,
     no_schema: bool,
     features: &clap_cargo::Features,
     testname: Option<impl AsRef<str>>,
@@ -137,7 +142,7 @@ pub fn test_extension(
         .env("PGX_FEATURES", features_arg.clone())
         .env("PGX_NO_DEFAULT_FEATURES", if no_default_features_arg { "true" } else { "false" })
         .env("PGX_ALL_FEATURES", if features.all_features { "true" } else { "false" })
-        .env("PGX_BUILD_PROFILE", if is_release { "release" } else { "debug" })
+        .env("PGX_BUILD_PROFILE", profile.name())
         .env("PGX_NO_SCHEMA", if no_schema { "true" } else { "false" });
 
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
@@ -157,9 +162,7 @@ pub fn test_extension(
         command.arg("--all-features");
     }
 
-    if is_release {
-        command.arg("--release");
-    }
+    command.args(profile.cargo_args());
 
     if let Some(user_manifest_path) = user_manifest_path {
         command.arg("--manifest-path");

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -32,7 +32,7 @@ pub(crate) struct Test {
     #[clap(long, parse(from_os_str))]
     manifest_path: Option<PathBuf>,
     /// compile for release mode (default is debug)
-    #[clap(env = "PROFILE", long, short)]
+    #[clap(long, short)]
     release: bool,
     /// Specific profile to use (conflicts with `--release`)
     #[clap(long)]

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -12,6 +12,8 @@ mod manifest;
 mod metadata;
 mod pgx_pg_sys_stub;
 
+pub(crate) mod profile;
+
 use atty::Stream;
 use clap::Parser;
 use tracing_error::ErrorLayer;

--- a/cargo-pgx/src/profile.rs
+++ b/cargo-pgx/src/profile.rs
@@ -1,0 +1,63 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+/// Represents a selected cargo profile
+///
+/// Generally chosen from flags like `--release`, `--profile <profile name>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CargoProfile {
+    /// The default non-release profile, `[profile.dev]`
+    Dev,
+    /// The default release profile, `[profile.release]`
+    Release,
+    /// Some other profile, specified by name.
+    Profile(String),
+}
+
+impl CargoProfile {
+    pub fn from_flags(release: bool, profile: Option<&str>) -> eyre::Result<Self> {
+        match (profile, release) {
+            (Some(profile), true) => {
+                eyre::bail!("conflicting usage of --profile={:?} and --release", profile);
+            }
+            // Cargo treats `--profile release` the same as `--release`.
+            (Some("release"), false) => Ok(Self::Release),
+            // Cargo has two names for the debug profile, due to legacy
+            // reasons...
+            (Some("debug"), false) | (Some("dev"), false) => Ok(Self::Dev),
+            (Some(profile), false) => Ok(Self::Profile(profile.into())),
+            (None, true) => Ok(Self::Release),
+            (None, false) => Ok(Self::Dev),
+        }
+    }
+
+    pub fn cargo_args(&self) -> Vec<String> {
+        match self {
+            Self::Dev => vec![],
+            Self::Release => vec!["--release".into()],
+            Self::Profile(p) => vec!["--profile".into(), p.into()],
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Dev => "dev",
+            Self::Release => "release",
+            Self::Profile(p) => p,
+        }
+    }
+
+    pub fn target_subdir(&self) -> &str {
+        match self {
+            Self::Dev => "debug",
+            Self::Release => "release",
+            Self::Profile(p) => p,
+        }
+    }
+}


### PR DESCRIPTION
Discussed in a call with @eeeebbbbrrrr.

This should allow users like zdb to dev with the default release profile profile (thinlto, more codegen units, etc) and configure a profile with more optimizations (fatlto, cgu=1, etc) for packaged releases.

(NB: Not fully tested yet, doing that now but some might have to wait til tomorrow)