### PR TITLE
Add bindings for typedefs within replication/logical.h to pg_sys

### DIFF
--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -81,6 +81,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"
+#include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/block.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -81,6 +81,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"
+#include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/block.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -81,6 +81,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"
+#include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/block.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -81,6 +81,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"
+#include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/block.h"

--- a/pgx-pg-sys/include/pg15.h
+++ b/pgx-pg-sys/include/pg15.h
@@ -81,6 +81,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"
+#include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/block.h"


### PR DESCRIPTION
Specifically I'm interested in the fields of the LogicalDecodingContext struct. At the moment the struct is empty in pg_sys.

Having access to the LogicalDecodingContext allows a couple new plugin use cases around manipulating the Postgres WAL.