### PR TITLE
Adds various Linux distro tests to CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.DS_Store
+.idea/
+target/
+*.iml
+**/*.rs.bk
+*.o
+*.so
+*.a
+cmake*/
+.direnv
+pgx-examples/*/target

--- a/.github/docker/Dockerfile.alpine:3.16
+++ b/.github/docker/Dockerfile.alpine:3.16
@@ -1,7 +1,18 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-alpine .
+#
+# Example of how to run this container with test after building the imagine:
+#   docker run pgx-alpine cargo test --no-default-features --features pg14
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
 ARG PG_MAJOR_VER
+# Use Postgres' official alpine version, it's just easier that way
 FROM postgres:${PG_MAJOR_VER}-alpine3.16
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
+# Required for compiling Rust
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 
 RUN apk add --no-cache \
@@ -18,20 +29,31 @@ RUN apk add --no-cache \
   clang-libs \
   tar
 
+# Set up permissions so that the rust user below can create extensions
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
   `$(which pg_config) --sharedir`/extension \
   /var/run/postgresql/
 
+# Running pgx and tests require a non-root user
 RUN adduser -s /bin/bash -D rust
 WORKDIR /checkout
 RUN chown -R rust:rust /checkout
 COPY --chown=rust:rust . /checkout
 
 USER rust
+# This environment variable is required for postgres while running the tests
 ENV USER=rust
 
+# Install cargo and Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
+
+# Install cargo-pgx from source copied into this container
 RUN cargo install --path cargo-pgx/
+
+# This seems strange, but by this point $PG_MAJOR_VER is blank and
+# $PG_MAJOR is always set to the correct version. I think it's something built
+# into the postgres:XX-alpine3.16 images, so it was easier to go with the grain
 RUN cargo pgx init --pg$PG_MAJOR=$(which pg_config)
+
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.alpine:3.16
+++ b/.github/docker/Dockerfile.alpine:3.16
@@ -2,7 +2,7 @@
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-alpine .
 #
 # Example of how to run this container with test after building the imagine:
-#   docker run pgx-alpine cargo test --no-default-features --features pg14
+#   docker run pgx-alpine cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
@@ -49,7 +49,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 # Install cargo-pgx from source copied into this container
-RUN cargo install --path cargo-pgx/
+RUN cargo install --path cargo-pgx/ --locked
 
 # This seems strange, but by this point $PG_MAJOR_VER is blank and
 # $PG_MAJOR is always set to the correct version. I think it's something built

--- a/.github/docker/Dockerfile.alpine:3.16
+++ b/.github/docker/Dockerfile.alpine:3.16
@@ -1,7 +1,7 @@
 # Example of how to build this container (ran from pgx checkout directory):
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-alpine .
 #
-# Example of how to run this container with test after building the imagine:
+# Example of how to run this container with tests after building the image:
 #   docker run pgx-alpine cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the

--- a/.github/docker/Dockerfile.alpine:3.16
+++ b/.github/docker/Dockerfile.alpine:3.16
@@ -1,0 +1,37 @@
+ARG PG_MAJOR_VER
+FROM postgres:${PG_MAJOR_VER}-alpine3.16
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
+
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+RUN apk add --no-cache \
+  git \
+  curl \
+  bash \
+  musl-dev \
+  make \
+  gcc \
+  coreutils \
+  util-linux-dev \
+  musl-dev \
+  openssl-dev \
+  clang-libs \
+  tar
+
+RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+  `$(which pg_config) --sharedir`/extension \
+  /var/run/postgresql/
+
+RUN adduser -s /bin/bash -D rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
+USER rust
+ENV USER=rust
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+RUN cargo install --path cargo-pgx/
+RUN cargo pgx init --pg$PG_MAJOR=$(which pg_config)
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -1,9 +1,23 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-amazonlinux2 .
+#
+# Example of how to run this container with test after building the imagine:
+#   docker run pgx-amazonlinux2 cargo test --no-default-features --features pg14
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
 FROM amazonlinux:2
 ARG PG_MAJOR_VER
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
+# NOTE: Normally in Amazon Linux 2, you would use "amazon-linux-extras" to set up
+# and install any version of Postgres. However, at the time of this writing,
+# installing Postgres 13 would flat out fail due to some packaging issues unrelated
+# to this Dockerfile. Therefore, we had to work around it by installing everything
+# necessary manually. The old method of using amazon-linux-extras are commented
+# at the end of this file in the event we want to resurrect it some day.
 RUN amazon-linux-extras install epel
-
 RUN yum -y remove python3
 RUN amazon-linux-extras enable python3
 RUN yum clean metadata
@@ -20,11 +34,12 @@ RUN yum install -y \
   readline-devel \
   which
 
+# Yucky, but required.
 RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-3.el7.centos.noarch.rpm
 RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-2-3.el7.centos.noarch.rpm
-# RUN yum -y install http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/l/llvm-toolset-7-clang-4.0.1-1.el7.x86_64.rpm
 RUN yum -y install http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/l/llvm-toolset-7-clang-5.0.1-4.el7.x86_64.rpm
 
+# Set up the official Postgres repos.
 # NOTE: Assumption here is x86_64, which might suffice for CI builds but care
 # should be taken if this is used as a template elsewhere.
 RUN echo -e "[pgdg$PG_MAJOR_VER]\n\
@@ -35,21 +50,27 @@ RUN echo -e "[pgdg$PG_MAJOR_VER]\n\
   gpgcheck=0\n\
   " | sed -e 's/^[ \t]*//' >> /etc/yum.repos.d/pgdg.repo
 
-RUN yum -y install postgresql$PG_MAJOR_VER postgresql$PG_MAJOR_VER-contrib postgresql$PG_MAJOR_VER-server postgresql$PG_MAJOR_VER-devel
-# RUN yum install -y
+RUN yum -y install \
+  postgresql$PG_MAJOR_VER \
+  postgresql$PG_MAJOR_VER-contrib \
+  postgresql$PG_MAJOR_VER-server \
+  postgresql$PG_MAJOR_VER-devel
 
 ENV PATH="/usr/pgsql-$PG_MAJOR_VER/bin:$PATH"
 
+# Set up permissions so that the rust user below can create extensions
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
   `$(which pg_config) --sharedir`/extension \
   /var/run/postgresql/
 
+# Running pgx and tests require a non-root user
 RUN adduser -G wheel rust
 WORKDIR /checkout
 RUN chown -R rust:rust /checkout
 COPY --chown=rust:rust . /checkout
 
 USER rust
+# This environment variable is required for postgres while running the tests
 ENV USER=rust
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
@@ -58,6 +79,7 @@ RUN cargo install --path cargo-pgx/
 RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]
 
+# === Previous "amazon-linux-extras" steps, kept for historical purposes ===
 # RUN amazon-linux-extras enable postgresql$PG_MAJOR_VER
 # RUN yum clean metadata
 

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -22,7 +22,8 @@ RUN yum install -y \
 
 RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-3.el7.centos.noarch.rpm
 RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-2-3.el7.centos.noarch.rpm
-RUN yum -y install http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/l/llvm-toolset-7-clang-4.0.1-1.el7.x86_64.rpm
+# RUN yum -y install http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/l/llvm-toolset-7-clang-4.0.1-1.el7.x86_64.rpm
+RUN yum -y install http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/l/llvm-toolset-7-clang-5.0.1-4.el7.x86_64.rpm
 
 # NOTE: Assumption here is x86_64, which might suffice for CI builds but care
 # should be taken if this is used as a template elsewhere.

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -1,7 +1,7 @@
 # Example of how to build this container (ran from pgx checkout directory):
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-amazonlinux2 .
 #
-# Example of how to run this container with test after building the imagine:
+# Example of how to run this container with tests after building the image:
 #   docker run pgx-amazonlinux2 cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -2,25 +2,42 @@ FROM amazonlinux:2
 ARG PG_MAJOR_VER
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
-RUN amazon-linux-extras enable postgresql$PG_MAJOR_VER
-RUN yum clean metadata
+RUN amazon-linux-extras install epel
 
+RUN yum -y remove python3
+RUN amazon-linux-extras enable python3
+RUN yum clean metadata
+RUN yum install -y python3-3.6.* --disablerepo=amzn2-core
 RUN yum install -y \
   bison \
   clang \
   flex \
-  libpq \
-  libpq-devel \
+  llvm13 \
+  llvm13-* \
   openssl \
   openssl-devel \
-  postgresql \
-  postgresql-devel \
-  postgresql-server \
-  postgresql-server-devel \
   readline \
   readline-devel \
-  vim \
   which
+
+RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-3.el7.centos.noarch.rpm
+RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-2-3.el7.centos.noarch.rpm
+RUN yum -y install http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/l/llvm-toolset-7-clang-4.0.1-1.el7.x86_64.rpm
+
+# NOTE: Assumption here is x86_64, which might suffice for CI builds but care
+# should be taken if this is used as a template elsewhere.
+RUN echo -e "[pgdg$PG_MAJOR_VER]\n\
+  name=PostgreSQL $PG_MAJOR_VER for RHEL/CentOS7 - x86_64\n\
+  gpgkey=https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-$PG_MAJOR_VER\n\
+  baseurl=https://download.postgresql.org/pub/repos/yum/$PG_MAJOR_VER/redhat/rhel-7-x86_64/\n\
+  enabled=1\n\
+  gpgcheck=0\n\
+  " | sed -e 's/^[ \t]*//' >> /etc/yum.repos.d/pgdg.repo
+
+RUN yum -y install postgresql$PG_MAJOR_VER postgresql$PG_MAJOR_VER-contrib postgresql$PG_MAJOR_VER-server postgresql$PG_MAJOR_VER-devel
+# RUN yum install -y
+
+ENV PATH="/usr/pgsql-$PG_MAJOR_VER/bin:$PATH"
 
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
   `$(which pg_config) --sharedir`/extension \
@@ -39,3 +56,41 @@ ENV PATH="/home/rust/.cargo/bin:${PATH}"
 RUN cargo install --path cargo-pgx/
 RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]
+
+# RUN amazon-linux-extras enable postgresql$PG_MAJOR_VER
+# RUN yum clean metadata
+
+# RUN yum install -y \
+#   bison \
+#   clang \
+#   flex \
+#   libpq \
+#   libpq-devel \
+#   openssl \
+#   openssl-devel \
+#   postgresql \
+#   postgresql-devel \
+#   postgresql-server \
+#   postgresql-server-devel \
+#   readline \
+#   readline-devel \
+#   vim \
+#   which
+
+# RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+#   `$(which pg_config) --sharedir`/extension \
+#   /var/run/postgresql/
+
+# RUN adduser -G wheel rust
+# WORKDIR /checkout
+# RUN chown -R rust:rust /checkout
+# COPY --chown=rust:rust . /checkout
+
+# USER rust
+# ENV USER=rust
+
+# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+# ENV PATH="/home/rust/.cargo/bin:${PATH}"
+# RUN cargo install --path cargo-pgx/
+# RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
+# CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -1,0 +1,40 @@
+FROM amazonlinux:2
+ARG PG_MAJOR_VER
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
+
+RUN amazon-linux-extras enable postgresql$PG_MAJOR_VER
+RUN yum clean metadata
+
+RUN yum install -y \
+  libpq \
+  libpq-devel \
+  postgresql \
+  postgresql-devel \
+  postgresql-server \
+  postgresql-server-devel \
+  openssl \
+  openssl-devel \
+  bison \
+  flex \
+  readline \
+  readline-devel \
+  which \
+  clang
+
+RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+  `$(which pg_config) --sharedir`/extension \
+  /var/run/postgresql/
+
+RUN adduser -G wheel rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
+USER rust
+ENV USER=rust
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+RUN cargo install --path cargo-pgx/
+RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -2,7 +2,7 @@
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-amazonlinux2 .
 #
 # Example of how to run this container with test after building the imagine:
-#   docker run pgx-amazonlinux2 cargo test --no-default-features --features pg14
+#   docker run pgx-amazonlinux2 cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
@@ -75,7 +75,7 @@ ENV USER=rust
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
-RUN cargo install --path cargo-pgx/
+RUN cargo install --path cargo-pgx/ --locked
 RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]
 

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -6,20 +6,21 @@ RUN amazon-linux-extras enable postgresql$PG_MAJOR_VER
 RUN yum clean metadata
 
 RUN yum install -y \
+  bison \
+  clang \
+  flex \
   libpq \
   libpq-devel \
+  openssl \
+  openssl-devel \
   postgresql \
   postgresql-devel \
   postgresql-server \
   postgresql-server-devel \
-  openssl \
-  openssl-devel \
-  bison \
-  flex \
   readline \
   readline-devel \
-  which \
-  clang
+  vim \
+  which
 
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
   `$(which pg_config) --sharedir`/extension \

--- a/.github/docker/Dockerfile.debian:bullseye
+++ b/.github/docker/Dockerfile.debian:bullseye
@@ -1,7 +1,7 @@
 # Example of how to build this container (ran from pgx checkout directory):
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-debian.
 #
-# Example of how to run this container with test after building the imagine:
+# Example of how to run this container with tests after building the image:
 #   docker run pgx-debian cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the

--- a/.github/docker/Dockerfile.debian:bullseye
+++ b/.github/docker/Dockerfile.debian:bullseye
@@ -1,12 +1,16 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-debian.
+#
+# Example of how to run this container with test after building the imagine:
+#   docker run pgx-debian cargo test --no-default-features --features pg14
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
 FROM debian:bullseye
 
 ARG PG_MAJOR_VER
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
-
-RUN useradd --create-home --shell /bin/bash rust
-WORKDIR /checkout
-RUN chown -R rust:rust /checkout
-COPY --chown=rust:rust . /checkout
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -30,15 +34,30 @@ RUN apt-get install -y \
   zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# Set up permissions so that the rust user below can create extensions
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
   `$(which pg_config) --sharedir`/extension \
   /var/run/postgresql/
 
+# Running pgx and tests require a non-root user
+RUN useradd --create-home --shell /bin/bash rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
 USER rust
+
+# This environment variable is required for postgres while running the tests
 ENV USER=rust
-ENV PATH="/home/rust/.cargo/bin:${PATH}"
+
+# Install cargo and Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+
+# Install cargo-pgx from source copied into this container
 RUN cargo install --path cargo-pgx/
+
+# Initialize cargo pgx so that we can run the tests
 RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
 
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.debian:bullseye
+++ b/.github/docker/Dockerfile.debian:bullseye
@@ -2,7 +2,7 @@
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-debian.
 #
 # Example of how to run this container with test after building the imagine:
-#   docker run pgx-debian cargo test --no-default-features --features pg14
+#   docker run pgx-debian cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
@@ -55,7 +55,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 # Install cargo-pgx from source copied into this container
-RUN cargo install --path cargo-pgx/
+RUN cargo install --path cargo-pgx/ --locked
 
 # Initialize cargo pgx so that we can run the tests
 RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)

--- a/.github/docker/Dockerfile.debian:bullseye
+++ b/.github/docker/Dockerfile.debian:bullseye
@@ -1,0 +1,44 @@
+FROM debian:bullseye
+
+ARG PG_MAJOR_VER
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
+
+RUN useradd --create-home --shell /bin/bash rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y wget gnupg
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get update -y --fix-missing
+RUN apt-get install -y \
+  build-essential \
+  curl \
+  clang \
+  git \
+  gcc \
+  libssl-dev \
+  libz-dev \
+  make \
+  pkg-config \
+  postgresql-$PG_MAJOR_VER \
+  postgresql-server-dev-$PG_MAJOR_VER \
+  zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+  `$(which pg_config) --sharedir`/extension \
+  /var/run/postgresql/
+
+USER rust
+ENV USER=rust
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN cargo install --path cargo-pgx/
+RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
+
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -2,7 +2,7 @@
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-fedora .
 #
 # Example of how to run this container with test after building the imagine:
-#   docker run pgx-fedora cargo test --no-default-features --features pg14
+#   docker run pgx-fedora cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
@@ -46,7 +46,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 # Install cargo-pgx from source copied into this container
-RUN cargo install --path cargo-pgx/
+RUN cargo install --path cargo-pgx/ --locked
 
 # Initialize cargo pgx so that we can run the tests
 RUN cargo pgx init --pg$PG_MAJOR_VER=/usr/pgsql-$PG_MAJOR_VER/bin/pg_config

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,9 +1,11 @@
 FROM fedora:36
 
-WORKDIR /checkout
 RUN adduser -G wheel rust
-RUN chmod a+rw /checkout && \
-  chown -R rust:rust /checkout
+WORKDIR /checkout
+COPY --chown=rust:rust . /checkout
+
+# RUN chmod a+rw /checkout && \
+#   chown -R rust:rust /checkout
 
 # RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 # RUN dnf install -y \

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -15,6 +15,7 @@ COPY --chown=rust:rust . /checkout
 
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 RUN dnf install -y \
+  cmake \
   openssl \
   openssl-devel \
   postgresql$PG_MAJOR_VER-server \

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -20,8 +20,10 @@ RUN chmod a+rw /checkout && \
 
 USER rust
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN whoami && cargo --version
+# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# RUN whoami && cargo --version
+
+RUN ls -lath /checkout
 
 CMD ["ls", "-lath"]
 

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -46,7 +46,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # RUN su rust -l -- -c cargo --version
 # ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
-RUN cargo install cargo-pgx
+RUN cargo install --path cargo-pgx/
 RUN cargo pgx init --pg$PG_MAJOR_VER=/usr/pgsql-$PG_MAJOR_VER/bin/pg_config
 
 # WORKDIR /app

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,0 +1,32 @@
+FROM fedora:36
+
+# RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+# RUN dnf install -y \
+#   openssl \
+#   openssl-devel \
+#   postgresql14-server \
+#   postgresql14-devel \
+#   redhat-rpm-config \
+#   util-linux
+
+# RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` `/usr/pgsql-14/bin/pg_config --sharedir`/extension /var/run/postgresql/
+# RUN adduser -G wheel rust
+
+
+# RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# RUN su rust -l -- -c cargo --version
+
+CMD ["ls -lath"]
+
+
+# USER rust
+# ENV PATH="/home/rust/.cargo/bin:${PATH}"
+
+# RUN cargo install cargo-pgx
+# RUN cargo pgx init --pg14=/usr/pgsql-14/bin/pg_config
+
+# WORKDIR /app
+# COPY . /app
+
+# ENV USER=rust
+# CMD ["cargo", "test", "--no-default-features", "--features", "pg14"]

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -2,7 +2,8 @@ FROM fedora:36
 
 WORKDIR /checkout
 RUN adduser -G wheel rust
-RUN chmod a+rw /checkout
+RUN chmod a+rw /checkout && \
+  chown -R rust:rust /checkout
 
 # RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 # RUN dnf install -y \

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -25,7 +25,8 @@ ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 RUN ls -lath /checkout
 
-CMD ["ls", "-lath"]
+# CMD ["ls", "-lath"]
+CMD ["pwd", "&&", "ls", "-lath"]
 
 
 # RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -7,39 +7,39 @@ COPY --chown=rust:rust . /checkout
 # RUN chmod a+rw /checkout && \
 #   chown -R rust:rust /checkout
 
-# RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-# RUN dnf install -y \
-#   openssl \
-#   openssl-devel \
-#   postgresql14-server \
-#   postgresql14-devel \
-#   redhat-rpm-config \
-#   util-linux
+RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+RUN dnf install -y \
+  openssl \
+  openssl-devel \
+  postgresql14-server \
+  postgresql14-devel \
+  redhat-rpm-config \
+  util-linux
 
-# RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
-#   `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
-#   /var/run/postgresql/
+RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
+  `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
+  /var/run/postgresql/
 
 USER rust
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
-# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # RUN whoami && cargo --version
 
-RUN ls -lath /checkout
+# RUN ls -lath /checkout
 
 # CMD ["ls", "-lath"]
-CMD ["pwd"]
+# CMD ["pwd"]
 
 
 # RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # RUN su rust -l -- -c cargo --version
 # ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
-# RUN cargo install cargo-pgx
-# RUN cargo pgx init --pg14=/usr/pgsql-14/bin/pg_config
+RUN cargo install cargo-pgx
+RUN cargo pgx init --pg14=/usr/pgsql-14/bin/pg_config
 
 # WORKDIR /app
 # COPY . /app
 
-# ENV USER=rust
-# CMD ["cargo", "test", "--no-default-features", "--features", "pg14"]
+ENV USER=rust
+CMD ["cargo", "test", "--no-default-features", "--features", "pg14"]

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,7 +1,7 @@
 FROM fedora:36
 
 ARG PG_MAJOR_VER
-ENV PG_MAJOR_VER=${PG_MAJOR_VER}}
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
 RUN echo ">>>>>>>>>>>>>>>>>>>>>>>> $PG_MAJOR_VER"
 RUN adduser -G wheel rust
@@ -17,13 +17,13 @@ RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x
 RUN dnf install -y \
   openssl \
   openssl-devel \
-  postgresql${PG_MAJOR_VER}-server \
-  postgresql${PG_MAJOR_VER}-devel \
+  postgresql$PG_MAJOR_VER-server \
+  postgresql$PG_MAJOR_VER-devel \
   redhat-rpm-config \
   util-linux
 
-RUN chmod a+rwx `/usr/pgsql-${PG_MAJOR_VER}/bin/pg_config --pkglibdir` \
-  `/usr/pgsql-${PG_MAJOR_VER}/bin/pg_config --sharedir`/extension \
+RUN chmod a+rwx `/usr/pgsql-$PG_MAJOR_VER/bin/pg_config --pkglibdir` \
+  `/usr/pgsql-$PG_MAJOR_VER/bin/pg_config --sharedir`/extension \
   /var/run/postgresql/
 
 USER rust
@@ -42,7 +42,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 RUN cargo install cargo-pgx
-RUN cargo pgx init --pg${PG_MAJOR_VER}=/usr/pgsql-${PG_MAJOR_VER}/bin/pg_config
+RUN cargo pgx init --pg$PG_MAJOR_VER=/usr/pgsql-$PG_MAJOR_VER/bin/pg_config
 
 # WORKDIR /app
 # COPY . /app

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -2,6 +2,7 @@ FROM fedora:36
 
 ARG PG_MAJOR_VER
 
+RUN echo ">>>>>>>>>>>>>>>>>>>>>>>> $PG_MAJOR_VER"
 RUN adduser -G wheel rust
 WORKDIR /checkout
 RUN chown -R rust:rust /checkout

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,31 +1,26 @@
 FROM fedora:36
 
-# RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-# RUN dnf install -y \
-#   openssl \
-#   openssl-devel \
-#   postgresql14-server \
-#   postgresql14-devel \
-#   redhat-rpm-config \
-#   util-linux
-
-# RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
-#   `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
-#   /var/run/postgresql/
-
-# RUN adduser -G wheel rust
-
 WORKDIR /checkout
-
-RUN whoami && pwd && ls -lath
-
+RUN adduser -G wheel rust
 RUN chmod a+rw /checkout
+
+RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+RUN dnf install -y \
+  openssl \
+  openssl-devel \
+  postgresql14-server \
+  postgresql14-devel \
+  redhat-rpm-config \
+  util-linux
+
+RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
+  `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
+  /var/run/postgresql/
 
 USER rust
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN whoami && cargo --version
-
 
 CMD ["ls", "-lath"]
 

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,6 +1,7 @@
 FROM fedora:36
 
 ARG PG_MAJOR_VER
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}}
 
 RUN echo ">>>>>>>>>>>>>>>>>>>>>>>> $PG_MAJOR_VER"
 RUN adduser -G wheel rust

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -2,6 +2,7 @@ FROM fedora:36
 
 RUN adduser -G wheel rust
 WORKDIR /checkout
+RUN chown -R rust:rust /checkout
 COPY --chown=rust:rust . /checkout
 
 # RUN chmod a+rw /checkout && \

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,7 +1,7 @@
 # Example of how to build this container (ran from pgx checkout directory):
 #   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-fedora .
 #
-# Example of how to run this container with test after building the imagine:
+# Example of how to run this container with tests after building the image:
 #   docker run pgx-fedora cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,17 +1,26 @@
 FROM fedora:36
 
-# RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-# RUN dnf install -y \
-#   openssl \
-#   openssl-devel \
-#   postgresql14-server \
-#   postgresql14-devel \
-#   redhat-rpm-config \
-#   util-linux
+RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+RUN dnf install -y \
+  openssl \
+  openssl-devel \
+  postgresql14-server \
+  postgresql14-devel \
+  redhat-rpm-config \
+  util-linux
 
-# RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` `/usr/pgsql-14/bin/pg_config --sharedir`/extension /var/run/postgresql/
-# RUN adduser -G wheel rust
+RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
+  `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
+  /var/run/postgresql/
 
+RUN adduser -G wheel rust
+
+RUN chmod a+rw /checkout
+
+USER rust
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN whoami && cargo --version
 
 # RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # RUN su rust -l -- -c cargo --version
@@ -19,7 +28,6 @@ FROM fedora:36
 CMD ["ls", "-lath"]
 
 
-# USER rust
 # ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 # RUN cargo install cargo-pgx

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,19 +1,21 @@
 FROM fedora:36
 
-RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-RUN dnf install -y \
-  openssl \
-  openssl-devel \
-  postgresql14-server \
-  postgresql14-devel \
-  redhat-rpm-config \
-  util-linux
+# RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+# RUN dnf install -y \
+#   openssl \
+#   openssl-devel \
+#   postgresql14-server \
+#   postgresql14-devel \
+#   redhat-rpm-config \
+#   util-linux
 
-RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
-  `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
-  /var/run/postgresql/
+# RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
+#   `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
+#   /var/run/postgresql/
 
-RUN adduser -G wheel rust
+# RUN adduser -G wheel rust
+
+RUN whoami && pwd && ls -lath
 
 RUN chmod a+rw /checkout
 
@@ -22,12 +24,12 @@ USER rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN whoami && cargo --version
 
-# RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-# RUN su rust -l -- -c cargo --version
 
 CMD ["ls", "-lath"]
 
 
+# RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# RUN su rust -l -- -c cargo --version
 # ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 # RUN cargo install cargo-pgx

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,5 +1,7 @@
 FROM fedora:36
 
+ARG PG_MAJOR_VER
+
 RUN adduser -G wheel rust
 WORKDIR /checkout
 RUN chown -R rust:rust /checkout
@@ -8,17 +10,18 @@ COPY --chown=rust:rust . /checkout
 # RUN chmod a+rw /checkout && \
 #   chown -R rust:rust /checkout
 
+
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 RUN dnf install -y \
   openssl \
   openssl-devel \
-  postgresql14-server \
-  postgresql14-devel \
+  postgresql${PG_MAJOR_VER}-server \
+  postgresql${PG_MAJOR_VER}-devel \
   redhat-rpm-config \
   util-linux
 
-RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
-  `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
+RUN chmod a+rwx `/usr/pgsql-${PG_MAJOR_VER}/bin/pg_config --pkglibdir` \
+  `/usr/pgsql-${PG_MAJOR_VER}/bin/pg_config --sharedir`/extension \
   /var/run/postgresql/
 
 USER rust
@@ -37,10 +40,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 RUN cargo install cargo-pgx
-RUN cargo pgx init --pg14=/usr/pgsql-14/bin/pg_config
+RUN cargo pgx init --pg${PG_MAJOR_VER}=/usr/pgsql-${PG_MAJOR_VER}/bin/pg_config
 
 # WORKDIR /app
 # COPY . /app
 
 ENV USER=rust
-CMD ["cargo", "test", "--no-default-features", "--features", "pg14"]
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -16,6 +16,8 @@ COPY --chown=rust:rust . /checkout
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 RUN dnf install -y \
   cmake \
+  make \
+  gcc \
   openssl \
   openssl-devel \
   postgresql$PG_MAJOR_VER-server \

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -3,7 +3,7 @@ FROM fedora:36
 ARG PG_MAJOR_VER
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
-RUN echo ">>>>>>>>>>>>>>>>>>>>>>>> $PG_MAJOR_VER"
+# RUN echo ">>>>>>>>>>>>>>>>>>>>>>>> $PG_MAJOR_VER"
 RUN adduser -G wheel rust
 WORKDIR /checkout
 RUN chown -R rust:rust /checkout
@@ -15,6 +15,7 @@ COPY --chown=rust:rust . /checkout
 
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 RUN dnf install -y \
+  clang-tools-extra \
   cmake \
   make \
   gcc \

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -4,21 +4,21 @@ WORKDIR /checkout
 RUN adduser -G wheel rust
 RUN chmod a+rw /checkout
 
-RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-RUN dnf install -y \
-  openssl \
-  openssl-devel \
-  postgresql14-server \
-  postgresql14-devel \
-  redhat-rpm-config \
-  util-linux
+# RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+# RUN dnf install -y \
+#   openssl \
+#   openssl-devel \
+#   postgresql14-server \
+#   postgresql14-devel \
+#   redhat-rpm-config \
+#   util-linux
 
-RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
-  `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
-  /var/run/postgresql/
+# RUN chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` \
+#   `/usr/pgsql-14/bin/pg_config --sharedir`/extension \
+#   /var/run/postgresql/
 
 USER rust
-
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN whoami && cargo --version
 

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -26,7 +26,7 @@ ENV PATH="/home/rust/.cargo/bin:${PATH}"
 RUN ls -lath /checkout
 
 # CMD ["ls", "-lath"]
-CMD ["pwd", "&&", "ls", "-lath"]
+CMD ["pwd"]
 
 
 # RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -15,6 +15,8 @@ FROM fedora:36
 
 # RUN adduser -G wheel rust
 
+WORKDIR /checkout
+
 RUN whoami && pwd && ls -lath
 
 RUN chmod a+rw /checkout

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,17 +1,16 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-fedora .
+#
+# Example of how to run this container with test after building the imagine:
+#   docker run pgx-fedora cargo test --no-default-features --features pg14
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
 FROM fedora:36
 
 ARG PG_MAJOR_VER
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
-
-# RUN echo ">>>>>>>>>>>>>>>>>>>>>>>> $PG_MAJOR_VER"
-RUN adduser -G wheel rust
-WORKDIR /checkout
-RUN chown -R rust:rust /checkout
-COPY --chown=rust:rust . /checkout
-
-# RUN chmod a+rw /checkout && \
-#   chown -R rust:rust /checkout
-
 
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 RUN dnf install -y \
@@ -27,30 +26,29 @@ RUN dnf install -y \
   redhat-rpm-config \
   util-linux
 
+# Set up permissions so that the rust user below can create extensions
 RUN chmod a+rwx `/usr/pgsql-$PG_MAJOR_VER/bin/pg_config --pkglibdir` \
   `/usr/pgsql-$PG_MAJOR_VER/bin/pg_config --sharedir`/extension \
   /var/run/postgresql/
 
+# Running pgx and tests require a non-root user
+RUN adduser -G wheel rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
 USER rust
-ENV PATH="/home/rust/.cargo/bin:${PATH}"
+# This environment variable is required for postgres while running the tests
+ENV USER=rust
+
+# Install cargo and Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-# RUN whoami && cargo --version
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
-# RUN ls -lath /checkout
-
-# CMD ["ls", "-lath"]
-# CMD ["pwd"]
-
-
-# RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-# RUN su rust -l -- -c cargo --version
-# ENV PATH="/home/rust/.cargo/bin:${PATH}"
-
+# Install cargo-pgx from source copied into this container
 RUN cargo install --path cargo-pgx/
+
+# Initialize cargo pgx so that we can run the tests
 RUN cargo pgx init --pg$PG_MAJOR_VER=/usr/pgsql-$PG_MAJOR_VER/bin/pg_config
 
-# WORKDIR /app
-# COPY . /app
-
-ENV USER=rust
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -15,6 +15,7 @@ COPY --chown=rust:rust . /checkout
 
 RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
 RUN dnf install -y \
+  clang \
   clang-tools-extra \
   cmake \
   make \

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -16,7 +16,7 @@ FROM fedora:36
 # RUN su rust -l -- -c curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # RUN su rust -l -- -c cargo --version
 
-CMD ["ls -lath"]
+CMD ["ls", "-lath"]
 
 
 # USER rust

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -1,13 +1,15 @@
 #! /usr/bin/env bash
 
-PG_VER=$1
+PG_MAJOR_VER=$1
 DOCKERFILE_ID=$2
 
-echo "Building docker container for PGX using Postgres version $PG_VER in container $DOCKERFILE_ID"
+echo "Building docker container for PGX using Postgres version $PG_MAJOR_VER in container $DOCKERFILE_ID"
 
-docker build -t pgx -f ".github/docker/Dockerfile.$DOCKERFILE_ID" .
+docker build \
+  --build-arg PG_MAJOR_VER=$PG_MAJOR_VER \
+  -t pgx -f ".github/docker/Dockerfile.$DOCKERFILE_ID" .
 
-echo "Running PGX test suite using Postgres version $PG_VER in container $DOCKERFILE_ID"
+echo "Running PGX test suite using Postgres version $PG_MAJOR_VER in container $DOCKERFILE_ID"
 
 docker run pgx
 # docker run \

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -5,7 +5,7 @@ DOCKERFILE_ID=$2
 
 echo "Building docker container for PGX using Postgres version $PG_VER in container $DOCKERFILE_ID"
 
-docker build -t pgx -f ".github/docker/Dockerfile$DOCKERFILE_ID" .
+docker build -t pgx -f ".github/docker/Dockerfile.$DOCKERFILE_ID" .
 
 echo "Running PGX test suite using Postgres version $PG_VER in container $DOCKERFILE_ID"
 

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -9,12 +9,15 @@ docker build -t pgx -f ".github/docker/Dockerfile.$DOCKERFILE_ID" .
 
 echo "Running PGX test suite using Postgres version $PG_VER in container $DOCKERFILE_ID"
 
-docker run \
-  --rm \
-  --volume "$(pwd)":/checkout:rw \
-  --workdir /checkout \
-  --privileged \
-  pgx
+docker run pgx
+# docker run \
+#   --rm \
+#   --volume "$(pwd)":/checkout:rw \
+#   --workdir /checkout \
+#   --privileged \
+#   pgx
+
+
 #   target=$(echo "${1}" | sed 's/-emulated//')
 #     echo "Building docker container for TARGET=${1}"
 #     docker build -t stdarch -f "ci/docker/${1}/Dockerfile" ci/

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -11,43 +11,4 @@ docker build \
 
 echo "Running PGX test suite using Postgres version $PG_MAJOR_VER in container $DOCKERFILE_ID"
 
-docker run pgx cargo test --no-default-features --features pg$PG_MAJOR_VER
-
-# docker run \
-#   --rm \
-#   --volume "$(pwd)":/checkout:rw \
-#   --workdir /checkout \
-#   --privileged \
-#   pgx
-
-
-#   target=$(echo "${1}" | sed 's/-emulated//')
-#     echo "Building docker container for TARGET=${1}"
-#     docker build -t stdarch -f "ci/docker/${1}/Dockerfile" ci/
-#     mkdir -p target c_programs rust_programs
-#     echo "Running docker"
-#     # shellcheck disable=SC2016
-#     docker run \
-#       --rm \
-#       --user "$(id -u)":"$(id -g)" \
-#       --env CARGO_HOME=/cargo \
-#       --env CARGO_TARGET_DIR=/checkout/target \
-#       --env TARGET="${target}" \
-#       --env STDARCH_TEST_EVERYTHING \
-#       --env STDARCH_ASSERT_INSTR_IGNORE \
-#       --env STDARCH_DISABLE_ASSERT_INSTR \
-#       --env NOSTD \
-#       --env NORUN \
-#       --env RUSTFLAGS \
-#       --env STDARCH_TEST_NORUN \
-#       --volume "${HOME}/.cargo":/cargo \
-#       --volume "$(rustc --print sysroot)":/rust:ro \
-#       --volume "$(pwd)":/checkout:ro \
-#       --volume "$(pwd)"/target:/checkout/target \
-#       --volume "$(pwd)"/c_programs:/checkout/c_programs \
-#       --volume "$(pwd)"/rust_programs:/checkout/rust_programs \
-#       --init \
-#       --workdir /checkout \
-#       --privileged \
-#       stdarch \
-#       sh -c "HOME=/tmp PATH=\$PATH:/rust/bin exec ci/run.sh ${1}"
+docker run pgx cargo test --no-default-features --features pg$PG_MAJOR_VER --locked

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -12,7 +12,6 @@ echo "Running PGX test suite using Postgres version $PG_VER in container $DOCKER
 docker run \
   --rm \
   --volume "$(pwd)":/checkout:rw \
-  --init \
   --workdir /checkout \
   --privileged \
   pgx

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -11,7 +11,8 @@ docker build \
 
 echo "Running PGX test suite using Postgres version $PG_MAJOR_VER in container $DOCKERFILE_ID"
 
-docker run pgx
+docker run pgx cargo test --no-default-features --features pg$PG_MAJOR_VER
+
 # docker run \
 #   --rm \
 #   --volume "$(pwd)":/checkout:rw \

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+
+PG_VER=$1
+DOCKERFILE_ID=$2
+
+echo "Building docker container for PGX using Postgres version $PG_VER in container $DOCKERFILE_ID"
+
+docker build -t pgx -f ".github/docker/Dockerfile$DOCKERFILE_ID" .
+
+echo "Running PGX test suite using Postgres version $PG_VER in container $DOCKERFILE_ID"
+
+docker run \
+  --rm \
+  --volume "$(pwd)":/checkout:rw \
+  --init \
+  --workdir /checkout \
+  --privileged \
+  pgx
+#   target=$(echo "${1}" | sed 's/-emulated//')
+#     echo "Building docker container for TARGET=${1}"
+#     docker build -t stdarch -f "ci/docker/${1}/Dockerfile" ci/
+#     mkdir -p target c_programs rust_programs
+#     echo "Running docker"
+#     # shellcheck disable=SC2016
+#     docker run \
+#       --rm \
+#       --user "$(id -u)":"$(id -g)" \
+#       --env CARGO_HOME=/cargo \
+#       --env CARGO_TARGET_DIR=/checkout/target \
+#       --env TARGET="${target}" \
+#       --env STDARCH_TEST_EVERYTHING \
+#       --env STDARCH_ASSERT_INSTR_IGNORE \
+#       --env STDARCH_DISABLE_ASSERT_INSTR \
+#       --env NOSTD \
+#       --env NORUN \
+#       --env RUSTFLAGS \
+#       --env STDARCH_TEST_NORUN \
+#       --volume "${HOME}/.cargo":/cargo \
+#       --volume "$(rustc --print sysroot)":/rust:ro \
+#       --volume "$(pwd)":/checkout:ro \
+#       --volume "$(pwd)"/target:/checkout/target \
+#       --volume "$(pwd)"/c_programs:/checkout/c_programs \
+#       --volume "$(pwd)"/rust_programs:/checkout/rust_programs \
+#       --init \
+#       --workdir /checkout \
+#       --privileged \
+#       stdarch \
+#       sh -c "HOME=/tmp PATH=\$PATH:/rust/bin exec ci/run.sh ${1}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   pgx_tests:
     name: Test conatiner builds
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         pg_version: [14]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,399 +19,405 @@ env:
 
 jobs:
   pgx_tests:
-    name: pgx-tests & examples
-    runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, 'nogha')"
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_DIR: /home/runner/.cache/sccache
-      RUSTFLAGS: -Copt-level=0
-
-    strategy:
-      matrix:
-        version: ["postgres-10", "postgres-11", "postgres-12", "postgres-13", "postgres-14"]
-        os: ["ubuntu-20.04"]
-
+    name: Test fedora build
+    runs-on: ubuntu-latest
+    container: fedora:36
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up prerequisites and environment
-      run: |
-        echo ""
-        echo "----- Install sccache -----"
-        mkdir -p $HOME/.local/bin
-        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-        chmod +x $HOME/.local/bin/sccache
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
-        mkdir -p /home/runner/.cache/sccache
-        echo ""
-
-        echo "----- Set up dynamic variables -----"
-        export PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)
-        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
-
-        echo "----- Remove old postgres -----"
-        sudo apt remove -y postgres*
-        echo ""
-
-        echo "----- Set up PostgreSQL Apt repository -----"
-        sudo apt-get install -y wget gnupg
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update -y -qq --fix-missing
-        echo ""
-
-        echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
-        sudo apt-get install -y \
-          clang-10 \
-          llvm-10 \
-          clang \
-          gcc \
-          make \
-          build-essential \
-          libz-dev \
-          zlib1g-dev \
-          strace \
-          libssl-dev \
-          pkg-config \
-          postgresql-$PG_VER \
-          postgresql-server-dev-$PG_VER
-        echo ""
-
-        echo "----- Set up Postgres permissions -----"
-        sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
-        echo ""
-
-        echo "----- Print env -----"
-        env
-        echo ""
-
-        echo "----- Get cargo version -----"
-        cargo --version
-        echo ""
-
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      continue-on-error: false
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: pgx-tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-    - name: Cache sccache directory
-      uses: actions/cache@v2
-      continue-on-error: false
-      with:
-        path: /home/runner/.cache/sccache
-        key: pgx-tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-    - name: Start sccache server
-      run: sccache --start-server
-
-    - name: Print sccache stats (before run)
-      run: sccache --show-stats
-
-    - name: Install cargo-pgx
-      run: cargo install --path cargo-pgx/ --debug --force
-
-    - name: Run 'cargo pgx init' against system-level ${{ matrix.version }}
-      run: cargo pgx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
-
-    - name: Run base-level tests
-      run: |
-        cargo test \
-          --features "pg$PG_VER" --no-default-features \
-          --package cargo-pgx \
-          --package pgx \
-          --package pgx-macros \
-          --package pgx-pg-sys \
-          --package pgx-tests \
-          --package pgx-utils
-
-    - name: Run aggregate example tests
-      run: cargo test --package aggregate --features "pg$PG_VER" --no-default-features
-
-    - name: Run arrays example tests
-      run: cargo test --package arrays --features "pg$PG_VER" --no-default-features
-
-    - name: Run bad_ideas example tests
-      run: cargo test --package bad_ideas --features "pg$PG_VER" --no-default-features
-
-    - name: Run bgworker example tests
-      run: cargo test --package bgworker --features "pg$PG_VER" --no-default-features
-
-    - name: Run bytea example tests
-      run: cargo test --package bytea --features "pg$PG_VER" --no-default-features
-
-    - name: Run composite_type example tests
-      run: cargo test --package composite_type --features "pg$PG_VER" --no-default-features
-
-    - name: Run custom_types example tests
-      run: cargo test --package custom_types --features "pg$PG_VER" --no-default-features
-
-    - name: Run custom_sql example tests
-      run: cargo test --package custom_sql --features "pg$PG_VER" --no-default-features
-
-    - name: Run errors example tests
-      run: cargo test --package errors --features "pg$PG_VER" --no-default-features
-
-    - name: Run nostd example tests
-      run: cargo test --package nostd --features "pg$PG_VER" --no-default-features
-
-    - name: Run operators example tests
-      run: cargo test --package operators --features "pg$PG_VER" --no-default-features
-
-    - name: Run schemas example tests
-      run: cargo test --package schemas --features "pg$PG_VER" --no-default-features
-
-    - name: Run shmem example tests
-      run: cargo test --package shmem --features "pg$PG_VER" --no-default-features
-
-    - name: Run spi example tests
-      run: cargo test --package spi --features "pg$PG_VER" --no-default-features
-
-    - name: Run spi_srf example tests
-      run: cargo test --package spi_srf --features "pg$PG_VER" --no-default-features
-
-    - name: Run srf example tests
-      run: cargo test --package srf --features "pg$PG_VER" --no-default-features
-
-    - name: Run strings example tests
-      run: cargo test --package strings --features "pg$PG_VER" --no-default-features
-
-    - name: Run triggers example tests
-      run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
-
-    - name: Run versioned_so example tests
-      run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
-
-    # Attempt to make the cache payload slightly smaller.
-    - name: Clean up built PGX files
-      run: |
-        cd target/debug/deps/
-        for built_file in $(find * -type f -executable -print | grep -v "\.so$"); do
-          base_name=$(echo $built_file | cut -d- -f1);
-          for basefile in "$base_name".*; do
-            [ -f "$basefile" ] || continue;
-            echo "Removing $basefile"
-            rm $basefile
-          done;
-          echo "Removing $built_file"
-          rm $built_file
-        done
-
-    - name: Stop sccache server
-      run: sccache --stop-server || true
-
-  cargo_pgx_init:
-    name: cargo pgx init
-    runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, 'nogha')"
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_DIR: /home/runner/.cache/sccache
-      RUSTFLAGS: -Copt-level=0
-
-    strategy:
-      matrix:
-        version: ["postgres-14"]
-        os: ["ubuntu-20.04"]
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up prerequisites and environment
-      run: |
-        echo ""
-
-        echo "----- Install / Set up sccache -----"
-        mkdir -p $HOME/.local/bin
-        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-        chmod +x $HOME/.local/bin/sccache
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
-        mkdir -p /home/runner/.cache/sccache
-        echo ""
-
-        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
-
-        echo "----- Set up MAKEFLAGS -----"
-        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
-
-        echo "----- Set up PG_VER variable -----"
-        echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
-
-        echo "----- Remove existing installations of postgres -----"
-        sudo apt remove -y postgres*
-        echo ""
-
-        echo "----- Install system dependencies -----"
-        sudo apt-get install -y \
-          clang-10 \
-          llvm-10 \
-          clang \
-          gcc \
-          make \
-          build-essential \
-          libz-dev \
-          zlib1g-dev \
-          strace \
-          libssl-dev \
-          pkg-config
-        echo ""
-
-        echo "----- Output Cargo version -----"
-        cargo --version
-        echo ""
-
-        echo "----- Outputting env -----"
-        env
-        echo ""
-
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      continue-on-error: false
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: pgx-cargo_init_tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-    - name: Cache sccache directory
-      uses: actions/cache@v2
-      continue-on-error: false
-      with:
-        path: /home/runner/.cache/sccache
-        key: pgx-cargo_init_tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-    - name: Start sccache server
-      run: sccache --start-server
-
-    - name: Print sccache stats (before)
-      run: sccache --show-stats
-
-    - name: Run rustfmt
-      run: cargo fmt --all -- --check
-
-    - name: Install cargo-pgx
-      run: cargo install --path cargo-pgx/ --debug --force
-
-    - name: Run 'cargo pgx init' for ${{ matrix.version }}
-      run: cargo pgx init --pg$PG_VER download
-
-    - name: create new sample extension
-      run: cd /tmp/ && cargo pgx new sample
-
-    # hack Cargo.toml to use this version of pgx from github
-    - name: hack Cargo.toml
-      run: |
-       echo "[patch.crates-io]" >> /tmp/sample/Cargo.toml
-       echo "pgx        = { path = \"${GITHUB_WORKSPACE}/pgx\"        }" >> /tmp/sample/Cargo.toml
-       echo "pgx-macros = { path = \"${GITHUB_WORKSPACE}/pgx-macros\" }" >> /tmp/sample/Cargo.toml
-       echo "pgx-tests  = { path = \"${GITHUB_WORKSPACE}/pgx-tests\"  }" >> /tmp/sample/Cargo.toml
-
-    - name: show Cargo.toml
-      run: cat /tmp/sample/Cargo.toml
-
-    - name: Test sample for ${{ matrix.version }}
-      run: cd /tmp/sample && cargo pgx test pg$PG_VER
-
-    - name: Stop sccache server
-      run: sccache --stop-server || true
-
-  build_mac:
-    name: MacOS build & test
-    runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, 'nogha')"
-    env:
-      RUSTC_WRAPPER: sccache
-
-    strategy:
-      matrix:
-        os: ["macos-11"]
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up prerequisites and environment
-      run: |
-        echo ""
-
-        echo "----- Install sccache -----"
-        brew update
-        brew install sccache
-        mkdir -p /Users/runner/Library/Caches/Mozilla.sccache
-
-        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
-        echo "----- Getting pre-installed Postgres major version -----"
-        PG_VER=$(pg_config --version | awk '{split($2,a,"."); print a[1]}')
-        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-
-        echo "----- Set up Postgres permissions -----"
-        sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-        ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-        echo ""
-
-        echo "----- Output Cargo version -----"
-        cargo --version
-        echo ""
-
-        echo "----- Outputting env -----"
-        env
-        echo ""
-
-    - name: Cache sccache directory
-      uses: actions/cache@v2
-      continue-on-error: false
-      with:
-        path: /Users/runner/Library/Caches/Mozilla.sccache
-        key: pgx-sccache-macos-11-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-    - name: Start sccache server
-      run: sccache --start-server
-
-    - name: Print sccache stats
-      run: sccache --show-stats
-
-    - name: Cache cargo directory
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: pgx-macos-11-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-    - name: Install cargo-pgx
-      run: cargo install --path cargo-pgx/ --debug --force
-
-    - name: Run 'cargo pgx init'
-      run: |
-        set -x
-        cargo pgx init --pg$PG_VER $(which pg_config)
-
-    - name: Run base-level tests
-      run: |
-        set -x
-        cargo test \
-          --features "pg$PG_VER" --no-default-features \
-          --package cargo-pgx \
-          --package pgx \
-          --package pgx-macros \
-          --package pgx-pg-sys \
-          --package pgx-tests \
-          --package pgx-utils
-
-    - name: Stop sccache server
-      run: sccache --stop-server || true
+      - run: cat /etc/os-release
+
+  #   name: pgx-tests & examples
+  #   runs-on: ${{ matrix.os }}
+  #   if: "!contains(github.event.head_commit.message, 'nogha')"
+  #   env:
+  #     RUSTC_WRAPPER: sccache
+  #     SCCACHE_DIR: /home/runner/.cache/sccache
+  #     RUSTFLAGS: -Copt-level=0
+
+  #   strategy:
+  #     matrix:
+  #       version: ["postgres-10", "postgres-11", "postgres-12", "postgres-13", "postgres-14"]
+  #       os: ["ubuntu-20.04"]
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+
+  #   - name: Set up prerequisites and environment
+  #     run: |
+  #       echo ""
+  #       echo "----- Install sccache -----"
+  #       mkdir -p $HOME/.local/bin
+  #       curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+  #       mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+  #       chmod +x $HOME/.local/bin/sccache
+  #       echo "$HOME/.local/bin" >> $GITHUB_PATH
+  #       echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
+  #       mkdir -p /home/runner/.cache/sccache
+  #       echo ""
+
+  #       echo "----- Set up dynamic variables -----"
+  #       export PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)
+  #       echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+  #       echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+  #       cat $GITHUB_ENV
+  #       echo ""
+
+  #       echo "----- Remove old postgres -----"
+  #       sudo apt remove -y postgres*
+  #       echo ""
+
+  #       echo "----- Set up PostgreSQL Apt repository -----"
+  #       sudo apt-get install -y wget gnupg
+  #       sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  #       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  #       sudo apt-get update -y -qq --fix-missing
+  #       echo ""
+
+  #       echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
+  #       sudo apt-get install -y \
+  #         clang-10 \
+  #         llvm-10 \
+  #         clang \
+  #         gcc \
+  #         make \
+  #         build-essential \
+  #         libz-dev \
+  #         zlib1g-dev \
+  #         strace \
+  #         libssl-dev \
+  #         pkg-config \
+  #         postgresql-$PG_VER \
+  #         postgresql-server-dev-$PG_VER
+  #       echo ""
+
+  #       echo "----- Set up Postgres permissions -----"
+  #       sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
+  #       echo ""
+
+  #       echo "----- Print env -----"
+  #       env
+  #       echo ""
+
+  #       echo "----- Get cargo version -----"
+  #       cargo --version
+  #       echo ""
+
+  #   - name: Cache cargo registry
+  #     uses: actions/cache@v2
+  #     continue-on-error: false
+  #     with:
+  #       path: |
+  #         ~/.cargo/registry
+  #         ~/.cargo/git
+  #       key: pgx-tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  #   - name: Cache sccache directory
+  #     uses: actions/cache@v2
+  #     continue-on-error: false
+  #     with:
+  #       path: /home/runner/.cache/sccache
+  #       key: pgx-tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  #   - name: Start sccache server
+  #     run: sccache --start-server
+
+  #   - name: Print sccache stats (before run)
+  #     run: sccache --show-stats
+
+  #   - name: Install cargo-pgx
+  #     run: cargo install --path cargo-pgx/ --debug --force
+
+  #   - name: Run 'cargo pgx init' against system-level ${{ matrix.version }}
+  #     run: cargo pgx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
+
+  #   - name: Run base-level tests
+  #     run: |
+  #       cargo test \
+  #         --features "pg$PG_VER" --no-default-features \
+  #         --package cargo-pgx \
+  #         --package pgx \
+  #         --package pgx-macros \
+  #         --package pgx-pg-sys \
+  #         --package pgx-tests \
+  #         --package pgx-utils
+
+  #   - name: Run aggregate example tests
+  #     run: cargo test --package aggregate --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run arrays example tests
+  #     run: cargo test --package arrays --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run bad_ideas example tests
+  #     run: cargo test --package bad_ideas --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run bgworker example tests
+  #     run: cargo test --package bgworker --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run bytea example tests
+  #     run: cargo test --package bytea --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run composite_type example tests
+  #     run: cargo test --package composite_type --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run custom_types example tests
+  #     run: cargo test --package custom_types --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run custom_sql example tests
+  #     run: cargo test --package custom_sql --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run errors example tests
+  #     run: cargo test --package errors --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run nostd example tests
+  #     run: cargo test --package nostd --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run operators example tests
+  #     run: cargo test --package operators --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run schemas example tests
+  #     run: cargo test --package schemas --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run shmem example tests
+  #     run: cargo test --package shmem --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run spi example tests
+  #     run: cargo test --package spi --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run spi_srf example tests
+  #     run: cargo test --package spi_srf --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run srf example tests
+  #     run: cargo test --package srf --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run strings example tests
+  #     run: cargo test --package strings --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run triggers example tests
+  #     run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
+
+  #   - name: Run versioned_so example tests
+  #     run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
+
+  #   # Attempt to make the cache payload slightly smaller.
+  #   - name: Clean up built PGX files
+  #     run: |
+  #       cd target/debug/deps/
+  #       for built_file in $(find * -type f -executable -print | grep -v "\.so$"); do
+  #         base_name=$(echo $built_file | cut -d- -f1);
+  #         for basefile in "$base_name".*; do
+  #           [ -f "$basefile" ] || continue;
+  #           echo "Removing $basefile"
+  #           rm $basefile
+  #         done;
+  #         echo "Removing $built_file"
+  #         rm $built_file
+  #       done
+
+  #   - name: Stop sccache server
+  #     run: sccache --stop-server || true
+
+  # cargo_pgx_init:
+  #   name: cargo pgx init
+  #   runs-on: ${{ matrix.os }}
+  #   if: "!contains(github.event.head_commit.message, 'nogha')"
+  #   env:
+  #     RUSTC_WRAPPER: sccache
+  #     SCCACHE_DIR: /home/runner/.cache/sccache
+  #     RUSTFLAGS: -Copt-level=0
+
+  #   strategy:
+  #     matrix:
+  #       version: ["postgres-14"]
+  #       os: ["ubuntu-20.04"]
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+
+  #   - name: Set up prerequisites and environment
+  #     run: |
+  #       echo ""
+
+  #       echo "----- Install / Set up sccache -----"
+  #       mkdir -p $HOME/.local/bin
+  #       curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+  #       mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+  #       chmod +x $HOME/.local/bin/sccache
+  #       echo "$HOME/.local/bin" >> $GITHUB_PATH
+  #       echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
+  #       mkdir -p /home/runner/.cache/sccache
+  #       echo ""
+
+  #       # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+
+  #       echo "----- Set up MAKEFLAGS -----"
+  #       echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+  #       cat $GITHUB_ENV
+  #       echo ""
+
+  #       echo "----- Set up PG_VER variable -----"
+  #       echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
+  #       cat $GITHUB_ENV
+  #       echo ""
+
+  #       echo "----- Remove existing installations of postgres -----"
+  #       sudo apt remove -y postgres*
+  #       echo ""
+
+  #       echo "----- Install system dependencies -----"
+  #       sudo apt-get install -y \
+  #         clang-10 \
+  #         llvm-10 \
+  #         clang \
+  #         gcc \
+  #         make \
+  #         build-essential \
+  #         libz-dev \
+  #         zlib1g-dev \
+  #         strace \
+  #         libssl-dev \
+  #         pkg-config
+  #       echo ""
+
+  #       echo "----- Output Cargo version -----"
+  #       cargo --version
+  #       echo ""
+
+  #       echo "----- Outputting env -----"
+  #       env
+  #       echo ""
+
+  #   - name: Cache cargo registry
+  #     uses: actions/cache@v2
+  #     continue-on-error: false
+  #     with:
+  #       path: |
+  #         ~/.cargo/registry
+  #         ~/.cargo/git
+  #       key: pgx-cargo_init_tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  #   - name: Cache sccache directory
+  #     uses: actions/cache@v2
+  #     continue-on-error: false
+  #     with:
+  #       path: /home/runner/.cache/sccache
+  #       key: pgx-cargo_init_tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  #   - name: Start sccache server
+  #     run: sccache --start-server
+
+  #   - name: Print sccache stats (before)
+  #     run: sccache --show-stats
+
+  #   - name: Run rustfmt
+  #     run: cargo fmt --all -- --check
+
+  #   - name: Install cargo-pgx
+  #     run: cargo install --path cargo-pgx/ --debug --force
+
+  #   - name: Run 'cargo pgx init' for ${{ matrix.version }}
+  #     run: cargo pgx init --pg$PG_VER download
+
+  #   - name: create new sample extension
+  #     run: cd /tmp/ && cargo pgx new sample
+
+  #   # hack Cargo.toml to use this version of pgx from github
+  #   - name: hack Cargo.toml
+  #     run: |
+  #      echo "[patch.crates-io]" >> /tmp/sample/Cargo.toml
+  #      echo "pgx        = { path = \"${GITHUB_WORKSPACE}/pgx\"        }" >> /tmp/sample/Cargo.toml
+  #      echo "pgx-macros = { path = \"${GITHUB_WORKSPACE}/pgx-macros\" }" >> /tmp/sample/Cargo.toml
+  #      echo "pgx-tests  = { path = \"${GITHUB_WORKSPACE}/pgx-tests\"  }" >> /tmp/sample/Cargo.toml
+
+  #   - name: show Cargo.toml
+  #     run: cat /tmp/sample/Cargo.toml
+
+  #   - name: Test sample for ${{ matrix.version }}
+  #     run: cd /tmp/sample && cargo pgx test pg$PG_VER
+
+  #   - name: Stop sccache server
+  #     run: sccache --stop-server || true
+
+  # build_mac:
+  #   name: MacOS build & test
+  #   runs-on: ${{ matrix.os }}
+  #   if: "!contains(github.event.head_commit.message, 'nogha')"
+  #   env:
+  #     RUSTC_WRAPPER: sccache
+
+  #   strategy:
+  #     matrix:
+  #       os: ["macos-11"]
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+
+  #   - name: Set up prerequisites and environment
+  #     run: |
+  #       echo ""
+
+  #       echo "----- Install sccache -----"
+  #       brew update
+  #       brew install sccache
+  #       mkdir -p /Users/runner/Library/Caches/Mozilla.sccache
+
+  #       # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+  #       echo "----- Getting pre-installed Postgres major version -----"
+  #       PG_VER=$(pg_config --version | awk '{split($2,a,"."); print a[1]}')
+  #       echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+  #       cat $GITHUB_ENV
+
+  #       echo "----- Set up Postgres permissions -----"
+  #       sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+  #       ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+  #       echo ""
+
+  #       echo "----- Output Cargo version -----"
+  #       cargo --version
+  #       echo ""
+
+  #       echo "----- Outputting env -----"
+  #       env
+  #       echo ""
+
+  #   - name: Cache sccache directory
+  #     uses: actions/cache@v2
+  #     continue-on-error: false
+  #     with:
+  #       path: /Users/runner/Library/Caches/Mozilla.sccache
+  #       key: pgx-sccache-macos-11-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  #   - name: Start sccache server
+  #     run: sccache --start-server
+
+  #   - name: Print sccache stats
+  #     run: sccache --show-stats
+
+  #   - name: Cache cargo directory
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: |
+  #         ~/.cargo/registry
+  #         ~/.cargo/git
+  #       key: pgx-macos-11-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  #   - name: Install cargo-pgx
+  #     run: cargo install --path cargo-pgx/ --debug --force
+
+  #   - name: Run 'cargo pgx init'
+  #     run: |
+  #       set -x
+  #       cargo pgx init --pg$PG_VER $(which pg_config)
+
+  #   - name: Run base-level tests
+  #     run: |
+  #       set -x
+  #       cargo test \
+  #         --features "pg$PG_VER" --no-default-features \
+  #         --package cargo-pgx \
+  #         --package pgx \
+  #         --package pgx-macros \
+  #         --package pgx-pg-sys \
+  #         --package pgx-tests \
+  #         --package pgx-utils
+
+  #   - name: Stop sccache server
+  #     run: sccache --stop-server || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        container: ["amazon:2"]
-        # container: ["fedora:36", "debian:bullseye","alpine:3.16"]
+        # container: ["amazon:2"]
+        container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,17 @@ jobs:
     container: fedora:36
     steps:
       - run: cat /etc/os-release
+      - run: dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+      - run: |
+        dnf install -y \
+          postgresql14-server \
+          postgresql14-devel \
+          openssl \
+          openssl-devel \
+          redhat-rpm-config
+
+      - run: chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` `/usr/pgsql-14/bin/pg_config --sharedir`/extension /var/run/postgresql/
+      - run: adduser -G wheel rust
 
   #   name: pgx-tests & examples
   #   runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,14 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [14]
+        pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
         container: ["fedora:36"]
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run PGX tests for Postgres ${{ matrix.pg_version}} using container ${{ matrix.container }}
+      - name: Set up environment variables
+        run: |
+          export PG_MAJOR_VER=$(echo ${{ matrix.pg_version}} | cut -c3-)
+          echo "PG_MAJOR_VER=$PG_MAJOR_VER" >> $GITHUB_ENV
+
+      - name: Run PGX tests for Postgres ${{ matrix.pg_version }} using container ${{ matrix.container }}
         shell: bash
-        run: ./.github/docker/run-docker.sh ${{ matrix.pg_version }} ${{ matrix.container }}
+        run: ./.github/docker/run-docker.sh $PG_MAJOR_VER ${{ matrix.container }}
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        container: ["amazon:2"]
-        # container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
+        # container: ["amazon:2"]
+        container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,440 +19,399 @@ env:
 
 jobs:
   pgx_tests:
-    name: Test container builds
-    runs-on: ubuntu-latest
+    name: pgx-tests & examples
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'nogha')"
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
+      RUSTFLAGS: -Copt-level=0
+
     strategy:
-      fail-fast: false
       matrix:
-        pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        # container: ["amazon:2"]
-        container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
+        version: ["postgres-10", "postgres-11", "postgres-12", "postgres-13", "postgres-14"]
+        os: ["ubuntu-20.04"]
+
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up environment variables
-        run: |
-          export PG_MAJOR_VER=$(echo ${{ matrix.pg_version}} | cut -c3-)
-          echo "PG_MAJOR_VER=$PG_MAJOR_VER" >> $GITHUB_ENV
-
-      - name: Run PGX tests for Postgres ${{ matrix.pg_version }} using container ${{ matrix.container }}
-        shell: bash
-        run: ./.github/docker/run-docker.sh "$PG_MAJOR_VER" ${{ matrix.container }}
-
-
-
-  #   name: Test fedora build
-  #   runs-on: ubuntu-latest
-  #   container: fedora:36
-  #   steps:
-  #     - run: cat /etc/os-release
-  #     - run: dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-  #     - run: |
-  #         dnf install -y \
-  #           postgresql14-server \
-  #           postgresql14-devel \
-  #           openssl \
-  #           openssl-devel \
-  #           redhat-rpm-config
-
-  #     - run: chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` `/usr/pgsql-14/bin/pg_config --sharedir`/extension /var/run/postgresql/
-  #     - run: adduser -G wheel rust
-
-
-
-  #   name: pgx-tests & examples
-  #   runs-on: ${{ matrix.os }}
-  #   if: "!contains(github.event.head_commit.message, 'nogha')"
-  #   env:
-  #     RUSTC_WRAPPER: sccache
-  #     SCCACHE_DIR: /home/runner/.cache/sccache
-  #     RUSTFLAGS: -Copt-level=0
-
-  #   strategy:
-  #     matrix:
-  #       version: ["postgres-10", "postgres-11", "postgres-12", "postgres-13", "postgres-14"]
-  #       os: ["ubuntu-20.04"]
-
-  #   steps:
-  #   - uses: actions/checkout@v2
-
-  #   - name: Set up prerequisites and environment
-  #     run: |
-  #       echo ""
-  #       echo "----- Install sccache -----"
-  #       mkdir -p $HOME/.local/bin
-  #       curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-  #       mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-  #       chmod +x $HOME/.local/bin/sccache
-  #       echo "$HOME/.local/bin" >> $GITHUB_PATH
-  #       echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
-  #       mkdir -p /home/runner/.cache/sccache
-  #       echo ""
-
-  #       echo "----- Set up dynamic variables -----"
-  #       export PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)
-  #       echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-  #       echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-  #       cat $GITHUB_ENV
-  #       echo ""
-
-  #       echo "----- Remove old postgres -----"
-  #       sudo apt remove -y postgres*
-  #       echo ""
-
-  #       echo "----- Set up PostgreSQL Apt repository -----"
-  #       sudo apt-get install -y wget gnupg
-  #       sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-  #       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  #       sudo apt-get update -y -qq --fix-missing
-  #       echo ""
-
-  #       echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
-  #       sudo apt-get install -y \
-  #         clang-10 \
-  #         llvm-10 \
-  #         clang \
-  #         gcc \
-  #         make \
-  #         build-essential \
-  #         libz-dev \
-  #         zlib1g-dev \
-  #         strace \
-  #         libssl-dev \
-  #         pkg-config \
-  #         postgresql-$PG_VER \
-  #         postgresql-server-dev-$PG_VER
-  #       echo ""
-
-  #       echo "----- Set up Postgres permissions -----"
-  #       sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
-  #       echo ""
-
-  #       echo "----- Print env -----"
-  #       env
-  #       echo ""
+    - uses: actions/checkout@v2
+
+    - name: Set up prerequisites and environment
+      run: |
+        echo ""
+        echo "----- Install sccache -----"
+        mkdir -p $HOME/.local/bin
+        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+        chmod +x $HOME/.local/bin/sccache
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
+        mkdir -p /home/runner/.cache/sccache
+        echo ""
+
+        echo "----- Set up dynamic variables -----"
+        export PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)
+        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+        echo ""
+
+        echo "----- Remove old postgres -----"
+        sudo apt remove -y postgres*
+        echo ""
+
+        echo "----- Set up PostgreSQL Apt repository -----"
+        sudo apt-get install -y wget gnupg
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update -y -qq --fix-missing
+        echo ""
+
+        echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
+        sudo apt-get install -y \
+          clang-10 \
+          llvm-10 \
+          clang \
+          gcc \
+          make \
+          build-essential \
+          libz-dev \
+          zlib1g-dev \
+          strace \
+          libssl-dev \
+          pkg-config \
+          postgresql-$PG_VER \
+          postgresql-server-dev-$PG_VER
+        echo ""
+
+        echo "----- Set up Postgres permissions -----"
+        sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
+        echo ""
+
+        echo "----- Print env -----"
+        env
+        echo ""
+
+        echo "----- Get cargo version -----"
+        cargo --version
+        echo ""
+
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: pgx-tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+    - name: Cache sccache directory
+      uses: actions/cache@v2
+      continue-on-error: false
+      with:
+        path: /home/runner/.cache/sccache
+        key: pgx-tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+    - name: Start sccache server
+      run: sccache --start-server
+
+    - name: Print sccache stats (before run)
+      run: sccache --show-stats
+
+    - name: Install cargo-pgx
+      run: cargo install --path cargo-pgx/ --debug --force
+
+    - name: Run 'cargo pgx init' against system-level ${{ matrix.version }}
+      run: cargo pgx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
+
+    - name: Run base-level tests
+      run: |
+        cargo test \
+          --features "pg$PG_VER" --no-default-features \
+          --package cargo-pgx \
+          --package pgx \
+          --package pgx-macros \
+          --package pgx-pg-sys \
+          --package pgx-tests \
+          --package pgx-utils
+
+    - name: Run aggregate example tests
+      run: cargo test --package aggregate --features "pg$PG_VER" --no-default-features
 
-  #       echo "----- Get cargo version -----"
-  #       cargo --version
-  #       echo ""
+    - name: Run arrays example tests
+      run: cargo test --package arrays --features "pg$PG_VER" --no-default-features
+
+    - name: Run bad_ideas example tests
+      run: cargo test --package bad_ideas --features "pg$PG_VER" --no-default-features
 
-  #   - name: Cache cargo registry
-  #     uses: actions/cache@v2
-  #     continue-on-error: false
-  #     with:
-  #       path: |
-  #         ~/.cargo/registry
-  #         ~/.cargo/git
-  #       key: pgx-tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-  #   - name: Cache sccache directory
-  #     uses: actions/cache@v2
-  #     continue-on-error: false
-  #     with:
-  #       path: /home/runner/.cache/sccache
-  #       key: pgx-tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-  #   - name: Start sccache server
-  #     run: sccache --start-server
-
-  #   - name: Print sccache stats (before run)
-  #     run: sccache --show-stats
-
-  #   - name: Install cargo-pgx
-  #     run: cargo install --path cargo-pgx/ --debug --force
-
-  #   - name: Run 'cargo pgx init' against system-level ${{ matrix.version }}
-  #     run: cargo pgx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
-
-  #   - name: Run base-level tests
-  #     run: |
-  #       cargo test \
-  #         --features "pg$PG_VER" --no-default-features \
-  #         --package cargo-pgx \
-  #         --package pgx \
-  #         --package pgx-macros \
-  #         --package pgx-pg-sys \
-  #         --package pgx-tests \
-  #         --package pgx-utils
-
-  #   - name: Run aggregate example tests
-  #     run: cargo test --package aggregate --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run arrays example tests
-  #     run: cargo test --package arrays --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run bad_ideas example tests
-  #     run: cargo test --package bad_ideas --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run bgworker example tests
-  #     run: cargo test --package bgworker --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run bytea example tests
-  #     run: cargo test --package bytea --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run composite_type example tests
-  #     run: cargo test --package composite_type --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run custom_types example tests
-  #     run: cargo test --package custom_types --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run custom_sql example tests
-  #     run: cargo test --package custom_sql --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run errors example tests
-  #     run: cargo test --package errors --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run nostd example tests
-  #     run: cargo test --package nostd --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run operators example tests
-  #     run: cargo test --package operators --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run schemas example tests
-  #     run: cargo test --package schemas --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run shmem example tests
-  #     run: cargo test --package shmem --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run spi example tests
-  #     run: cargo test --package spi --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run spi_srf example tests
-  #     run: cargo test --package spi_srf --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run srf example tests
-  #     run: cargo test --package srf --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run strings example tests
-  #     run: cargo test --package strings --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run triggers example tests
-  #     run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
-
-  #   - name: Run versioned_so example tests
-  #     run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
-
-  #   # Attempt to make the cache payload slightly smaller.
-  #   - name: Clean up built PGX files
-  #     run: |
-  #       cd target/debug/deps/
-  #       for built_file in $(find * -type f -executable -print | grep -v "\.so$"); do
-  #         base_name=$(echo $built_file | cut -d- -f1);
-  #         for basefile in "$base_name".*; do
-  #           [ -f "$basefile" ] || continue;
-  #           echo "Removing $basefile"
-  #           rm $basefile
-  #         done;
-  #         echo "Removing $built_file"
-  #         rm $built_file
-  #       done
-
-  #   - name: Stop sccache server
-  #     run: sccache --stop-server || true
-
-  # cargo_pgx_init:
-  #   name: cargo pgx init
-  #   runs-on: ${{ matrix.os }}
-  #   if: "!contains(github.event.head_commit.message, 'nogha')"
-  #   env:
-  #     RUSTC_WRAPPER: sccache
-  #     SCCACHE_DIR: /home/runner/.cache/sccache
-  #     RUSTFLAGS: -Copt-level=0
-
-  #   strategy:
-  #     matrix:
-  #       version: ["postgres-14"]
-  #       os: ["ubuntu-20.04"]
-
-  #   steps:
-  #   - uses: actions/checkout@v2
-
-  #   - name: Set up prerequisites and environment
-  #     run: |
-  #       echo ""
-
-  #       echo "----- Install / Set up sccache -----"
-  #       mkdir -p $HOME/.local/bin
-  #       curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-  #       mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-  #       chmod +x $HOME/.local/bin/sccache
-  #       echo "$HOME/.local/bin" >> $GITHUB_PATH
-  #       echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
-  #       mkdir -p /home/runner/.cache/sccache
-  #       echo ""
-
-  #       # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
-
-  #       echo "----- Set up MAKEFLAGS -----"
-  #       echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-  #       cat $GITHUB_ENV
-  #       echo ""
-
-  #       echo "----- Set up PG_VER variable -----"
-  #       echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
-  #       cat $GITHUB_ENV
-  #       echo ""
-
-  #       echo "----- Remove existing installations of postgres -----"
-  #       sudo apt remove -y postgres*
-  #       echo ""
-
-  #       echo "----- Install system dependencies -----"
-  #       sudo apt-get install -y \
-  #         clang-10 \
-  #         llvm-10 \
-  #         clang \
-  #         gcc \
-  #         make \
-  #         build-essential \
-  #         libz-dev \
-  #         zlib1g-dev \
-  #         strace \
-  #         libssl-dev \
-  #         pkg-config
-  #       echo ""
-
-  #       echo "----- Output Cargo version -----"
-  #       cargo --version
-  #       echo ""
-
-  #       echo "----- Outputting env -----"
-  #       env
-  #       echo ""
-
-  #   - name: Cache cargo registry
-  #     uses: actions/cache@v2
-  #     continue-on-error: false
-  #     with:
-  #       path: |
-  #         ~/.cargo/registry
-  #         ~/.cargo/git
-  #       key: pgx-cargo_init_tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-  #   - name: Cache sccache directory
-  #     uses: actions/cache@v2
-  #     continue-on-error: false
-  #     with:
-  #       path: /home/runner/.cache/sccache
-  #       key: pgx-cargo_init_tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-  #   - name: Start sccache server
-  #     run: sccache --start-server
-
-  #   - name: Print sccache stats (before)
-  #     run: sccache --show-stats
-
-  #   - name: Run rustfmt
-  #     run: cargo fmt --all -- --check
-
-  #   - name: Install cargo-pgx
-  #     run: cargo install --path cargo-pgx/ --debug --force
-
-  #   - name: Run 'cargo pgx init' for ${{ matrix.version }}
-  #     run: cargo pgx init --pg$PG_VER download
-
-  #   - name: create new sample extension
-  #     run: cd /tmp/ && cargo pgx new sample
-
-  #   # hack Cargo.toml to use this version of pgx from github
-  #   - name: hack Cargo.toml
-  #     run: |
-  #      echo "[patch.crates-io]" >> /tmp/sample/Cargo.toml
-  #      echo "pgx        = { path = \"${GITHUB_WORKSPACE}/pgx\"        }" >> /tmp/sample/Cargo.toml
-  #      echo "pgx-macros = { path = \"${GITHUB_WORKSPACE}/pgx-macros\" }" >> /tmp/sample/Cargo.toml
-  #      echo "pgx-tests  = { path = \"${GITHUB_WORKSPACE}/pgx-tests\"  }" >> /tmp/sample/Cargo.toml
-
-  #   - name: show Cargo.toml
-  #     run: cat /tmp/sample/Cargo.toml
-
-  #   - name: Test sample for ${{ matrix.version }}
-  #     run: cd /tmp/sample && cargo pgx test pg$PG_VER
-
-  #   - name: Stop sccache server
-  #     run: sccache --stop-server || true
-
-  # build_mac:
-  #   name: MacOS build & test
-  #   runs-on: ${{ matrix.os }}
-  #   if: "!contains(github.event.head_commit.message, 'nogha')"
-  #   env:
-  #     RUSTC_WRAPPER: sccache
-
-  #   strategy:
-  #     matrix:
-  #       os: ["macos-11"]
-
-  #   steps:
-  #   - uses: actions/checkout@v2
-
-  #   - name: Set up prerequisites and environment
-  #     run: |
-  #       echo ""
-
-  #       echo "----- Install sccache -----"
-  #       brew update
-  #       brew install sccache
-  #       mkdir -p /Users/runner/Library/Caches/Mozilla.sccache
-
-  #       # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
-  #       echo "----- Getting pre-installed Postgres major version -----"
-  #       PG_VER=$(pg_config --version | awk '{split($2,a,"."); print a[1]}')
-  #       echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-  #       cat $GITHUB_ENV
-
-  #       echo "----- Set up Postgres permissions -----"
-  #       sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-  #       ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-  #       echo ""
-
-  #       echo "----- Output Cargo version -----"
-  #       cargo --version
-  #       echo ""
-
-  #       echo "----- Outputting env -----"
-  #       env
-  #       echo ""
-
-  #   - name: Cache sccache directory
-  #     uses: actions/cache@v2
-  #     continue-on-error: false
-  #     with:
-  #       path: /Users/runner/Library/Caches/Mozilla.sccache
-  #       key: pgx-sccache-macos-11-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-  #   - name: Start sccache server
-  #     run: sccache --start-server
-
-  #   - name: Print sccache stats
-  #     run: sccache --show-stats
-
-  #   - name: Cache cargo directory
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: |
-  #         ~/.cargo/registry
-  #         ~/.cargo/git
-  #       key: pgx-macos-11-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
-
-  #   - name: Install cargo-pgx
-  #     run: cargo install --path cargo-pgx/ --debug --force
-
-  #   - name: Run 'cargo pgx init'
-  #     run: |
-  #       set -x
-  #       cargo pgx init --pg$PG_VER $(which pg_config)
-
-  #   - name: Run base-level tests
-  #     run: |
-  #       set -x
-  #       cargo test \
-  #         --features "pg$PG_VER" --no-default-features \
-  #         --package cargo-pgx \
-  #         --package pgx \
-  #         --package pgx-macros \
-  #         --package pgx-pg-sys \
-  #         --package pgx-tests \
-  #         --package pgx-utils
-
-  #   - name: Stop sccache server
-  #     run: sccache --stop-server || true
+    - name: Run bgworker example tests
+      run: cargo test --package bgworker --features "pg$PG_VER" --no-default-features
+
+    - name: Run bytea example tests
+      run: cargo test --package bytea --features "pg$PG_VER" --no-default-features
+
+    - name: Run composite_type example tests
+      run: cargo test --package composite_type --features "pg$PG_VER" --no-default-features
+
+    - name: Run custom_types example tests
+      run: cargo test --package custom_types --features "pg$PG_VER" --no-default-features
+
+    - name: Run custom_sql example tests
+      run: cargo test --package custom_sql --features "pg$PG_VER" --no-default-features
+
+    - name: Run errors example tests
+      run: cargo test --package errors --features "pg$PG_VER" --no-default-features
+
+    - name: Run nostd example tests
+      run: cargo test --package nostd --features "pg$PG_VER" --no-default-features
+
+    - name: Run operators example tests
+      run: cargo test --package operators --features "pg$PG_VER" --no-default-features
+
+    - name: Run schemas example tests
+      run: cargo test --package schemas --features "pg$PG_VER" --no-default-features
+
+    - name: Run shmem example tests
+      run: cargo test --package shmem --features "pg$PG_VER" --no-default-features
+
+    - name: Run spi example tests
+      run: cargo test --package spi --features "pg$PG_VER" --no-default-features
+
+    - name: Run spi_srf example tests
+      run: cargo test --package spi_srf --features "pg$PG_VER" --no-default-features
+
+    - name: Run srf example tests
+      run: cargo test --package srf --features "pg$PG_VER" --no-default-features
+
+    - name: Run strings example tests
+      run: cargo test --package strings --features "pg$PG_VER" --no-default-features
+
+    - name: Run triggers example tests
+      run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
+
+    - name: Run versioned_so example tests
+      run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
+
+    # Attempt to make the cache payload slightly smaller.
+    - name: Clean up built PGX files
+      run: |
+        cd target/debug/deps/
+        for built_file in $(find * -type f -executable -print | grep -v "\.so$"); do
+          base_name=$(echo $built_file | cut -d- -f1);
+          for basefile in "$base_name".*; do
+            [ -f "$basefile" ] || continue;
+            echo "Removing $basefile"
+            rm $basefile
+          done;
+          echo "Removing $built_file"
+          rm $built_file
+        done
+
+    - name: Stop sccache server
+      run: sccache --stop-server || true
+
+  cargo_pgx_init:
+    name: cargo pgx init
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'nogha')"
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
+      RUSTFLAGS: -Copt-level=0
+
+    strategy:
+      matrix:
+        version: ["postgres-14"]
+        os: ["ubuntu-20.04"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up prerequisites and environment
+      run: |
+        echo ""
+
+        echo "----- Install / Set up sccache -----"
+        mkdir -p $HOME/.local/bin
+        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+        chmod +x $HOME/.local/bin/sccache
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo 'SCCACHE_CACHE_SIZE="20G"' >> $GITHUB_ENV
+        mkdir -p /home/runner/.cache/sccache
+        echo ""
+
+        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+
+        echo "----- Set up MAKEFLAGS -----"
+        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+        echo ""
+
+        echo "----- Set up PG_VER variable -----"
+        echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+        echo ""
+
+        echo "----- Remove existing installations of postgres -----"
+        sudo apt remove -y postgres*
+        echo ""
+
+        echo "----- Install system dependencies -----"
+        sudo apt-get install -y \
+          clang-10 \
+          llvm-10 \
+          clang \
+          gcc \
+          make \
+          build-essential \
+          libz-dev \
+          zlib1g-dev \
+          strace \
+          libssl-dev \
+          pkg-config
+        echo ""
+
+        echo "----- Output Cargo version -----"
+        cargo --version
+        echo ""
+
+        echo "----- Outputting env -----"
+        env
+        echo ""
+
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: pgx-cargo_init_tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+    - name: Cache sccache directory
+      uses: actions/cache@v2
+      continue-on-error: false
+      with:
+        path: /home/runner/.cache/sccache
+        key: pgx-cargo_init_tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+    - name: Start sccache server
+      run: sccache --start-server
+
+    - name: Print sccache stats (before)
+      run: sccache --show-stats
+
+    - name: Run rustfmt
+      run: cargo fmt --all -- --check
+
+    - name: Install cargo-pgx
+      run: cargo install --path cargo-pgx/ --debug --force
+
+    - name: Run 'cargo pgx init' for ${{ matrix.version }}
+      run: cargo pgx init --pg$PG_VER download
+
+    - name: create new sample extension
+      run: cd /tmp/ && cargo pgx new sample
+
+    # hack Cargo.toml to use this version of pgx from github
+    - name: hack Cargo.toml
+      run: |
+       echo "[patch.crates-io]" >> /tmp/sample/Cargo.toml
+       echo "pgx        = { path = \"${GITHUB_WORKSPACE}/pgx\"        }" >> /tmp/sample/Cargo.toml
+       echo "pgx-macros = { path = \"${GITHUB_WORKSPACE}/pgx-macros\" }" >> /tmp/sample/Cargo.toml
+       echo "pgx-tests  = { path = \"${GITHUB_WORKSPACE}/pgx-tests\"  }" >> /tmp/sample/Cargo.toml
+
+    - name: show Cargo.toml
+      run: cat /tmp/sample/Cargo.toml
+
+    - name: Test sample for ${{ matrix.version }}
+      run: cd /tmp/sample && cargo pgx test pg$PG_VER
+
+    - name: Stop sccache server
+      run: sccache --stop-server || true
+
+  build_mac:
+    name: MacOS build & test
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'nogha')"
+    env:
+      RUSTC_WRAPPER: sccache
+
+    strategy:
+      matrix:
+        os: ["macos-11"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up prerequisites and environment
+      run: |
+        echo ""
+
+        echo "----- Install sccache -----"
+        brew update
+        brew install sccache
+        mkdir -p /Users/runner/Library/Caches/Mozilla.sccache
+
+        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+        echo "----- Getting pre-installed Postgres major version -----"
+        PG_VER=$(pg_config --version | awk '{split($2,a,"."); print a[1]}')
+        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+
+        echo "----- Set up Postgres permissions -----"
+        sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+        ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+        echo ""
+
+        echo "----- Output Cargo version -----"
+        cargo --version
+        echo ""
+
+        echo "----- Outputting env -----"
+        env
+        echo ""
+
+    - name: Cache sccache directory
+      uses: actions/cache@v2
+      continue-on-error: false
+      with:
+        path: /Users/runner/Library/Caches/Mozilla.sccache
+        key: pgx-sccache-macos-11-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+    - name: Start sccache server
+      run: sccache --start-server
+
+    - name: Print sccache stats
+      run: sccache --show-stats
+
+    - name: Cache cargo directory
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: pgx-macos-11-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+    - name: Install cargo-pgx
+      run: cargo install --path cargo-pgx/ --debug --force
+
+    - name: Run 'cargo pgx init'
+      run: |
+        set -x
+        cargo pgx init --pg$PG_VER $(which pg_config)
+
+    - name: Run base-level tests
+      run: |
+        set -x
+        cargo test \
+          --features "pg$PG_VER" --no-default-features \
+          --package cargo-pgx \
+          --package pgx \
+          --package pgx-macros \
+          --package pgx-pg-sys \
+          --package pgx-tests \
+          --package pgx-utils
+
+    - name: Stop sccache server
+      run: sccache --stop-server || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        container: ["fedora:36", "debian:bullseye"]
+        container: ["alpine:3.16"]
+        # container: ["fedora:36", "debian:bullseye"]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   pgx_tests:
-    name: Test conatiner builds
+    name: Test container builds
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run PGX tests for Postgres ${{ matrix.pg_version }} using container ${{ matrix.container }}
         shell: bash
-        run: ./.github/docker/run-docker.sh $PG_MAJOR_VER ${{ matrix.container }}
+        run: ./.github/docker/run-docker.sh "$PG_MAJOR_VER" ${{ matrix.container }}
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        container: ["fedora:36"]
+        container: ["fedora:36", "debian:bullseye"]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        # container: ["amazon:2"]
-        container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
+        container: ["amazon:2"]
+        # container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        container: ["amazon:2"]
-        # container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
+        # container: ["amazon:2"]
+        container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,22 +19,38 @@ env:
 
 jobs:
   pgx_tests:
-    name: Test fedora build
-    runs-on: ubuntu-latest
-    container: fedora:36
+    name: Test conatiner builds
+    strategy:
+      matrix:
+        pg_version: [14]
+        container: ["fedora:36"]
     steps:
-      - run: cat /etc/os-release
-      - run: dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-      - run: |
-          dnf install -y \
-            postgresql14-server \
-            postgresql14-devel \
-            openssl \
-            openssl-devel \
-            redhat-rpm-config
+      - uses: actions/checkout@v2
 
-      - run: chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` `/usr/pgsql-14/bin/pg_config --sharedir`/extension /var/run/postgresql/
-      - run: adduser -G wheel rust
+      - name: Run PGX tests for Postgres ${{ matrix.pg_version}} using container ${{ matrix.container }}
+        shell: bash
+        run: ./.github/docker/run-docker.sh ${{ matrix.pg_version }} ${{ matrix.container }}
+
+
+
+  #   name: Test fedora build
+  #   runs-on: ubuntu-latest
+  #   container: fedora:36
+  #   steps:
+  #     - run: cat /etc/os-release
+  #     - run: dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+  #     - run: |
+  #         dnf install -y \
+  #           postgresql14-server \
+  #           postgresql14-devel \
+  #           openssl \
+  #           openssl-devel \
+  #           redhat-rpm-config
+
+  #     - run: chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` `/usr/pgsql-14/bin/pg_config --sharedir`/extension /var/run/postgresql/
+  #     - run: adduser -G wheel rust
+
+
 
   #   name: pgx-tests & examples
   #   runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,12 @@ jobs:
       - run: cat /etc/os-release
       - run: dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
       - run: |
-        dnf install -y \
-          postgresql14-server \
-          postgresql14-devel \
-          openssl \
-          openssl-devel \
-          redhat-rpm-config
+          dnf install -y \
+            postgresql14-server \
+            postgresql14-devel \
+            openssl \
+            openssl-devel \
+            redhat-rpm-config
 
       - run: chmod a+rwx `/usr/pgsql-14/bin/pg_config --pkglibdir` `/usr/pgsql-14/bin/pg_config --sharedir`/extension /var/run/postgresql/
       - run: adduser -G wheel rust

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        # container: ["amazon:2"]
-        container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
+        container: ["amazon:2"]
+        # container: ["fedora:36", "debian:bullseye","alpine:3.16","amazon:2"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up environment variables
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,11 @@ jobs:
     name: Test container builds
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
-        container: ["alpine:3.16"]
-        # container: ["fedora:36", "debian:bullseye"]
+        container: ["amazon:2"]
+        # container: ["fedora:36", "debian:bullseye","alpine:3.16"]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -1,0 +1,35 @@
+name: Will It Blend™, develop edition
+
+on:
+  schedule:
+   - cron: "08 21 * * *"
+
+env:
+  # NB: Don't modify `RUSTFLAGS` here, since it would override the ones
+  # configured by `.cargo/config.toml` on macOS.
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: "false"
+  # CARGO_LOG: cargo::core::compiler::fingerprint=info # Uncomment this to output compiler fingerprint info
+
+jobs:
+  pgx_tests:
+    name: Distro tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
+        container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: develop
+
+      - name: Set up environment variables
+        run: |
+          export PG_MAJOR_VER=$(echo ${{ matrix.pg_version}} | cut -c3-)
+          echo "PG_MAJOR_VER=$PG_MAJOR_VER" >> $GITHUB_ENV
+
+      - name: Run PGX tests for Postgres ${{ matrix.pg_version }} using container ${{ matrix.container }}
+        shell: bash
+        run: ./.github/docker/run-docker.sh "$PG_MAJOR_VER" ${{ matrix.container }}

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -34,7 +34,7 @@ jobs:
         run: env
       # If this workflow is being called from a schedule/cron job, then let's
       # force the "develop" branch. Otherwise, use whatever is passed in via
-      # GITHUB_REF_NAME. The result of this will be used below in the
+      # GITHUB_HEAD_REF. The result of this will be used below in the
       # actions/checkout@vX step. Note that at the time of this writing, Github
       # Actions does not allow us to specify which branch to run a schedule from
       # (it always runs from the default branch, which in this case is master).
@@ -45,7 +45,7 @@ jobs:
             echo "NIGHTLY_BUILD_REF=develop" >> $GITHUB_ENV
           else
             echo "Not running via schedule, so using branch $GITHUB_REF_NAME"
-            echo "NIGHTLY_BUILD_REF=$GITHUB_REF_NAME" >> $GITHUB_ENV
+            echo "NIGHTLY_BUILD_REF=$GITHUB_HEAD_REF" >> $GITHUB_ENV
           fi
 
       - uses: actions/checkout@v3

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -2,7 +2,7 @@ name: Will It Blend, develop edition
 
 on:
   schedule:
-   - cron: "13 21 * * *"
+   - cron: '16 21 * * *'
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -4,6 +4,14 @@ on:
   schedule:
    - cron: '0 23 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -4,14 +4,6 @@ on:
   schedule:
     - cron: '0 7 * * *'
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - develop
-  pull_request:
-    branches:
-      - master
-      - develop
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones
@@ -30,8 +22,6 @@ jobs:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
         container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
     steps:
-      - name: Print env
-        run: env
       # If this workflow is being called from a schedule/cron job, then let's
       # force the "develop" branch. Otherwise, use whatever is passed in via
       # GITHUB_HEAD_REF. The result of this will be used below in the

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -31,8 +31,8 @@ jobs:
         container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: develop
+        # with:
+        #   ref: develop
 
       - name: Set up environment variables
         run: |

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -44,7 +44,7 @@ jobs:
             echo "Running via schedule, so using branch develop"
             echo "NIGHTLY_BUILD_REF=develop" >> $GITHUB_ENV
           else
-            echo "Not running via schedule, so using branch $GITHUB_REF_NAME"
+            echo "Not running via schedule, so using branch $GITHUB_HEAD_REF"
             echo "NIGHTLY_BUILD_REF=$GITHUB_HEAD_REF" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -30,6 +30,8 @@ jobs:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
         container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
     steps:
+      - name: Print env
+        run: env
       # If this workflow is being called from a schedule/cron job, then let's
       # force the "develop" branch. Otherwise, use whatever is passed in via
       # GITHUB_REF_NAME. The result of this will be used below in the

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -1,8 +1,8 @@
-name: Will It Blend, develop edition
+name: Will It Blend™
 
 on:
   schedule:
-    - cron: '20 22 * * *'
+    - cron: '0 7 * * *'
   workflow_dispatch:
   push:
     branches:
@@ -25,14 +25,30 @@ jobs:
     name: Distro tests
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: false # We want all of them to run, even if one fails
       matrix:
         pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
         container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
     steps:
+      # If this workflow is being called from a schedule/cron job, then let's
+      # force the "develop" branch. Otherwise, use whatever is passed in via
+      # GITHUB_REF_NAME. The result of this will be used below in the
+      # actions/checkout@vX step. Note that at the time of this writing, Github
+      # Actions does not allow us to specify which branch to run a schedule from
+      # (it always runs from the default branch, which in this case is master).
+      - name: Set up correct branch environment variable
+        run: |
+          if [ $GITHUB_EVENT_NAME == "schedule" ]; then
+            echo "Running via schedule, so using branch develop"
+            echo "NIGHTLY_BUILD_REF=develop" >> $GITHUB_ENV
+          else
+            echo "Not running via schedule, so using branch $GITHUB_REF_NAME"
+            echo "NIGHTLY_BUILD_REF=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v3
-        # with:
-        #   ref: develop
+        with:
+          ref: ${{ env.NIGHTLY_BUILD_REF }}
 
       - name: Set up environment variables
         run: |

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -2,7 +2,7 @@ name: Will It Blend, develop edition
 
 on:
   schedule:
-   - cron: '0 23 * * *'
+    - cron: '20 22 * * *'
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -13,7 +13,7 @@ env:
   # CARGO_LOG: cargo::core::compiler::fingerprint=info # Uncomment this to output compiler fingerprint info
 
 jobs:
-  pgx_tests:
+  distro_tests:
     name: Distro tests
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -2,7 +2,7 @@ name: Will It Blend, develop edition
 
 on:
   schedule:
-   - cron: '16 21 * * *'
+   - cron: '35 21 * * *'
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -2,7 +2,8 @@ name: Will It Blend, develop edition
 
 on:
   schedule:
-   - cron: '35 21 * * *'
+   - cron: '0 23 * * *'
+  workflow_dispatch:
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -1,8 +1,8 @@
-name: Will It Blend™, develop edition
+name: Will It Blend, develop edition
 
 on:
   schedule:
-   - cron: "08 21 * * *"
+   - cron: "13 21 * * *"
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -711,3 +711,11 @@ mod internal {
         }
     }
 }
+
+// Hack to fix linker errors that we get under amazonlinux2 on some PG versions
+// due to our wrappers for various system library functions. Should be fairly
+// harmless, but ideally we would not wrap these functions
+// (https://github.com/tcdi/pgx/issues/730).
+#[cfg(target_os = "linux")]
+#[link(name = "resolv")]
+extern "C" {}


### PR DESCRIPTION
Originally, this branch was named `fedora-ci`, but as I started developing it I realized that we could be trying out builds in other various distros. With some input from @eeeebbbbrrrr we decided to add as much as we could here for the time being. There is still some stuff we plan on adding in the future, but for now this should cover a lot of use cases.