### PR TITLE
Problem: working with independent extensions simultaneously

### DIFF
--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -107,7 +107,7 @@ As shown by the screenshot above, it downloads the latest versions of Postgres v
 In cases when default ports pgx uses to run PostgreSQL within are not available, one can specify
 custom values for these during initialization using `--base-port` and `--base-testing-port`
 options. One of the use cases for this is using multiple installations of pgx (using `$PGX_HOME` variable)
-when developing multiple extensions at the same time.
+when developing multiple extensions at the same time. These values can be later changed in `$PGX_HOME/config.toml`.
 
 If you want to use your operating system's package manager to install Postgres, `cargo pgx init` has optional arguments that allow you to specify where they're installed (see below).
 

--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -104,6 +104,11 @@ As shown by the screenshot above, it downloads the latest versions of Postgres v
 
 `pgx` is designed to support multiple Postgres versions in such a way that during development, you'll know if you're trying to use a Postgres API that isn't common across all versions. It's also designed to make testing your extension against these versions easy. This is why it requires you to have all fully compiled and installed versions of Postgres during development.
 
+In cases when default ports pgx uses to run PostgreSQL within are not available, one can specify
+custom values for these during initialization using `--base-port` and `--base-testing-port`
+options. One of the use cases for this is using multiple installations of pgx (using `$PGX_HOME` variable)
+when developing multiple extensions at the same time.
+
 If you want to use your operating system's package manager to install Postgres, `cargo pgx init` has optional arguments that allow you to specify where they're installed (see below).
 
 What you're telling `cargo pgx init` is the full path to `pg_config` for each version.
@@ -130,6 +135,12 @@ USAGE:
     cargo pgx init [OPTIONS]
 
 OPTIONS:
+        --base-port <BASE_PORT>
+            Base port number
+
+        --base-testing-port <BASE_TESTING_PORT>
+            Base testing port number
+
     -h, --help           Print help information
         --pg10 <PG10>    [env: PG10_PG_CONFIG=]
         --pg11 <PG11>    If installed locally, the path to PG11's `pgconfig` tool, or `download` to

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -60,7 +60,7 @@ impl CommandExecute for Install {
 
         let pg_config = match self.pg_config {
             None => PgConfig::from_path(),
-            Some(config) => PgConfig::new(PathBuf::from(config)),
+            Some(config) => PgConfig::new_with_defaults(PathBuf::from(config)),
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
         let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -60,7 +60,7 @@ impl CommandExecute for Package {
 
         let pg_config = match self.pg_config {
             None => PgConfig::from_path(),
-            Some(config) => PgConfig::new(PathBuf::from(config)),
+            Some(config) => PgConfig::new_with_defaults(PathBuf::from(config)),
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
 

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -109,7 +109,7 @@ impl CommandExecute for Schema {
                 Some(pgver) => (Pgx::from_config()?.get(&pgver)?.clone(), pgver),
             },
             Some(config) => {
-                let pg_config = PgConfig::new(PathBuf::from(config));
+                let pg_config = PgConfig::new_with_defaults(PathBuf::from(config));
                 let pg_version = format!("pg{}", pg_config.major_version()?);
                 (pg_config, pg_version)
             }

--- a/cargo-pgx/src/command/version.rs
+++ b/cargo-pgx/src/command/version.rs
@@ -1,7 +1,7 @@
 use pgx_pg_config::{PgConfig, Pgx};
 
 pub(crate) fn pgx_default(supported_major_versions: &[u16]) -> eyre::Result<Pgx> {
-    let mut pgx = Pgx::new();
+    let mut pgx = Pgx::default();
     rss::PostgreSQLVersionRss::new(supported_major_versions)?
         .into_iter()
         .for_each(|version| pgx.push(PgConfig::from(version)));

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -52,6 +52,8 @@ impl Display for PgVersion {
 pub struct PgConfig {
     version: Option<PgVersion>,
     pg_config: Option<PathBuf>,
+    base_port: u16,
+    base_testing_port: u16,
 }
 
 impl Display for PgConfig {
@@ -68,23 +70,37 @@ impl Display for PgConfig {
 
 impl Default for PgConfig {
     fn default() -> Self {
-        PgConfig { version: None, pg_config: None }
+        PgConfig {
+            version: None,
+            pg_config: None,
+            base_port: BASE_POSTGRES_PORT_NO,
+            base_testing_port: BASE_POSTGRES_TESTING_PORT_NO,
+        }
     }
 }
 
 impl From<PgVersion> for PgConfig {
     fn from(version: PgVersion) -> Self {
-        PgConfig { version: Some(version), pg_config: None }
+        PgConfig { version: Some(version), pg_config: None, ..Default::default() }
     }
 }
 
 impl PgConfig {
-    pub fn new(pg_config: PathBuf) -> Self {
-        PgConfig { version: None, pg_config: Some(pg_config) }
+    pub fn new(pg_config: PathBuf, base_port: u16, base_testing_port: u16) -> Self {
+        PgConfig { version: None, pg_config: Some(pg_config), base_port, base_testing_port }
+    }
+
+    pub fn new_with_defaults(pg_config: PathBuf) -> Self {
+        PgConfig {
+            version: None,
+            pg_config: Some(pg_config),
+            base_port: BASE_POSTGRES_PORT_NO,
+            base_testing_port: BASE_POSTGRES_TESTING_PORT_NO,
+        }
     }
 
     pub fn from_path() -> Self {
-        PgConfig::new("pg_config".into())
+        Self::new_with_defaults("pg_config".into())
     }
 
     pub fn is_real(&self) -> bool {
@@ -164,11 +180,11 @@ impl PgConfig {
     }
 
     pub fn port(&self) -> eyre::Result<u16> {
-        Ok(BASE_POSTGRES_PORT_NO + self.major_version()?)
+        Ok(self.base_port + self.major_version()?)
     }
 
     pub fn test_port(&self) -> eyre::Result<u16> {
-        Ok(BASE_POSTGRES_TESTING_PORT_NO + self.major_version()?)
+        Ok(self.base_testing_port + self.major_version()?)
     }
 
     pub fn host(&self) -> &'static str {
@@ -262,11 +278,27 @@ impl PgConfig {
 
 pub struct Pgx {
     pg_configs: Vec<PgConfig>,
+    base_port: u16,
+    base_testing_port: u16,
+}
+
+impl Default for Pgx {
+    fn default() -> Self {
+        Self {
+            pg_configs: vec![],
+            base_port: BASE_POSTGRES_PORT_NO,
+            base_testing_port: BASE_POSTGRES_TESTING_PORT_NO,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ConfigToml {
     configs: HashMap<String, PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_testing_port: Option<u16>,
 }
 
 pub enum PgConfigSelector<'a> {
@@ -285,16 +317,16 @@ impl<'a> PgConfigSelector<'a> {
 }
 
 impl Pgx {
-    pub fn new() -> Self {
-        Pgx { pg_configs: vec![] }
+    pub fn new(base_port: u16, base_testing_port: u16) -> Self {
+        Pgx { pg_configs: vec![], base_port, base_testing_port }
     }
 
     pub fn from_config() -> eyre::Result<Self> {
         match std::env::var("PGX_PG_CONFIG_PATH") {
             Ok(pg_config) => {
                 // we have an environment variable that tells us the pg_config to use
-                let mut pgx = Pgx::new();
-                pgx.push(PgConfig::new(pg_config.into()));
+                let mut pgx = Pgx::default();
+                pgx.push(PgConfig::new(pg_config.into(), pgx.base_port, pgx.base_testing_port));
                 Ok(pgx)
             }
             Err(_) => {
@@ -310,10 +342,13 @@ impl Pgx {
 
                 match toml::from_str::<ConfigToml>(&std::fs::read_to_string(&path)?) {
                     Ok(configs) => {
-                        let mut pgx = Pgx::new();
+                        let mut pgx = Pgx::new(
+                            configs.base_port.unwrap_or(BASE_POSTGRES_PORT_NO),
+                            configs.base_testing_port.unwrap_or(BASE_POSTGRES_TESTING_PORT_NO),
+                        );
 
                         for (_, v) in configs.configs {
-                            pgx.push(PgConfig::new(v));
+                            pgx.push(PgConfig::new(v, pgx.base_port, pgx.base_testing_port));
                         }
                         Ok(pgx)
                     }


### PR DESCRIPTION
As I am developing a few small extensions, I tend to switch between them, leaving the database in a state that's not necessarily stable, and therefore sharing the same instance of PostgreSQL is a bit problematic.

I can use PGX_HOME to use independent installations of PostgreSQL but they compete for the same set of ports.

Solution: make ports configurable during `pgx init` and in `config.toml`