### PR TITLE
Remove lifetimes from FunctionMetadata impl

### DIFF
--- a/pgx-utils/src/sql_entity_graph/metadata/function_metadata.rs
+++ b/pgx-utils/src/sql_entity_graph/metadata/function_metadata.rs
@@ -79,12 +79,12 @@ impl FunctionMetadata<(), ()> for unsafe fn() {
 seq_macro::seq!(I in 0..=32 {
     #(
         seq_macro::seq!(N in 0..=I {
-            impl<'output, #('input~N: 'output,)* #(Input~N,)* Output> FunctionMetadata<(#(Input~N,)*), Output> for fn(#(Input~N,)*) -> Output
+            impl<#(Input~N,)* Output> FunctionMetadata<(#(Input~N,)*), Output> for fn(#(Input~N,)*) -> Output
             where
                 #(
-                    Input~N: SqlTranslatable + 'input~N,
+                    Input~N: SqlTranslatable,
                 )*
-                Output: SqlTranslatable + 'output,
+                Output: SqlTranslatable,
             {
                 fn entity(&self) -> FunctionMetadataEntity {
                     let mut arguments = Vec::new();


### PR DESCRIPTION
These prevent something like the following, which I believe we want to support:

```rs
#[pg_extern]
fn example(s: &str) -> String {
    s.into()
}
```

That is, they prevent accepting a non-static input and returning a static output. I think they're intended to prevent code from returning a non-static lifetime that outlives the input (but came from it), but the only way for it to do that would be unsafe code, and unsafe code can already lie about lifetimes.