### PR TITLE
`name!(column_name, RustType)` will fail to compile if `column_name` is a Rust reserved keyword

### DIFF
--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -29,6 +29,15 @@ mod tests {
 
     use pgx::prelude::*;
 
+    // exists just to make sure the code compiles -- tickles the bug behind PR #807
+    #[pg_extern]
+    fn returns_named_tuple_with_rust_reserved_keyword<'a>(/*
+                                 `type` is a reserved Rust keyword, but we still need to be able to parse it for SQL generation 
+                                                        */
+    ) -> TableIterator<'a, (name!(type, String), name!(i, i32))> {
+        unimplemented!()
+    }
+
     #[pg_extern(immutable)]
     fn is_immutable() {}
 

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -413,12 +413,12 @@ pub fn staticize_lifetimes(value: &mut syn::Type) {
             if let Some(archetype) = mac.path.segments.last() {
                 match archetype.ident.to_string().as_str() {
                     "name" => {
-                        if let Ok(mut out) = mac.parse_body::<NameMacro>() {
-                            staticize_lifetimes(&mut out.used_ty.resolved_ty);
-
+                        if let Ok(out) = mac.parse_body::<NameMacro>() {
                             // rewrite the name!() macro so that it has a static lifetime, if any
                             if let Ok(ident) = syn::parse_str::<Ident>(&out.ident) {
-                                let ty = out.used_ty.resolved_ty;
+                                let mut ty = out.used_ty.resolved_ty;
+
+                                staticize_lifetimes(&mut ty);
                                 type_macro.mac = syn::parse_quote! {name!(#ident, #ty)};
                             }
                         }

--- a/pgx-utils/src/lib.rs
+++ b/pgx-utils/src/lib.rs
@@ -413,13 +413,14 @@ pub fn staticize_lifetimes(value: &mut syn::Type) {
             if let Some(archetype) = mac.path.segments.last() {
                 match archetype.ident.to_string().as_str() {
                     "name" => {
-                        let mut out: NameMacro = mac.parse_body().expect("name!() in wrong format");
-                        staticize_lifetimes(&mut out.used_ty.resolved_ty);
+                        if let Ok(mut out) = mac.parse_body::<NameMacro>() {
+                            staticize_lifetimes(&mut out.used_ty.resolved_ty);
 
-                        // rewrite the name!() macro so that it has a static lifetime, if any
-                        if let Ok(ident) = syn::parse_str::<Ident>(&out.ident) {
-                            let ty = out.used_ty.resolved_ty;
-                            type_macro.mac = syn::parse_quote! {name!(#ident, #ty)};
+                            // rewrite the name!() macro so that it has a static lifetime, if any
+                            if let Ok(ident) = syn::parse_str::<Ident>(&out.ident) {
+                                let ty = out.used_ty.resolved_ty;
+                                type_macro.mac = syn::parse_quote! {name!(#ident, #ty)};
+                            }
                         }
                     }
                     _ => {}


### PR DESCRIPTION
For example, a code block like this:

```rust
    #[pg_extern]
    fn returns_named_tuple_with_rust_reserved_word<'a>(
    ) -> TableIterator<'a, (name!(type, String), name!(foo, i32))> {
        unimplemented!()
    }
```

Fails with this worthless error from inside our #[pg_extern] proc macro:

```
error: custom attribute panicked
   --> blah.rs:0:1
    |
466 | #[pg_extern]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: called `Result::unwrap()` on an `Err` value: Error("expected identifier")
```

The problem is that we named the "column_name" `type`, which is a Rust reserved keyword.
The fix is to parse the "column_name" from the `name!()` macro as a raw `proc_macro2::TokenStream` instead of specifically a `proc_macro2::Ident`.  The generated rust code doesn't use the "column_name" at all -- it's only used for the generated SQL, and SQL and Rust have different ideas of reserved words.

PR also does some drive-by cleanup to better handle (read: ignore) a malformed `name!()` macro.

This affects v0.5.4 and necessitates a release as it stops ZDB from compiling.