### PR TITLE
Update clap and related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
  "atty",
  "cargo_metadata",
  "cargo_toml",
- "clap",
+ "clap 4.0.18",
  "clap-cargo",
  "color-eyre",
  "env_proxy",
@@ -319,15 +319,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.14",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -387,8 +388,8 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
@@ -397,13 +398,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-cargo"
-version = "0.8.0"
+name = "clap"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551b6aa534ced210e29bc4ea2016bc11c74770f0a2b94b29dfc1a92ab6fc28d4"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.18",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap-cargo"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca953650a7350560b61db95a0ab1d9c6f7b74d146a9e08fb258b834f3cf7e2c"
 dependencies = [
  "cargo_metadata",
- "clap",
+ "clap 4.0.18",
  "doc-comment",
 ]
 
@@ -421,10 +437,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1512,7 +1550,7 @@ dependencies = [
 name = "pgx-version-updater"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "clap 3.2.22",
  "owo-colors",
  "toml_edit",
  "walkdir",
@@ -2293,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 
 [[package]]
 name = "thiserror"

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 
 [dependencies]
 atty = "0.2.14"
-cargo_metadata = "0.14.2"
+cargo_metadata = "0.15.1"
 cargo_toml = "0.11.8"
-clap = { version = "3.2.22", features = [ "env", "suggestions", "cargo", "derive" ] }
-clap-cargo = { version = "0.8.0", features = [ "cargo_metadata" ] }
+clap = { version = "4.0.18", features = [ "env", "suggestions", "cargo", "derive" ] }
+clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.14"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"

--- a/cargo-pgx/src/command/connect.rs
+++ b/cargo-pgx/src/command/connect.rs
@@ -27,13 +27,13 @@ pub(crate) struct Connect {
     /// The database to connect to (and create if the first time).  Defaults to a database with the same name as the current extension name
     #[clap(env = "DBNAME")]
     dbname: Option<String>,
-    #[clap(from_global, parse(from_occurrences))]
+    #[clap(from_global, action = ArgAction::Count)]
     verbose: usize,
     /// Package to determine default `pg_version` with (see `cargo help pkgid`)
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
     /// Use an existing `pgcli` on the $PATH.
     #[clap(env = "PGX_PGCLI", long)]

--- a/cargo-pgx/src/command/get.rs
+++ b/cargo-pgx/src/command/get.rs
@@ -20,13 +20,13 @@ use std::process::Command;
 pub(crate) struct Get {
     /// One of the properties from `$EXTENSION.control`
     name: String,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
     /// Package to determine default `pg_version` with (see `cargo help pkgid`)
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
 }
 

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -60,8 +60,8 @@ pub(crate) struct Init {
     /// If installed locally, the path to PG14's `pgconfig` tool, or `download` to have pgx download/compile/install it
     #[clap(env = "PG14_PG_CONFIG", long)]
     pg14: Option<String>,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
     #[clap(long, help = "Base port number")]
     base_port: Option<u16>,
     #[clap(long, help = "Base testing port number")]

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -26,7 +26,7 @@ pub(crate) struct Install {
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
     /// Compile for release mode (default is debug)
     #[clap(long, short)]
@@ -42,8 +42,8 @@ pub(crate) struct Install {
     pg_config: Option<String>,
     #[clap(flatten)]
     features: clap_cargo::Features,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
 }
 
 impl CommandExecute for Install {

--- a/cargo-pgx/src/command/new.rs
+++ b/cargo-pgx/src/command/new.rs
@@ -23,8 +23,8 @@ pub(crate) struct New {
     /// Create a background worker template
     #[clap(long, short)]
     bgworker: bool,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
 }
 
 impl CommandExecute for New {

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -23,7 +23,7 @@ pub(crate) struct Package {
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
     /// Compile for debug mode (default is release)
     #[clap(long, short)]
@@ -35,15 +35,15 @@ pub(crate) struct Package {
     #[clap(long)]
     test: bool,
     /// The `pg_config` path (default is first in $PATH)
-    #[clap(long, short = 'c', parse(from_os_str))]
+    #[clap(long, short = 'c', value_parser)]
     pg_config: Option<PathBuf>,
     /// The directory to output the package (default is `./target/[debug|release]/extname-pgXX/`)
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     out_dir: Option<PathBuf>,
     #[clap(flatten)]
     features: clap_cargo::Features,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
 }
 
 impl CommandExecute for Package {

--- a/cargo-pgx/src/command/pgx.rs
+++ b/cargo-pgx/src/command/pgx.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 pub(crate) struct Pgx {
     #[clap(subcommand)]
     subcommand: CargoPgxSubCommands,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
 }
 
 impl CommandExecute for Pgx {

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -43,8 +43,8 @@ pub(crate) struct Run {
     profile: Option<String>,
     #[clap(flatten)]
     features: clap_cargo::Features,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
     /// Use an existing `pgcli` on the $PATH.
     #[clap(env = "PGX_PGCLI", long)]
     pgcli: bool,

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -42,7 +42,7 @@ pub(crate) struct Schema {
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
     /// Build in test mode (for `cargo pgx test`)
     #[clap(long)]
@@ -56,18 +56,18 @@ pub(crate) struct Schema {
     #[clap(long)]
     profile: Option<String>,
     /// The `pg_config` path (default is first in $PATH)
-    #[clap(long, short = 'c', parse(from_os_str))]
+    #[clap(long, short = 'c', value_parser)]
     pg_config: Option<PathBuf>,
     #[clap(flatten)]
     features: clap_cargo::Features,
     /// A path to output a produced SQL file (default is `stdout`)
-    #[clap(long, short, parse(from_os_str))]
+    #[clap(long, short, value_parser)]
     out: Option<PathBuf>,
     /// A path to output a produced GraphViz DOT file
-    #[clap(long, short, parse(from_os_str))]
+    #[clap(long, short, value_parser)]
     dot: Option<PathBuf>,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
     /// Skip building a fresh extension shared object.
     #[clap(long)]
     skip_build: bool,

--- a/cargo-pgx/src/command/start.rs
+++ b/cargo-pgx/src/command/start.rs
@@ -25,13 +25,13 @@ pub(crate) struct Start {
     /// The Postgres version to start (`pg10`, `pg11`, `pg12`, `pg13`, `pg14`, or `all`)
     #[clap(env = "PG_VERSION")]
     pg_version: Option<String>,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
     /// Package to determine default `pg_version` with (see `cargo help pkgid`)
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
 }
 

--- a/cargo-pgx/src/command/status.rs
+++ b/cargo-pgx/src/command/status.rs
@@ -22,13 +22,13 @@ pub(crate) struct Status {
     /// The Postgres version
     #[clap(env = "PG_VERSION")]
     pg_version: Option<String>,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
     /// Package to determine default `pg_version` with (see `cargo help pkgid`)
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
 }
 

--- a/cargo-pgx/src/command/stop.rs
+++ b/cargo-pgx/src/command/stop.rs
@@ -23,13 +23,13 @@ pub(crate) struct Stop {
     /// The Postgres version to stop (`pg10`, `pg11`, `pg12`, `pg13`, `pg14`, or `all`)
     #[clap(env = "PG_VERSION")]
     pg_version: Option<String>,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = ArgAction::Count)]
+    verbose: u8,
     /// Package to determine default `pg_version` with (see `cargo help pkgid`)
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
 }
 

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -29,7 +29,7 @@ pub(crate) struct Test {
     #[clap(long, short)]
     package: Option<String>,
     /// Path to Cargo.toml
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
     /// compile for release mode (default is debug)
     #[clap(long, short)]
@@ -42,8 +42,8 @@ pub(crate) struct Test {
     no_schema: bool,
     #[clap(flatten)]
     features: clap_cargo::Features,
-    #[clap(from_global, parse(from_occurrences))]
-    verbose: usize,
+    #[clap(from_global, action = clap::ArgAction::Count)]
+    verbose: u8,
 }
 
 impl CommandExecute for Test {

--- a/cargo-pgx/src/main.rs
+++ b/cargo-pgx/src/main.rs
@@ -32,8 +32,8 @@ struct CargoCommand {
     #[clap(subcommand)]
     subcommand: CargoSubcommands,
     /// Enable info logs, -vv for debug, -vvv for trace
-    #[clap(short = 'v', long, parse(from_occurrences), global = true)]
-    verbose: usize,
+    #[clap(short = 'v', long, action = clap::ArgAction::Count, global = true)]
+    verbose: u8,
 }
 
 impl CommandExecute for CargoCommand {

--- a/cargo-pgx/src/metadata.rs
+++ b/cargo-pgx/src/metadata.rs
@@ -8,7 +8,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 use cargo_metadata::{Metadata, MetadataCommand};
 use eyre::eyre;
-use semver::{Version, VersionReq};
+use semver::VersionReq;
 use std::path::Path;
 
 pub fn metadata(
@@ -37,7 +37,7 @@ pub fn validate(metadata: &Metadata) -> eyre::Result<()> {
     });
 
     for package in pgx_packages {
-        let package_semver = metadata_version_to_semver(package.version.clone());
+        let package_semver = package.version.clone();
         if !cargo_pgx_version_req.matches(&package_semver) {
             return Err(eyre!(
                 r#"`{}-{}` shouldn't be used with `cargo-pgx-{}`, please use `{} = "~{}"` in your `Cargo.toml`."#,
@@ -58,14 +58,4 @@ pub fn validate(metadata: &Metadata) -> eyre::Result<()> {
     }
 
     Ok(())
-}
-
-fn metadata_version_to_semver(metadata_version: cargo_metadata::Version) -> semver::Version {
-    Version {
-        major: metadata_version.major,
-        minor: metadata_version.minor,
-        patch: metadata_version.patch,
-        pre: metadata_version.pre,
-        build: metadata_version.build,
-    }
 }


### PR DESCRIPTION
Fixes the issue with textwrap in https://github.com/tcdi/pgx/pull/629#issuecomment-1292304458. Although, after I did this, I realized there's a semver-compatible textwrap, and this could have just been pushing up the result of `cargo update -p textwrap --precise 0.15.2`. Still, we probably do want to make these changes, so here they are.

(Note that this still builds fine in 1.61)