### PR TITLE
Removes allowlist_* from bindgen, for now

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -566,13 +566,6 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .clang_arg(&format!("-I{}", includedir_server.display()))
         .clang_args(&extra_bindgen_clang_args(pg_config)?)
         .parse_callbacks(Box::new(PgxOverrides::default()))
-        .allowlist_file(".*confdefs.h")
-        .allowlist_file(".*(?:[fF]uncs|mgr).h")
-        .allowlist_file(".*htup(?:_details)?.h")
-        .allowlist_file(".*syscache.h")
-        .allowlist_file(".*mcxt.h")
-        .allowlist_file(".*(?:storage|catalog|access|commands|executor|adt|optimizer|rewrite|postmaster|tcop|replication|nodes|postgres|parse|pg_|item|heap).*")
-        .allowlist_var("SIG.*")
         .blocklist_type("(Nullable)?Datum") // manually wrapping datum types for correctness
         .blocklist_function("varsize_any") // pgx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
         .blocklist_function("(?:query|expression)_tree_walker")

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -595,12 +595,7 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .derive_partialord(false)
         .layout_tests(false)
         .generate()
-        .unwrap_or_else(|e| {
-            panic!(
-                "Unable to generate bindings for pg{}: {:?}",
-                major_version, e
-            )
-        });
+        .unwrap_or_else(|e| panic!("Unable to generate bindings for pg{}: {:?}", major_version, e));
 
     syn::parse_file(bindings.to_string().as_str()).map_err(|e| From::from(e))
 }


### PR DESCRIPTION
While testing PGX on Amazon Linux 2, it was discovered that the latest changes in 0.5.0 regarding bindgen's `allowlist_*` declarations in `pgx-pg-sys` were causing failed builds. Removing everything `allowlist_*` makes it happy for all platforms at the moment, so they will be reverted back until we can circle back and address the underlying issue.

The current theory is that there are some differences in the Postgres header files between the source that `amazon-linux-extras` provides in an Amazon Linux 2 environment versus the official Postgres source that comes from all other sources (including directly from Postgres itself via something like `cargo pgx init`).

This relates to https://github.com/tcdi/pgx/issues/730 and other issues/pull requests mentioned therein.

