### PR TITLE
derive Debug for PgLogLevel and PgSqlErrorCode

### DIFF
--- a/pgx/src/log.rs
+++ b/pgx/src/log.rs
@@ -11,7 +11,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 /// Postgres' various logging levels
 #[allow(dead_code)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum PgLogLevel {
     /// Debugging messages, in categories of decreasing detail
     DEBUG5 = crate::pg_sys::DEBUG5 as isize,
@@ -59,7 +59,7 @@ pub enum PgLogLevel {
 
 /// This list of SQL Error Codes is taken directly from Postgres 12's generated "utils/errcodes.h"
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum PgSqlErrorCode {
     /// Class 00 - Successful Completion
     ERRCODE_SUCCESSFUL_COMPLETION = MAKE_SQLSTATE('0', '0', '0', '0', '0') as isize,


### PR DESCRIPTION
Problem: inability to use PgLogLevel and PgSqlErrorCode in debug
This means that it's not feasible to `unwrap` on types containing these.

Solution: derive Debug for both