### PR TITLE
Make default template use UTC timezone

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,13 @@ jobs:
         sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
         echo ""
 
+        echo "----- Setting timezone -----"
+        # Use the Pacific/Chatham (UTC+12:45) timezone to find code that assumes:
+        # - it's in UTC
+        # - it's in a timezone with an integer UTC offset
+        sudo timedatectl set-timezone Pacific/Chatham
+        echo ""
+
         echo "----- Print env -----"
         env
         echo ""
@@ -275,6 +282,11 @@ jobs:
         cargo --version
         echo ""
 
+        echo "----- Setting timezone -----"
+        # See the reasoning for this timezone in the pgx_tests job
+        sudo timedatectl set-timezone Pacific/Chatham
+        echo ""
+
         echo "----- Outputting env -----"
         env
         echo ""
@@ -366,6 +378,12 @@ jobs:
 
         echo "----- Output Cargo version -----"
         cargo --version
+        echo ""
+
+
+        echo "----- Setting timezone -----"
+        # See the reasoning for this timezone in the pgx_tests job
+        sudo systemsetup -settimezone Pacific/Chatham
         echo ""
 
         echo "----- Outputting env -----"

--- a/cargo-pgx/src/templates/lib_rs
+++ b/cargo-pgx/src/templates/lib_rs
@@ -27,6 +27,6 @@ pub mod pg_test {{
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {{
         // return any postgresql.conf settings that are required for your tests
-        vec![]
+        vec!["timezone = 'UTC'"]
     }}
 }}

--- a/nix/templates/default/src/lib.rs
+++ b/nix/templates/default/src/lib.rs
@@ -49,6 +49,6 @@ pub mod pg_test {
     }
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
-        vec![&*WORK_DIR, &*PG_CONFIG]
+        vec![&*WORK_DIR, &*PG_CONFIG, "timezone = 'UTC'"]
     }
 }

--- a/pgx-tests/src/lib.rs
+++ b/pgx-tests/src/lib.rs
@@ -23,6 +23,6 @@ pub mod pg_test {
     }
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
-        vec![]
+        vec!["timezone = 'UTC'"]
     }
 }

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -409,8 +409,6 @@ mod tests {
         .try_into()
         .unwrap();
 
-        // prevents PG's timestamp serialization from imposing the local servers time zone
-        Spi::run("SET TIME ZONE 'UTC'");
         let json = json!({ "time stamp with timezone test": time_stamp_with_timezone });
 
         // but we serialize timestamps at UTC
@@ -419,9 +417,6 @@ mod tests {
 
     #[pg_test]
     fn test_timestamp_serialization() {
-        // prevents PG's timestamp serialization from imposing the local servers time zone
-        Spi::run("SET TIME ZONE 'UTC'");
-
         let datetime = PrimitiveDateTime::new(
             time::Date::from_calendar_date(2020, time::Month::try_from(1).unwrap(), 1).unwrap(),
             time::Time::from_hms(12, 34, 54).unwrap(),


### PR DESCRIPTION
Sets the timezone to UTC by default. This removes the need to do a `SET TIME ZONE 'UTC'` in every test that does stuff with dates, which can occur a lot in some extensions. It can be confusing when the tests you write pass on your machine but fail for other people (and CI machines) in other timezones.

I also updated the CI to use the [Pacific/Chatham (UTC+12:45)](https://en.wikipedia.org/wiki/Chatham_Standard_Time_Zone) so that the timezone-invariance of the tests is verified.