### PR TITLE
Reduce Array assert! in release builds

### DIFF
--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -198,6 +198,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
         // So, assert correctness of the NullKind implementation and cleanup.
         // SAFETY: The pointer we got should be correctly constructed for slice validity.
         let pallocd_null_slice = unsafe { slice::from_raw_parts(nulls, nelems) };
+        #[cfg(debug_assertions)]
         for i in 0..nelems {
             assert_eq!(null_slice.get(i).unwrap(), pallocd_null_slice[i]);
         }


### PR DESCRIPTION
Due to the extremely touchy nature of Array's implementation, I left this debugging code in to make sure that anyone screamed if this exploded in production. It has not, and I received my first complaint about Array's slowness and overhead in benchmarks. It's time to cfg this out and investigate other possible speed improvements in addition.