### PR TITLE
Release pgx 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -786,9 +786,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -796,15 +796,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,21 +813,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "dirs",
  "eyre",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "eyre",
  "libc",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "atty",
  "convert_case",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgx' to make Postgres extension development easy"
@@ -23,8 +23,8 @@ semver = "1.0.14"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.13.1"
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.5.3" }
-pgx-utils = { path = "../pgx-utils", version = "=0.5.3", features = ["syntax-highlighting"] }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.5.4" }
+pgx-utils = { path = "../pgx-utils", version = "=0.5.4", features = ["syntax-highlighting"] }
 prettyplease = "0.1.21"
 proc-macro2 = { version = "1.0.47", features = [ "span-locations" ] }
 quote = "1.0.21"
@@ -35,7 +35,7 @@ url = "2.3.1"
 serde = { version = "1.0.145", features = [ "derive" ] }
 serde_derive = "1.0.145"
 serde-xml-rs = "0.5.1"
-syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 fork = "0.1.20"
 libloading = "0.7.3"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.5.3"
+pgx = "=0.5.4"
 
 [dev-dependencies]
-pgx-tests = "=0.5.3"
+pgx-tests = "=0.5.4"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,13 +16,13 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.5.3"
-pgx-macros = "=0.5.3"
-pgx-utils = "=0.5.3"
+pgx = "=0.5.4"
+pgx-macros = "=0.5.4"
+pgx-utils = "=0.5.4"
 
 
 [dev-dependencies]
-pgx-tests = "=0.5.3"
+pgx-tests = "=0.5.4"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgx'"
@@ -18,10 +18,10 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "=0.5.3" }
+pgx-utils = { path = "../pgx-utils", version = "=0.5.4" }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
-syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 
 [dev-dependencies]

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-config"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgx'"
@@ -18,6 +18,6 @@ eyre = "0.6.8"
 owo-colors = "3.5.0"
 serde = { version = "1.0.145", features = [ "derive" ] }
 serde_derive = "1.0.145"
-serde_json = "1.0.86"
+serde_json = "1.0.87"
 toml = "0.5.9"
 url = "2.3.1"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgx'"
@@ -30,18 +30,18 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.5"
 once_cell = "1.15.0"
-pgx-macros = { path = "../pgx-macros/", version = "=0.5.3" }
-pgx-utils = { path = "../pgx-utils/", version = "=0.5.3" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.5.4" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.5.4" }
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.5.3" }
-pgx-utils = { path = "../pgx-utils/", version = "=0.5.3" }
+pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.5.4" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.5.4" }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
 rayon = "1.5.3"
-syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -26,6 +26,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/memutils.h"
 #include "utils/builtins.h"
 #include "utils/array.h"
+#include "storage/spin.h"
 
 
 PGDLLEXPORT MemoryContext pgx_GetMemoryContextChunk(void *ptr);
@@ -140,4 +141,24 @@ bool pgx_ARR_HASNULL(ArrayType *arr) {
 PGDLLEXPORT int *pgx_ARR_DIMS(ArrayType *arr);
 int *pgx_ARR_DIMS(ArrayType *arr){
     return ARR_DIMS(arr);
+}
+
+PGDLLEXPORT void pgx_SpinLockInit(volatile slock_t *lock);
+void pgx_SpinLockInit(volatile slock_t *lock) {
+    SpinLockInit(lock);
+}
+
+PGDLLEXPORT void pgx_SpinLockAcquire(volatile slock_t *lock);
+void pgx_SpinLockAcquire(volatile slock_t *lock) {
+    SpinLockAcquire(lock);
+}
+
+PGDLLEXPORT void pgx_SpinLockRelease(volatile slock_t *lock);
+void pgx_SpinLockRelease(volatile slock_t *lock) {
+    SpinLockRelease(lock);
+}
+
+PGDLLEXPORT bool pgx_SpinLockFree(slock_t *lock);
+bool pgx_SpinLockFree(slock_t *lock) {
+    return SpinLockFree(lock);
 }

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -250,6 +250,10 @@ mod all_versions {
         pub fn pgx_list_nth_oid(list: *mut super::List, nth: i32) -> super::Oid;
         pub fn pgx_list_nth_cell(list: *mut super::List, nth: i32) -> *mut super::ListCell;
         pub fn pgx_GETSTRUCT(tuple: pg_sys::HeapTuple) -> *mut std::os::raw::c_char;
+        pub fn pgx_SpinLockInit(lock: *mut pg_sys::slock_t);
+        pub fn pgx_SpinLockAcquire(lock: *mut pg_sys::slock_t);
+        pub fn pgx_SpinLockRelease(lock: *mut pg_sys::slock_t);
+        pub fn pgx_SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
     }
 
     #[inline]

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -250,10 +250,6 @@ mod all_versions {
         pub fn pgx_list_nth_oid(list: *mut super::List, nth: i32) -> super::Oid;
         pub fn pgx_list_nth_cell(list: *mut super::List, nth: i32) -> *mut super::ListCell;
         pub fn pgx_GETSTRUCT(tuple: pg_sys::HeapTuple) -> *mut std::os::raw::c_char;
-        pub fn pgx_SpinLockInit(lock: *mut pg_sys::slock_t);
-        pub fn pgx_SpinLockAcquire(lock: *mut pg_sys::slock_t);
-        pub fn pgx_SpinLockRelease(lock: *mut pg_sys::slock_t);
-        pub fn pgx_SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
     }
 
     #[inline]
@@ -459,6 +455,19 @@ mod all_versions {
             context: *mut ::std::os::raw::c_void,
         ) -> bool;
     }
+
+    #[pgx_macros::pg_guard]
+    extern "C" {
+        fn pgx_SpinLockInit(lock: *mut pg_sys::slock_t);
+        fn pgx_SpinLockAcquire(lock: *mut pg_sys::slock_t);
+        fn pgx_SpinLockRelease(lock: *mut pg_sys::slock_t);
+        fn pgx_SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
+    }
+
+    pub use {
+        pgx_SpinLockAcquire as SpinLockAcquire, pgx_SpinLockFree as SpinLockFree,
+        pgx_SpinLockInit as SpinLockInit, pgx_SpinLockRelease as SpinLockRelease,
+    };
 }
 
 mod internal {

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgx'-based Postgres extensions"
@@ -34,13 +34,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 owo-colors = "3.5.0"
 once_cell = "1.15.0"
 libc = "0.2.135"
-pgx-macros = { path = "../pgx-macros", version = "=0.5.3" }
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.5.3" }
-pgx-utils = { path = "../pgx-utils", version = "=0.5.3" }
+pgx-macros = { path = "../pgx-macros", version = "=0.5.4" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.5.4" }
+pgx-utils = { path = "../pgx-utils", version = "=0.5.4" }
 postgres = "0.19.4"
 regex = "1.6.0"
 serde = "1.0.145"
-serde_json = "1.0.86"
+serde_json = "1.0.87"
 shutdown_hooks = "0.1.0"
 time = "0.3.15"
 eyre = "0.6.8"
@@ -50,4 +50,4 @@ thiserror = "1.0"
 path = "../pgx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.5.3"
+version = "=0.5.4"

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -618,11 +618,11 @@ fn get_pgdata_path() -> eyre::Result<PathBuf> {
     Ok(target_dir)
 }
 
-fn get_pg_dbname() -> &'static str {
+pub(crate) fn get_pg_dbname() -> &'static str {
     "pgx_tests"
 }
 
-fn get_pg_user() -> String {
+pub(crate) fn get_pg_user() -> String {
     std::env::var("USER")
         .unwrap_or_else(|_| panic!("USER environment var is unset or invalid UTF-8"))
 }

--- a/pgx-tests/src/tests/bgworker_tests.rs
+++ b/pgx-tests/src/tests/bgworker_tests.rs
@@ -1,0 +1,105 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+use pgx::prelude::*;
+use pgx::{FromDatum, IntoDatum, PgOid};
+
+#[pg_guard]
+#[no_mangle]
+pub extern "C" fn bgworker(arg: pg_sys::Datum) {
+    use pgx::bgworkers::*;
+    use std::time::Duration;
+    BackgroundWorker::attach_signal_handlers(SignalWakeFlags::SIGHUP | SignalWakeFlags::SIGTERM);
+    BackgroundWorker::connect_worker_to_spi(
+        Some(crate::framework::get_pg_dbname()),
+        Some(crate::framework::get_pg_user().as_str()),
+    );
+
+    let arg = unsafe { i32::from_datum(arg, false) }.expect("invalid arg");
+
+    if arg > 0 {
+        BackgroundWorker::transaction(|| {
+            Spi::run("CREATE TABLE tests.bgworker_test (v INTEGER);");
+            Spi::execute(|mut client| {
+                client.update(
+                    "INSERT INTO tests.bgworker_test VALUES ($1);",
+                    None,
+                    Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())]),
+                );
+            });
+        });
+    }
+    while BackgroundWorker::wait_latch(Some(Duration::from_millis(100))) {}
+    if arg > 0 {
+        BackgroundWorker::transaction(|| {
+            Spi::run("UPDATE tests.bgworker_test SET v = v + 1;");
+        });
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+
+    use pgx::bgworkers::*;
+    use pgx::prelude::*;
+    use pgx::{pg_guard, pg_sys, IntoDatum};
+
+    #[pg_test]
+    fn test_dynamic_bgworker() {
+        let worker = BackgroundWorkerBuilder::new("dynamic_bgworker")
+            .set_library("pgx_tests")
+            .set_function("bgworker")
+            .set_argument(123i32.into_datum())
+            .enable_spi_access()
+            .set_notify_pid(unsafe { pg_sys::MyProcPid })
+            .load_dynamic();
+        let pid = worker.wait_for_startup().expect("no PID from the worker");
+        assert!(pid > 0);
+        let handle = worker.terminate();
+        handle.wait_for_shutdown().expect("aborted shutdown");
+
+        assert_eq!(
+            124,
+            Spi::get_one::<i32>("SELECT v FROM tests.bgworker_test;")
+                .expect("no return value from the worker")
+        );
+    }
+
+    #[pg_test]
+    fn test_dynamic_bgworker_untracked() {
+        let worker = BackgroundWorkerBuilder::new("dynamic_bgworker")
+            .set_library("pgx_tests")
+            .set_function("bgworker")
+            .set_argument(0i32.into_datum())
+            .enable_spi_access()
+            .load_dynamic();
+        assert!(matches!(worker.wait_for_startup(), Err(BackgroundWorkerStatus::Untracked { .. })));
+        assert!(matches!(
+            worker.wait_for_shutdown(),
+            Err(BackgroundWorkerStatus::Untracked { .. })
+        ));
+    }
+
+    #[pg_test]
+    fn test_dynamic_bgworker_untracked_termination_handle() {
+        let worker = BackgroundWorkerBuilder::new("dynamic_bgworker")
+            .set_library("pgx_tests")
+            .set_function("bgworker")
+            .set_argument(0i32.into_datum())
+            .enable_spi_access()
+            .load_dynamic();
+        let handle = worker.terminate();
+        assert!(matches!(
+            handle.wait_for_shutdown(),
+            Err(BackgroundWorkerStatus::Untracked { .. })
+        ));
+    }
+}

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -43,5 +43,6 @@ mod uuid_tests;
 mod variadic_tests;
 mod xact_callback_tests;
 mod xid64_tests;
+mod zero_datum_edge_cases;
 
 pgx::pg_magic_func!();

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod aggregate_tests;
 mod anyarray_tests;
 mod array_tests;
 mod attributes_tests;
+mod bgworker_tests;
 mod bytea_tests;
 mod cfg_tests;
 mod datetime_tests;

--- a/pgx-tests/src/tests/zero_datum_edge_cases.rs
+++ b/pgx-tests/src/tests/zero_datum_edge_cases.rs
@@ -1,0 +1,72 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+    use pgx::*;
+
+    fn from_helper<T: FromDatum + IntoDatum>(d: Datum) -> Option<T> {
+        unsafe { T::from_polymorphic_datum(d, false, pg_sys::InvalidOid) }
+    }
+
+    #[pg_test]
+    fn test_two_tuple_bool() {
+        let d = (Some(false), Some(true)).into_datum().unwrap();
+        let (a, b) = from_helper::<(Option<bool>, Option<bool>)>(d).unwrap();
+        assert_eq!((a, b), (Some(false), Some(true)));
+    }
+
+    #[pg_test]
+    fn test_vec_bool() {
+        let d = vec![Some(false).into_datum(), Some(true).into_datum()].into_datum().unwrap();
+        let a = from_helper::<Vec<Option<pg_sys::Datum>>>(d).unwrap();
+        assert_eq!(a.first().unwrap().is_some(), true);
+    }
+
+    #[pg_test]
+    fn test_vec_ints() {
+        let d = vec![Some(0).into_datum(), Some(1).into_datum()].into_datum().unwrap();
+        let a = from_helper::<Vec<Option<pg_sys::Datum>>>(d).unwrap();
+        assert_eq!(a.first().unwrap().is_some(), true);
+    }
+
+    #[pg_test]
+    fn test_zero_i32() {
+        let d = 0.into_datum();
+        assert!(d.is_some());
+
+        let i = unsafe { i32::from_datum(d.unwrap(), false) };
+        assert_eq!(i, Some(0));
+    }
+
+    #[pg_test]
+    fn test_false_bool() {
+        let d = false.into_datum();
+        assert!(d.is_some());
+
+        let i = unsafe { bool::from_datum(d.unwrap(), false) };
+        assert_eq!(i, Some(false));
+    }
+
+    #[pg_test]
+    fn test_zero_i32_is_some_zero() {
+        let d = pg_sys::Datum::from(0i32);
+
+        let d = unsafe { pg_sys::Datum::from_datum(d, false) };
+        assert!(d.is_some());
+
+        let i = unsafe { i32::from_datum(d.unwrap(), false) };
+        assert_eq!(i, Some(0));
+    }
+
+    #[pg_test]
+    fn test_false_bool_is_some_false() {
+        let d = pg_sys::Datum::from(false);
+
+        let d = unsafe { pg_sys::Datum::from_datum(d, false) };
+        assert!(d.is_some());
+
+        let b = unsafe { bool::from_datum(d.unwrap(), false) };
+        assert_eq!(b, Some(false));
+    }
+}

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Utility functions for 'pgx'"
@@ -26,8 +26,8 @@ quote = "1.0.21"
 regex = "1.6.0"
 serde = { version = "1.0.145", features = [ "derive" ] }
 serde_derive = "1.0.145"
-serde_json = "1.0.86"
-syn = { version = "1.0.102", features = [ "extra-traits", "full", "fold", "parsing" ] }
+serde_json = "1.0.87"
+syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"], optional = true }
 unescape = "0.1.0"
 tracing = "0.1.37"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgx:  A Rust framework for creating Postgres extensions"
@@ -33,9 +33,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-macros = { path = "../pgx-macros/", version = "=0.5.3" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.5.3" }
-pgx-utils = { path = "../pgx-utils/", version = "=0.5.3" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.5.4" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.5.4" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.5.4" }
 
 # used to internally impl things
 once_cell = "1.15.0" # polyfill until std::lazy::OnceCell stabilizes
@@ -59,5 +59,5 @@ libc = "0.2.135" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0.145", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
-serde_json = "1.0.86" # everything JSON
+serde_json = "1.0.87" # everything JSON
 time = { version = "0.3.15", features = ["formatting", "parsing", "alloc", "macros"] } # TODO(0.6.0): add `optional = true`

--- a/pgx/src/bgworkers.rs
+++ b/pgx/src/bgworkers.rs
@@ -14,6 +14,7 @@ use crate::pg_sys;
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::ptr::null_mut;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -52,6 +53,7 @@ bitflags! {
 }
 
 /// The various points in which a BackgroundWorker can be started by Postgres
+#[derive(Copy, Clone)]
 pub enum BgWorkerStartTime {
     PostmasterStart = pg_sys::BgWorkerStartTime_BgWorkerStart_PostmasterStart as isize,
     ConsistentState = pg_sys::BgWorkerStartTime_BgWorkerStart_ConsistentState as isize,
@@ -210,10 +212,130 @@ unsafe extern "C" fn worker_spi_sigterm(_signal_args: i32) {
     pg_sys::SetLatch(pg_sys::MyLatch);
 }
 
+/// Dynamic background worker handle
+pub struct DynamicBackgroundWorker {
+    handle: *mut pg_sys::BackgroundWorkerHandle,
+    notify_pid: pg_sys::pid_t,
+}
+
+/// PID
+pub type Pid = pg_sys::pid_t;
+
+/// Dynamic background worker status
+#[derive(Debug, Clone, Copy)]
+pub enum BackgroundWorkerStatus {
+    Started,
+    NotYetStarted,
+    Stopped,
+    PostmasterDied,
+    /// `BackgroundWorkerBuilder.bgw_notify_pid` was not set to `pg_sys::MyProcPid`
+    ///
+    /// This makes worker's startup or shutdown untrackable by the current process.
+    Untracked {
+        /// `bgw_notify_pid` as specified in the builder
+        notify_pid: pg_sys::pid_t,
+    },
+}
+
+impl From<pg_sys::BgwHandleStatus> for BackgroundWorkerStatus {
+    fn from(s: pg_sys::BgwHandleStatus) -> Self {
+        match s {
+            pg_sys::BgwHandleStatus_BGWH_STARTED => BackgroundWorkerStatus::Started,
+            pg_sys::BgwHandleStatus_BGWH_NOT_YET_STARTED => BackgroundWorkerStatus::NotYetStarted,
+            pg_sys::BgwHandleStatus_BGWH_STOPPED => BackgroundWorkerStatus::Stopped,
+            pg_sys::BgwHandleStatus_BGWH_POSTMASTER_DIED => BackgroundWorkerStatus::PostmasterDied,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl DynamicBackgroundWorker {
+    /// Return dynamic background worker's PID if the worker is successfully registered,
+    /// otherwise it return worker's status as an error.
+    pub fn pid(&self) -> Result<Pid, BackgroundWorkerStatus> {
+        let mut pid: pg_sys::pid_t = 0;
+        let status: BackgroundWorkerStatus =
+            unsafe { pg_sys::GetBackgroundWorkerPid(self.handle, &mut pid) }.into();
+        match status {
+            BackgroundWorkerStatus::Started => Ok(pid),
+            _ => Err(status),
+        }
+    }
+
+    /// Causes the postmaster to send SIGTERM to the worker if it is running,
+    /// and to unregister it as soon as it is not.
+    pub fn terminate(self) -> TerminatingDynamicBackgroundWorker {
+        unsafe {
+            pg_sys::TerminateBackgroundWorker(self.handle);
+        }
+        TerminatingDynamicBackgroundWorker { handle: self.handle, notify_pid: self.notify_pid }
+    }
+
+    /// Block until the postmaster has attempted to start the background worker,
+    /// or until the postmaster dies. If the background worker is running, the successful return value
+    /// will be the worker's PID. Otherwise, the return value will be an error with the worker's status.
+    ///
+    /// Requires `BackgroundWorkerBuilder.bgw_notify_pid` to be set to `pg_sys::MyProcPid`, otherwise it'll
+    /// return [`BackgroundWorkerStatus::Untracked`] error
+    pub fn wait_for_startup(&self) -> Result<Pid, BackgroundWorkerStatus> {
+        unsafe {
+            if self.notify_pid != pg_sys::MyProcPid {
+                return Err(BackgroundWorkerStatus::Untracked { notify_pid: self.notify_pid });
+            }
+        }
+        let mut pid: pg_sys::pid_t = 0;
+        let status: BackgroundWorkerStatus =
+            unsafe { pg_sys::WaitForBackgroundWorkerStartup(self.handle, &mut pid) }.into();
+        match status {
+            BackgroundWorkerStatus::Started => Ok(pid),
+            _ => Err(status),
+        }
+    }
+
+    /// Block until the background worker exits, or postmaster dies. When the background worker exits, the return value is unit,
+    /// if postmaster dies it will return error with `BackgroundWorkerStatus::PostmasterDied` status
+    ///
+    /// Requires `BackgroundWorkerBuilder.bgw_notify_pid` to be set to `pg_sys::MyProcPid`, otherwise it'll
+    /// return [`BackgroundWorkerStatus::Untracked`] error
+    pub fn wait_for_shutdown(self) -> Result<(), BackgroundWorkerStatus> {
+        TerminatingDynamicBackgroundWorker { handle: self.handle, notify_pid: self.notify_pid }
+            .wait_for_shutdown()
+    }
+}
+
+/// Handle of a dynamic background worker that is being terminated with
+/// [`DynamicBackgroundWorker::terminate`]. Only allows waiting for shutdown.
+pub struct TerminatingDynamicBackgroundWorker {
+    handle: *mut pg_sys::BackgroundWorkerHandle,
+    notify_pid: pg_sys::pid_t,
+}
+
+impl TerminatingDynamicBackgroundWorker {
+    /// Block until the background worker exits, or postmaster dies. When the background worker exits, the return value is unit,
+    /// if postmaster dies it will return error with `BackgroundWorkerStatus::PostmasterDied` status
+    ///
+    /// Requires `BackgroundWorkerBuilder.bgw_notify_pid` to be set to `pg_sys::MyProcPid`, otherwise it'll
+    /// return [`BackgroundWorkerStatus::Untracked`] error
+    pub fn wait_for_shutdown(self) -> Result<(), BackgroundWorkerStatus> {
+        unsafe {
+            if self.notify_pid != pg_sys::MyProcPid {
+                return Err(BackgroundWorkerStatus::Untracked { notify_pid: self.notify_pid });
+            }
+        }
+        let status: BackgroundWorkerStatus =
+            unsafe { pg_sys::WaitForBackgroundWorkerShutdown(self.handle) }.into();
+        match status {
+            BackgroundWorkerStatus::Stopped => Ok(()),
+            _ => Err(status),
+        }
+    }
+}
+
 /// A builder-style interface for creating a new Background Worker
 ///
-/// This must be used from within your extension's `_PG_init()` function,
-/// finishing with the `.load()` function.
+/// For a static background worker, this must be used from within your extension's `_PG_init()` function,
+/// finishing with the `.load()` function. Dynamic background workers are loaded with `.load_dynamic()` and
+/// have no restriction as to where they can be loaded.
 ///
 /// ## Example
 ///
@@ -279,6 +401,9 @@ impl BackgroundWorkerBuilder {
     }
 
     /// Does this BackgroundWorker want Shared Memory access?
+    ///
+    /// `startup` allows specifying shared memory initialization startup hook. Ignored
+    /// if [`BackgroundWorkerBuilder::load_dynamic`] is used.
     pub fn enable_shmem_access(mut self: Self, startup: Option<unsafe extern "C" fn()>) -> Self {
         self.bgw_flags = self.bgw_flags | BGWflags::BGWORKER_SHMEM_ACCESS;
         self.shared_memory_startup_fn = startup;
@@ -397,8 +522,39 @@ impl BackgroundWorkerBuilder {
     /// Once properly configured, call `load()` to get the BackgroundWorker registered and
     /// started at the proper time by Postgres.
     pub fn load(self: Self) {
+        let mut bgw: pg_sys::BackgroundWorker = (&self).into();
+
+        unsafe {
+            pg_sys::RegisterBackgroundWorker(&mut bgw);
+            if self.bgw_flags.contains(BGWflags::BGWORKER_SHMEM_ACCESS)
+                && self.shared_memory_startup_fn.is_some()
+            {
+                PREV_SHMEM_STARTUP_HOOK = pg_sys::shmem_startup_hook;
+                pg_sys::shmem_startup_hook = self.shared_memory_startup_fn;
+            }
+        };
+    }
+
+    /// Once properly configured, call `load_dynamic()` to get the BackgroundWorker registered and started dynamically.
+    pub fn load_dynamic(self: Self) -> DynamicBackgroundWorker {
+        let mut bgw: pg_sys::BackgroundWorker = (&self).into();
+        let mut handle: *mut pg_sys::BackgroundWorkerHandle = null_mut();
+
+        unsafe {
+            pg_sys::RegisterDynamicBackgroundWorker(&mut bgw, &mut handle);
+        };
+
+        DynamicBackgroundWorker { handle, notify_pid: bgw.bgw_notify_pid }
+    }
+}
+
+/// This conversion is useful only in limited context outside of pgx, such as when this structure is required
+/// by other libraries and the worker is not to be started by pgx itself. In this case,
+/// the builder is useful for building this structure.
+impl<'a> Into<pg_sys::BackgroundWorker> for &'a BackgroundWorkerBuilder {
+    fn into(self) -> pg_sys::BackgroundWorker {
         #[cfg(feature = "pg10")]
-        let mut bgw = pg_sys::BackgroundWorker {
+        let bgw = pg_sys::BackgroundWorker {
             bgw_name: RpgffiChar::from(&self.bgw_name[..]).0,
             bgw_flags: self.bgw_flags.bits(),
             bgw_start_time: self.bgw_start_time as u32,
@@ -414,7 +570,7 @@ impl BackgroundWorkerBuilder {
         };
 
         #[cfg(any(feature = "pg11", feature = "pg12", feature = "pg13", feature = "pg14"))]
-        let mut bgw = pg_sys::BackgroundWorker {
+        let bgw = pg_sys::BackgroundWorker {
             bgw_name: RpgffiChar::from(&self.bgw_name[..]).0,
             bgw_type: RpgffiChar::from(&self.bgw_type[..]).0,
             bgw_flags: self.bgw_flags.bits(),
@@ -430,15 +586,7 @@ impl BackgroundWorkerBuilder {
             bgw_notify_pid: self.bgw_notify_pid,
         };
 
-        unsafe {
-            pg_sys::RegisterBackgroundWorker(&mut bgw);
-            if self.bgw_flags.contains(BGWflags::BGWORKER_SHMEM_ACCESS)
-                && self.shared_memory_startup_fn.is_some()
-            {
-                PREV_SHMEM_STARTUP_HOOK = pg_sys::shmem_startup_hook;
-                pg_sys::shmem_startup_hook = self.shared_memory_startup_fn;
-            }
-        };
+        bgw
     }
 }
 

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -133,7 +133,7 @@ impl FromDatum for pg_sys::Datum {
         is_null: bool,
         _: pg_sys::Oid,
     ) -> Option<pg_sys::Datum> {
-        if is_null || datum.is_null() {
+        if is_null {
             None
         } else {
             Some(datum)


### PR DESCRIPTION
This release covers an incorrect handling of some Datum arguments, some missed SpinLock macro bindings that we wanted to add to the C shim, and introduces a base API for dynamic background worker registration!