### PR TITLE
Problem: impossible to return anything from Spi::connect

### DIFF
--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -46,4 +46,10 @@ mod tests {
 
         assert!(did_drop.load(Ordering::SeqCst))
     }
+
+    #[pg_test]
+    fn parent() {
+        assert!(PgMemoryContexts::TopMemoryContext.parent().is_none());
+        assert!(PgMemoryContexts::CurrentMemoryContext.parent().is_some());
+    }
 }

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -211,6 +211,7 @@ mod tests {
         });
     }
 
+    #[pg_test]
     fn test_connect_return_anything() {
         struct T;
         assert!(matches!(Spi::connect(|_| Ok(Some(T))).unwrap(), T));

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -210,4 +210,9 @@ mod tests {
             assert_eq!(0, res.columns());
         });
     }
+
+    fn test_connect_return_anything() {
+        struct T;
+        assert!(matches!(Spi::connect(|_| Ok(Some(T))).unwrap(), T));
+    }
 }

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -239,6 +239,16 @@ impl PgMemoryContexts {
         }
     }
 
+    /// Returns parent memory context if any
+    pub fn parent(&self) -> Option<PgMemoryContexts> {
+        let parent = unsafe { pg_sys::MemoryContextGetParent(self.value()) };
+        if parent.is_null() {
+            None
+        } else {
+            Some(PgMemoryContexts::For(parent))
+        }
+    }
+
     /// Run the specified function "within" the `MemoryContext` represented by this enum.
     ///
     /// The important implementation detail is that Postgres' `CurrentMemoryContext` is changed

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -241,6 +241,8 @@ impl PgMemoryContexts {
 
     /// Returns parent memory context if any
     pub fn parent(&self) -> Option<PgMemoryContexts> {
+        // SAFETY: We do this instead of simply plucking the .parent field ourselves
+        // mostly to let Postgres check the context validity if --enable-cassert is on
         let parent = unsafe { pg_sys::MemoryContextGetParent(self.value()) };
         if parent.is_null() {
             None


### PR DESCRIPTION
We're currently limited by `Datum` (`IntoDatum` + `FromDatum`) boundaries. Any data that has nothing to do with Postgres, can't cross it.

Solution: copy data to the parent context when it is retrieved

Hat tip to @eeeebbbbrrrr