### PR TITLE
SRF functions need to "fetch" (call `FromDatum`) each argument while …

### DIFF
--- a/pgx-examples/strings/src/lib.rs
+++ b/pgx-examples/strings/src/lib.rs
@@ -41,6 +41,14 @@ fn split_set<'a>(input: &'a str, pattern: &'a str) -> SetOfIterator<'a, &'a str>
     SetOfIterator::new(input.split_terminator(pattern).into_iter())
 }
 
+#[pg_extern]
+fn split_table<'a>(
+    input: &'a str,
+    pattern: &'a str,
+) -> TableIterator<'a, (name!(i, i32), name!(s, &'a str))> {
+    TableIterator::new(input.split_terminator(pattern).enumerate().map(|(i, s)| (i as i32, s)))
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -7,8 +7,8 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
-use crate::sql_entity_graph::PositioningRef;
-use proc_macro2::{TokenStream, TokenTree};
+use crate::sql_entity_graph::{NameMacro, PositioningRef};
+use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
 use std::collections::HashSet;
 use syn::{GenericArgument, PathArguments, Type, TypeParamBound};
@@ -408,6 +408,23 @@ pub fn staticize_lifetimes(value: &mut syn::Type) {
             }
         }
 
+        syn::Type::Macro(type_macro) => {
+            let mac = &type_macro.mac;
+            let archetype = mac.path.segments.last().unwrap();
+            match archetype.ident.to_string().as_str() {
+                "name" => {
+                    let mut out: NameMacro = mac.parse_body().expect("name!() in wrong format");
+                    staticize_lifetimes(&mut out.used_ty.resolved_ty);
+                    staticize_lifetimes(&mut out.used_ty.original_ty);
+
+                    // rewrite the name!() macro so that it has a static lifetime, if any
+                    let ident = syn::parse_str::<Ident>(&out.ident).unwrap();
+                    let ty = out.used_ty.resolved_ty;
+                    type_macro.mac = syn::parse_quote! {name!(#ident, #ty)};
+                }
+                _ => {}
+            }
+        }
         _ => {}
     }
 }

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -415,7 +415,6 @@ pub fn staticize_lifetimes(value: &mut syn::Type) {
                 "name" => {
                     let mut out: NameMacro = mac.parse_body().expect("name!() in wrong format");
                     staticize_lifetimes(&mut out.used_ty.resolved_ty);
-                    staticize_lifetimes(&mut out.used_ty.original_ty);
 
                     // rewrite the name!() macro so that it has a static lifetime, if any
                     let ident = syn::parse_str::<Ident>(&out.ident).unwrap();


### PR DESCRIPTION
…operating within the function's "multi-call-memory-context".  This ensures any allocation `FromDatum` might do lives as along as the entire SRF calling process does.

This is the proper fix for PR #779, which pointed out that it wasn't possible for SRFs to return data borrowed from their input.  Tests are included.

@Smittyvb:  This PR should resolve the problems that #779 was trying to explain away with documentation.  Prior to this PR, pgx was potentially detoasting argument datums in the wrong memory context, causing the UAF you were seeing.  I'd love it if you could rejigger your code against this PR and make sure it now works as you'd expect.  I updated the `strings` example to show that a SRF can borrow from its input.