### PR TITLE
Fix Issue #792

### DIFF
--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -43,5 +43,6 @@ mod uuid_tests;
 mod variadic_tests;
 mod xact_callback_tests;
 mod xid64_tests;
+mod zero_datum_edge_cases;
 
 pgx::pg_magic_func!();

--- a/pgx-tests/src/tests/zero_datum_edge_cases.rs
+++ b/pgx-tests/src/tests/zero_datum_edge_cases.rs
@@ -1,0 +1,72 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+    use pgx::*;
+
+    fn from_helper<T: FromDatum + IntoDatum>(d: Datum) -> Option<T> {
+        unsafe { T::from_polymorphic_datum(d, false, pg_sys::InvalidOid) }
+    }
+
+    #[pg_test]
+    fn test_two_tuple_bool() {
+        let d = (Some(false), Some(true)).into_datum().unwrap();
+        let (a, b) = from_helper::<(Option<bool>, Option<bool>)>(d).unwrap();
+        assert_eq!((a, b), (Some(false), Some(true)));
+    }
+
+    #[pg_test]
+    fn test_vec_bool() {
+        let d = vec![Some(false).into_datum(), Some(true).into_datum()].into_datum().unwrap();
+        let a = from_helper::<Vec<Option<pg_sys::Datum>>>(d).unwrap();
+        assert_eq!(a.first().unwrap().is_some(), true);
+    }
+
+    #[pg_test]
+    fn test_vec_ints() {
+        let d = vec![Some(0).into_datum(), Some(1).into_datum()].into_datum().unwrap();
+        let a = from_helper::<Vec<Option<pg_sys::Datum>>>(d).unwrap();
+        assert_eq!(a.first().unwrap().is_some(), true);
+    }
+
+    #[pg_test]
+    fn test_zero_i32() {
+        let d = 0.into_datum();
+        assert!(d.is_some());
+
+        let i = unsafe { i32::from_datum(d.unwrap(), false) };
+        assert_eq!(i, Some(0));
+    }
+
+    #[pg_test]
+    fn test_false_bool() {
+        let d = false.into_datum();
+        assert!(d.is_some());
+
+        let i = unsafe { bool::from_datum(d.unwrap(), false) };
+        assert_eq!(i, Some(false));
+    }
+
+    #[pg_test]
+    fn test_zero_i32_is_some_zero() {
+        let d = pg_sys::Datum::from(0i32);
+
+        let d = unsafe { pg_sys::Datum::from_datum(d, false) };
+        assert!(d.is_some());
+
+        let i = unsafe { i32::from_datum(d.unwrap(), false) };
+        assert_eq!(i, Some(0));
+    }
+
+    #[pg_test]
+    fn test_false_bool_is_some_false() {
+        let d = pg_sys::Datum::from(false);
+
+        let d = unsafe { pg_sys::Datum::from_datum(d, false) };
+        assert!(d.is_some());
+
+        let b = unsafe { bool::from_datum(d.unwrap(), false) };
+        assert_eq!(b, Some(false));
+    }
+}

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -133,7 +133,7 @@ impl FromDatum for pg_sys::Datum {
         is_null: bool,
         _: pg_sys::Oid,
     ) -> Option<pg_sys::Datum> {
-        if is_null || datum.is_null() {
+        if is_null {
             None
         } else {
             Some(datum)


### PR DESCRIPTION
The crux of the issue here is that `pgx_sys::Datum::from_datum(d, is_null)` can't ask the input Datum if it thinks it's null (via `Datum::is_null(&self)`), as nullness isn't a concept Datums encode.

A Datum is technically only ever considered null if the accompanying `is_null` argument tells us so.

It so happens that if the `Datum` type is pass-by-reference, and its value is zero, then it's pointing to a NULL, but Postgres doesn't even guarantee us that that is the nullness indicator.  Again, only the `is_null` argument does that.

As such, when converting a `Datum` into an `Option<Datum>`, only listen to the arguments and don't try to infer anything from the input datum's underlying value.

This PR includes a few simple tests that are now green with the change to `from.rs`.

Thanks to @sumerman for catching this!