### PR TITLE
Wrap `SpinLock.*` functions in the C shim

### DIFF
--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -26,6 +26,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/memutils.h"
 #include "utils/builtins.h"
 #include "utils/array.h"
+#include "storage/spin.h"
 
 
 PGDLLEXPORT MemoryContext pgx_GetMemoryContextChunk(void *ptr);
@@ -140,4 +141,24 @@ bool pgx_ARR_HASNULL(ArrayType *arr) {
 PGDLLEXPORT int *pgx_ARR_DIMS(ArrayType *arr);
 int *pgx_ARR_DIMS(ArrayType *arr){
     return ARR_DIMS(arr);
+}
+
+PGDLLEXPORT void pgx_SpinLockInit(volatile slock_t *lock);
+void pgx_SpinLockInit(volatile slock_t *lock) {
+    SpinLockInit(lock);
+}
+
+PGDLLEXPORT void pgx_SpinLockAcquire(volatile slock_t *lock);
+void pgx_SpinLockAcquire(volatile slock_t *lock) {
+    SpinLockAcquire(lock);
+}
+
+PGDLLEXPORT void pgx_SpinLockRelease(volatile slock_t *lock);
+void pgx_SpinLockRelease(volatile slock_t *lock) {
+    SpinLockRelease(lock);
+}
+
+PGDLLEXPORT bool pgx_SpinLockFree(slock_t *lock);
+bool pgx_SpinLockFree(slock_t *lock) {
+    return SpinLockFree(lock);
 }

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -250,6 +250,10 @@ mod all_versions {
         pub fn pgx_list_nth_oid(list: *mut super::List, nth: i32) -> super::Oid;
         pub fn pgx_list_nth_cell(list: *mut super::List, nth: i32) -> *mut super::ListCell;
         pub fn pgx_GETSTRUCT(tuple: pg_sys::HeapTuple) -> *mut std::os::raw::c_char;
+        pub fn pgx_SpinLockInit(lock: *mut pg_sys::slock_t);
+        pub fn pgx_SpinLockAcquire(lock: *mut pg_sys::slock_t);
+        pub fn pgx_SpinLockRelease(lock: *mut pg_sys::slock_t);
+        pub fn pgx_SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
     }
 
     #[inline]

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -250,10 +250,6 @@ mod all_versions {
         pub fn pgx_list_nth_oid(list: *mut super::List, nth: i32) -> super::Oid;
         pub fn pgx_list_nth_cell(list: *mut super::List, nth: i32) -> *mut super::ListCell;
         pub fn pgx_GETSTRUCT(tuple: pg_sys::HeapTuple) -> *mut std::os::raw::c_char;
-        pub fn pgx_SpinLockInit(lock: *mut pg_sys::slock_t);
-        pub fn pgx_SpinLockAcquire(lock: *mut pg_sys::slock_t);
-        pub fn pgx_SpinLockRelease(lock: *mut pg_sys::slock_t);
-        pub fn pgx_SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
     }
 
     #[inline]
@@ -459,6 +455,19 @@ mod all_versions {
             context: *mut ::std::os::raw::c_void,
         ) -> bool;
     }
+
+    #[pgx_macros::pg_guard]
+    extern "C" {
+        fn pgx_SpinLockInit(lock: *mut pg_sys::slock_t);
+        fn pgx_SpinLockAcquire(lock: *mut pg_sys::slock_t);
+        fn pgx_SpinLockRelease(lock: *mut pg_sys::slock_t);
+        fn pgx_SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
+    }
+
+    pub use {
+        pgx_SpinLockAcquire as SpinLockAcquire, pgx_SpinLockFree as SpinLockFree,
+        pgx_SpinLockInit as SpinLockInit, pgx_SpinLockRelease as SpinLockRelease,
+    };
 }
 
 mod internal {


### PR DESCRIPTION
Fixes #752.

@eeeebbbbrrrr Do we usually just expose these as `pgx_MacroNameHere` functions, or do we re-export them somewhere using the names from PG (in which case I've missed a bit)?