### PR TITLE
Mention pitfall in safety documentation

### DIFF
--- a/SAFETY.md
+++ b/SAFETY.md
@@ -16,8 +16,8 @@ Quirks specific to Postgres.
 The `palloc*` family of functions may throw a Postgres error but will not return `nullptr`.
 
 You should be careful to avoid using data allocated by Postgres after it has been freed. In particular,
-when writing set returning functions, don't directly return data from the arguments without cloning the
-data into memory owned by Rust.
+when writing set returning functions, don't directly return referenced data from the arguments without
+cloning the data into memory owned by Rust.
 
 ## Rust
 

--- a/SAFETY.md
+++ b/SAFETY.md
@@ -15,6 +15,10 @@ Quirks specific to Postgres.
 
 The `palloc*` family of functions may throw a Postgres error but will not return `nullptr`.
 
+You should be careful to avoid using data allocated by Postgres after it has been freed. In particular,
+when writing set returning functions, don't directly return data from the arguments without cloning the
+data into memory owned by Rust.
+
 ## Rust
 
 Quirks specific to Rust that specifically inform the design of this crate and not, say,


### PR DESCRIPTION
When writing SRFs that return a function of the input arguments with lifetimes, it's easy to accidentally create a use after free. This PR documents that pitfall in the safety documentation.

e.g. this code

```rust
struct State<'a> { ... }
#[pg_extern]
fn foo<'a>(state: State<'a>) -> TableIterator<'a, (pgx::name!(val, i32))> {
    TableIterator::new(
        state.vals.clone().map(|x| (x + 1,))
    )
}
```

has a use after free. See [this disscusion](https://discord.com/channels/561648697805504526/749454413407584258/1029497569925144626).