### PR TITLE
Allow use in Rust 1.61.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "pgx-utils",
  "proc-macro2",
  "quote",
+ "rayon",
  "shlex",
  "sptr",
  "syn",

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -41,6 +41,7 @@ pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.5.2" }
 pgx-utils = { path = "../pgx-utils/", version = "=0.5.2" }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
+rayon = "1.5.3"
 syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -12,6 +12,7 @@ use eyre::{eyre, WrapErr};
 use pgx_pg_config::{prefix_path, PgConfig, PgConfigSelector, Pgx, SUPPORTED_MAJOR_VERSIONS};
 use pgx_utils::rewriter::PgGuardRewriter;
 use quote::{quote, ToTokens};
+use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::{Command, Output};
@@ -140,24 +141,12 @@ fn main() -> eyre::Result<()> {
         let specific = pgx.get(&found)?;
         vec![specific]
     };
-    std::thread::scope(|scope| {
-        // This is pretty much either always 1 (normally) or 5 (for releases),
-        // but in the future if we ever have way more, we should consider
-        // chunking `pg_configs` based on `thread::available_parallelism()`.
-        let threads = pg_configs
-            .iter()
-            .map(|pg_config| {
-                scope.spawn(|| generate_bindings(pg_config, &build_paths, is_for_release))
-            })
-            .collect::<Vec<_>>();
-        // Most of the rest of this is just for better error handling --
-        // `thread::scope` already joins the threads for us before it returns.
-        let results = threads
-            .into_iter()
-            .map(|thread| thread.join().expect("thread panicked while generating bindings"))
-            .collect::<Vec<eyre::Result<_>>>();
-        results.into_iter().try_for_each(|r| r)
-    })?;
+
+    pg_configs
+        .par_iter()
+        .map(|pg_config| generate_bindings(pg_config, &build_paths, is_for_release))
+        .collect::<eyre::Result<Vec<_>>>()?;
+
     // compile the cshim for each binding
     for pg_config in pg_configs {
         build_shim(&build_paths.shim_src, &build_paths.shim_dst, &pg_config)?;

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -28,8 +28,8 @@ std::compile_error!("exactly one one feature must be provided (pg10, pg11, pg12,
 
 pub mod submodules;
 
-use core::ffi::CStr;
 use core::ptr::NonNull;
+use std::ffi::CStr;
 pub use submodules::{guard, *};
 
 //


### PR DESCRIPTION
This reverts commit 3222141 (from #747) and changes another patch to work in 1.61.0

We should revert this after we can *actually* use newer rust.