### PR TITLE
Multiple Linux distros nightly run -- re-publishing content from #796

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.DS_Store
+.idea/
+target/
+*.iml
+**/*.rs.bk
+*.o
+*.so
+*.a
+cmake*/
+.direnv
+pgx-examples/*/target

--- a/.github/docker/Dockerfile.alpine:3.16
+++ b/.github/docker/Dockerfile.alpine:3.16
@@ -1,0 +1,59 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-alpine .
+#
+# Example of how to run this container with tests after building the image:
+#   docker run pgx-alpine cargo test --no-default-features --features pg14 --locked
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
+ARG PG_MAJOR_VER
+# Use Postgres' official alpine version, it's just easier that way
+FROM postgres:${PG_MAJOR_VER}-alpine3.16
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
+
+# Required for compiling Rust
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+RUN apk add --no-cache \
+  git \
+  curl \
+  bash \
+  musl-dev \
+  make \
+  gcc \
+  coreutils \
+  util-linux-dev \
+  musl-dev \
+  openssl-dev \
+  clang-libs \
+  tar
+
+# Set up permissions so that the rust user below can create extensions
+RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+  `$(which pg_config) --sharedir`/extension \
+  /var/run/postgresql/
+
+# Running pgx and tests require a non-root user
+RUN adduser -s /bin/bash -D rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
+USER rust
+# This environment variable is required for postgres while running the tests
+ENV USER=rust
+
+# Install cargo and Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+
+# Install cargo-pgx from source copied into this container
+RUN cargo install --path cargo-pgx/ --locked
+
+# This seems strange, but by this point $PG_MAJOR_VER is blank and
+# $PG_MAJOR is always set to the correct version. I think it's something built
+# into the postgres:XX-alpine3.16 images, so it was easier to go with the grain
+RUN cargo pgx init --pg$PG_MAJOR=$(which pg_config)
+
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.amazon:2
+++ b/.github/docker/Dockerfile.amazon:2
@@ -1,0 +1,119 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-amazonlinux2 .
+#
+# Example of how to run this container with tests after building the image:
+#   docker run pgx-amazonlinux2 cargo test --no-default-features --features pg14 --locked
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
+FROM amazonlinux:2
+ARG PG_MAJOR_VER
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
+
+# NOTE: Normally in Amazon Linux 2, you would use "amazon-linux-extras" to set up
+# and install any version of Postgres. However, at the time of this writing,
+# installing Postgres 13 would flat out fail due to some packaging issues unrelated
+# to this Dockerfile. Therefore, we had to work around it by installing everything
+# necessary manually. The old method of using amazon-linux-extras are commented
+# at the end of this file in the event we want to resurrect it some day.
+RUN amazon-linux-extras install epel
+RUN yum -y remove python3
+RUN amazon-linux-extras enable python3
+RUN yum clean metadata
+RUN yum install -y python3-3.6.* --disablerepo=amzn2-core
+RUN yum install -y \
+  bison \
+  clang \
+  flex \
+  llvm13 \
+  llvm13-* \
+  openssl \
+  openssl-devel \
+  readline \
+  readline-devel \
+  which
+
+# Yucky, but required.
+RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-3.el7.centos.noarch.rpm
+RUN yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-2-3.el7.centos.noarch.rpm
+RUN yum -y install http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/l/llvm-toolset-7-clang-5.0.1-4.el7.x86_64.rpm
+
+# Set up the official Postgres repos.
+# NOTE: Assumption here is x86_64, which might suffice for CI builds but care
+# should be taken if this is used as a template elsewhere.
+RUN echo -e "[pgdg$PG_MAJOR_VER]\n\
+  name=PostgreSQL $PG_MAJOR_VER for RHEL/CentOS7 - x86_64\n\
+  gpgkey=https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-$PG_MAJOR_VER\n\
+  baseurl=https://download.postgresql.org/pub/repos/yum/$PG_MAJOR_VER/redhat/rhel-7-x86_64/\n\
+  enabled=1\n\
+  gpgcheck=0\n\
+  " | sed -e 's/^[ \t]*//' >> /etc/yum.repos.d/pgdg.repo
+
+RUN yum -y install \
+  postgresql$PG_MAJOR_VER \
+  postgresql$PG_MAJOR_VER-contrib \
+  postgresql$PG_MAJOR_VER-server \
+  postgresql$PG_MAJOR_VER-devel
+
+ENV PATH="/usr/pgsql-$PG_MAJOR_VER/bin:$PATH"
+
+# Set up permissions so that the rust user below can create extensions
+RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+  `$(which pg_config) --sharedir`/extension \
+  /var/run/postgresql/
+
+# Running pgx and tests require a non-root user
+RUN adduser -G wheel rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
+USER rust
+# This environment variable is required for postgres while running the tests
+ENV USER=rust
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+RUN cargo install --path cargo-pgx/ --locked
+RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]
+
+# === Previous "amazon-linux-extras" steps, kept for historical purposes ===
+# RUN amazon-linux-extras enable postgresql$PG_MAJOR_VER
+# RUN yum clean metadata
+
+# RUN yum install -y \
+#   bison \
+#   clang \
+#   flex \
+#   libpq \
+#   libpq-devel \
+#   openssl \
+#   openssl-devel \
+#   postgresql \
+#   postgresql-devel \
+#   postgresql-server \
+#   postgresql-server-devel \
+#   readline \
+#   readline-devel \
+#   vim \
+#   which
+
+# RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+#   `$(which pg_config) --sharedir`/extension \
+#   /var/run/postgresql/
+
+# RUN adduser -G wheel rust
+# WORKDIR /checkout
+# RUN chown -R rust:rust /checkout
+# COPY --chown=rust:rust . /checkout
+
+# USER rust
+# ENV USER=rust
+
+# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+# ENV PATH="/home/rust/.cargo/bin:${PATH}"
+# RUN cargo install --path cargo-pgx/
+# RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
+# CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.debian:bullseye
+++ b/.github/docker/Dockerfile.debian:bullseye
@@ -1,0 +1,63 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-debian.
+#
+# Example of how to run this container with tests after building the image:
+#   docker run pgx-debian cargo test --no-default-features --features pg14 --locked
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
+FROM debian:bullseye
+
+ARG PG_MAJOR_VER
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y wget gnupg
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get update -y --fix-missing
+RUN apt-get install -y \
+  build-essential \
+  curl \
+  clang \
+  git \
+  gcc \
+  libssl-dev \
+  libz-dev \
+  make \
+  pkg-config \
+  postgresql-$PG_MAJOR_VER \
+  postgresql-server-dev-$PG_MAJOR_VER \
+  zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set up permissions so that the rust user below can create extensions
+RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
+  `$(which pg_config) --sharedir`/extension \
+  /var/run/postgresql/
+
+# Running pgx and tests require a non-root user
+RUN useradd --create-home --shell /bin/bash rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
+USER rust
+
+# This environment variable is required for postgres while running the tests
+ENV USER=rust
+
+# Install cargo and Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+
+# Install cargo-pgx from source copied into this container
+RUN cargo install --path cargo-pgx/ --locked
+
+# Initialize cargo pgx so that we can run the tests
+RUN cargo pgx init --pg$PG_MAJOR_VER=$(which pg_config)
+
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/Dockerfile.fedora:36
+++ b/.github/docker/Dockerfile.fedora:36
@@ -1,0 +1,54 @@
+# Example of how to build this container (ran from pgx checkout directory):
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgx-fedora .
+#
+# Example of how to run this container with tests after building the image:
+#   docker run pgx-fedora cargo test --no-default-features --features pg14 --locked
+#
+# Note that "PG_MAJOR_VER" build arg in the build step must match the
+# "--features pgXX" in the run step
+
+FROM fedora:36
+
+ARG PG_MAJOR_VER
+ENV PG_MAJOR_VER=${PG_MAJOR_VER}
+
+RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/F-36-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+RUN dnf install -y \
+  clang \
+  clang-tools-extra \
+  cmake \
+  make \
+  gcc \
+  openssl \
+  openssl-devel \
+  postgresql$PG_MAJOR_VER-server \
+  postgresql$PG_MAJOR_VER-devel \
+  redhat-rpm-config \
+  util-linux
+
+# Set up permissions so that the rust user below can create extensions
+RUN chmod a+rwx `/usr/pgsql-$PG_MAJOR_VER/bin/pg_config --pkglibdir` \
+  `/usr/pgsql-$PG_MAJOR_VER/bin/pg_config --sharedir`/extension \
+  /var/run/postgresql/
+
+# Running pgx and tests require a non-root user
+RUN adduser -G wheel rust
+WORKDIR /checkout
+RUN chown -R rust:rust /checkout
+COPY --chown=rust:rust . /checkout
+
+USER rust
+# This environment variable is required for postgres while running the tests
+ENV USER=rust
+
+# Install cargo and Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/rust/.cargo/bin:${PATH}"
+
+# Install cargo-pgx from source copied into this container
+RUN cargo install --path cargo-pgx/ --locked
+
+# Initialize cargo pgx so that we can run the tests
+RUN cargo pgx init --pg$PG_MAJOR_VER=/usr/pgsql-$PG_MAJOR_VER/bin/pg_config
+
+CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER}"]

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+PG_MAJOR_VER=$1
+DOCKERFILE_ID=$2
+
+echo "Building docker container for PGX using Postgres version $PG_MAJOR_VER in container $DOCKERFILE_ID"
+
+docker build \
+  --build-arg PG_MAJOR_VER=$PG_MAJOR_VER \
+  -t pgx -f ".github/docker/Dockerfile.$DOCKERFILE_ID" .
+
+echo "Running PGX test suite using Postgres version $PG_MAJOR_VER in container $DOCKERFILE_ID"
+
+docker run pgx cargo test --no-default-features --features pg$PG_MAJOR_VER --locked

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -1,0 +1,52 @@
+name: Will It Blend™
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+env:
+  # NB: Don't modify `RUSTFLAGS` here, since it would override the ones
+  # configured by `.cargo/config.toml` on macOS.
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: "false"
+  # CARGO_LOG: cargo::core::compiler::fingerprint=info # Uncomment this to output compiler fingerprint info
+
+jobs:
+  distro_tests:
+    name: Distro tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # We want all of them to run, even if one fails
+      matrix:
+        pg_version: ["pg10", "pg11", "pg12", "pg13", "pg14"]
+        container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
+    steps:
+      # If this workflow is being called from a schedule/cron job, then let's
+      # force the "develop" branch. Otherwise, use whatever is passed in via
+      # GITHUB_HEAD_REF. The result of this will be used below in the
+      # actions/checkout@vX step. Note that at the time of this writing, Github
+      # Actions does not allow us to specify which branch to run a schedule from
+      # (it always runs from the default branch, which in this case is master).
+      - name: Set up correct branch environment variable
+        run: |
+          if [ $GITHUB_EVENT_NAME == "schedule" ]; then
+            echo "Running via schedule, so using branch develop"
+            echo "NIGHTLY_BUILD_REF=develop" >> $GITHUB_ENV
+          else
+            echo "Not running via schedule, so using branch $GITHUB_HEAD_REF"
+            echo "NIGHTLY_BUILD_REF=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+          fi
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.NIGHTLY_BUILD_REF }}
+
+      - name: Set up environment variables
+        run: |
+          export PG_MAJOR_VER=$(echo ${{ matrix.pg_version}} | cut -c3-)
+          echo "PG_MAJOR_VER=$PG_MAJOR_VER" >> $GITHUB_ENV
+
+      - name: Run PGX tests for Postgres ${{ matrix.pg_version }} using container ${{ matrix.container }}
+        shell: bash
+        run: ./.github/docker/run-docker.sh "$PG_MAJOR_VER" ${{ matrix.container }}

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -711,3 +711,11 @@ mod internal {
         }
     }
 }
+
+// Hack to fix linker errors that we get under amazonlinux2 on some PG versions
+// due to our wrappers for various system library functions. Should be fairly
+// harmless, but ideally we would not wrap these functions
+// (https://github.com/tcdi/pgx/issues/730).
+#[cfg(target_os = "linux")]
+#[link(name = "resolv")]
+extern "C" {}


### PR DESCRIPTION
This is a re-issue of content from #796 

This is because ultimately we wanted to merge 796 directly into master, but it already had upstream changes from the `develop` branch that we did not want to merge in pre-emptively.