### PR TITLE
Detect and complain about use of `pgx-pg-sys` functions from multiple threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ version = "0.5.6"
 dependencies = [
  "bindgen",
  "eyre",
+ "libc",
  "memoffset",
  "once_cell",
  "pgx-macros",

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -34,6 +34,7 @@ pgx-macros = { path = "../pgx-macros/", version = "=0.5.6" }
 pgx-utils = { path = "../pgx-utils/", version = "=0.5.6" }
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
+libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }

--- a/pgx-pg-sys/src/submodules/mod.rs
+++ b/pgx-pg-sys/src/submodules/mod.rs
@@ -12,6 +12,7 @@ pub mod guard;
 mod oids;
 mod polyfill;
 pub mod setjmp;
+pub(crate) mod thread_check;
 mod tupdesc;
 mod utils;
 // Various SqlTranslatable mappings for SQL generation

--- a/pgx-pg-sys/src/submodules/setjmp.rs
+++ b/pgx-pg-sys/src/submodules/setjmp.rs
@@ -45,6 +45,7 @@ being converted into a transaction-aborting Postgres `ERROR` by PGX.
 
 **/
 #[inline(always)]
+#[track_caller]
 pub(crate) unsafe fn pg_guard_ffi_boundary<T, F: FnOnce() -> T>(f: F) -> T {
     // SAFETY: Caller promises not to call us from anything but the main thread.
     unsafe { pg_guard_ffi_boundary_impl(f) }
@@ -52,9 +53,14 @@ pub(crate) unsafe fn pg_guard_ffi_boundary<T, F: FnOnce() -> T>(f: F) -> T {
 
 #[cfg(not(feature = "postgrestd"))]
 #[inline(always)]
+#[track_caller]
 unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
     //! This is the version that uses sigsetjmp and all that, for "normal" Rust/PGX interfaces.
     use crate as pg_sys;
+
+    // The next code is definitely thread-unsafe (it manipulates statics in an
+    // unsynchronized manner), so we may as well check here.
+    super::thread_check::check_active_thread();
 
     // SAFETY: This should really, really not be done in a multithreaded context as it
     // accesses multiple `static mut`. The ultimate caller asserts this is the main thread.

--- a/pgx-pg-sys/src/submodules/thread_check.rs
+++ b/pgx-pg-sys/src/submodules/thread_check.rs
@@ -1,0 +1,77 @@
+//! Enforces thread-safety in `pgx`.
+//!
+//! It's UB to call into Postgres functions from multiple threads. We handle
+//! this by remembering the first thread to call into postgres functions, and
+//! panicking if we're called from a different thread.
+//!
+//! This is called from the current crate from inside the setjmp shim, as that
+//! code is *definitely* unsound to call in the presense of multiple threads.
+//!
+//! This is somewhat heavyhanded, and should be called from fewer places in the
+//! future...
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[track_caller]
+pub(crate) fn check_active_thread() {
+    static ACTIVE_THREAD: AtomicUsize = AtomicUsize::new(0);
+    let current_thread = nonzero_thread_id();
+    // Relaxed is sufficient as we're only interested in the effects on a single
+    // atomic variable, and don't need synchronization beyond that.
+    return match ACTIVE_THREAD.load(Ordering::Relaxed) {
+        0 => init_active_thread(current_thread, &ACTIVE_THREAD),
+        thread_id => {
+            if current_thread.get() != thread_id {
+                thread_id_check_failed();
+            }
+        }
+    };
+}
+
+#[track_caller]
+fn init_active_thread(tid: NonZeroUsize, atom: &AtomicUsize) {
+    match atom.compare_exchange(0, tid.get(), Ordering::Relaxed, Ordering::Relaxed) {
+        Ok(_) => {
+            // All good!
+        }
+        Err(_) => {
+            thread_id_check_failed();
+        }
+    }
+}
+
+#[cold]
+#[inline(never)]
+#[track_caller]
+fn thread_id_check_failed() -> ! {
+    panic!("`pgx` may not functionality may not be used from multiple threads.");
+}
+
+fn nonzero_thread_id() -> NonZeroUsize {
+    // Returns the `addr()` of a thread local variable.
+    //
+    // For now this is reasonably efficient, but could be (substantially, for
+    // our use) improved by using a pointer to the thread control block, which
+    // can avoid going through `__tls_get_addr`.
+    //
+    // Sadly, doing that would require some fiddley platform-specific inline
+    // assembly, which is enough of a pain that it's not worth bothering with
+    // for now. That said, in the future if this becomes a performance issue,
+    // that'd be a good fix.
+    //
+    // For examples of how to do this, see the how checks for cross-thread frees
+    // on are implemented in thread-pooling allocators, ex:
+    // - https://github.com/microsoft/mimalloc/blob/f2712f4a8f038a7fb4df2790f4c3b7e3ed9e219b/include/mimalloc-internal.h#L871
+    // - https://github.com/mjansson/rpmalloc/blob/f56e2f6794eab5c280b089c90750c681679fde92/rpmalloc/rpmalloc.c#L774
+    // and so on.
+    std::thread_local! {
+        static BYTE: u8 = const { 0 };
+    }
+    BYTE.with(|p: &u8| {
+        // Note: Avoid triggering the `unstable_name_collisions` lint.
+        let addr = sptr::Strict::addr(p as *const u8);
+        // SAFETY: `&u8` is always nonnull, so it's address is always nonzero.
+        unsafe { NonZeroUsize::new_unchecked(addr) }
+    })
+}

--- a/pgx-pg-sys/src/submodules/thread_check.rs
+++ b/pgx-pg-sys/src/submodules/thread_check.rs
@@ -19,14 +19,14 @@ pub(crate) fn check_active_thread() {
     let current_thread = nonzero_thread_id();
     // Relaxed is sufficient as we're only interested in the effects on a single
     // atomic variable, and don't need synchronization beyond that.
-    return match ACTIVE_THREAD.load(Ordering::Relaxed) {
+    match ACTIVE_THREAD.load(Ordering::Relaxed) {
         0 => init_active_thread(current_thread),
         thread_id => {
             if current_thread.get() != thread_id {
                 thread_id_check_failed();
             }
         }
-    };
+    }
 }
 
 #[track_caller]
@@ -50,7 +50,7 @@ fn init_active_thread(tid: NonZeroUsize) {
 #[inline(never)]
 #[track_caller]
 fn thread_id_check_failed() -> ! {
-    panic!("`pgx` may not not be used from multiple threads.");
+    panic!("postgres FFI may not not be called from multiple threads.");
 }
 
 fn nonzero_thread_id() -> NonZeroUsize {
@@ -76,7 +76,7 @@ fn nonzero_thread_id() -> NonZeroUsize {
     BYTE.with(|p: &u8| {
         // Note: Avoid triggering the `unstable_name_collisions` lint.
         let addr = sptr::Strict::addr(p as *const u8);
-        // SAFETY: `&u8` is always nonnull, so it's address is always nonzero.
+        // SAFETY: `&u8` is always nonnull, so its address is always nonzero.
         unsafe { NonZeroUsize::new_unchecked(addr) }
     })
 }

--- a/pgx-pg-sys/src/submodules/thread_check.rs
+++ b/pgx-pg-sys/src/submodules/thread_check.rs
@@ -45,7 +45,7 @@ fn init_active_thread(tid: NonZeroUsize, atom: &AtomicUsize) {
 #[inline(never)]
 #[track_caller]
 fn thread_id_check_failed() -> ! {
-    panic!("`pgx` may not functionality may not be used from multiple threads.");
+    panic!("`pgx` may not not be used from multiple threads.");
 }
 
 fn nonzero_thread_id() -> NonZeroUsize {


### PR DESCRIPTION
Doing this will likely break stuff like #775, although that code is already thread-unsafe (due to our setjmp shim)... That said, it reduces UB from data races (at best) to a panic with a reasonable backtrace.