### PR TITLE
Problem: PostgresType can't be derived on an enum

### DIFF
--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -671,6 +671,11 @@ struct Dog {
     treats_recieved: i64,
     pets_gotten: i64,
 }
+
+#[derive(Debug, Serialize, Deserialize, PostgresType)]
+enum Animal {
+    Dog(Dog),
+}
 ```
 
 Optionally accepts the following attributes:
@@ -698,7 +703,12 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
     // validate that we're only operating on a struct
     match ast.data {
         Data::Struct(_) => { /* this is okay */ }
-        _ => panic!("#[derive(PostgresType)] can only be applied to structs"),
+        Data::Enum(_) => {
+            // this is okay and if there's an attempt to implement PostgresEnum,
+            // it will result in compile-time error of conflicting implementation
+            // of traits (IntoDatum, inout, etc.)
+        }
+        _ => panic!("#[derive(PostgresType)] can only be applied to structs or enums"),
     }
 
     if args.is_empty() {

--- a/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
@@ -69,10 +69,10 @@ impl PostgresType {
     }
 
     pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
-        let _data_struct = match derive_input.data {
-            syn::Data::Struct(data_struct) => data_struct,
-            syn::Data::Union(_) | syn::Data::Enum(_) => {
-                return Err(syn::Error::new(derive_input.ident.span(), "expected struct"))
+        match derive_input.data {
+            syn::Data::Struct(_) | syn::Data::Enum(_) => {}
+            syn::Data::Union(_) => {
+                return Err(syn::Error::new(derive_input.ident.span(), "expected struct or enum"))
             }
         };
         let to_sql_config =


### PR DESCRIPTION
In some cases, a Rust enum is not meant to be Postgres enumerated type but just a type that can be managed and serialized using Rust and its ecosystem.

A workaround for this is to wrap an enum into a struct and derive `PostgresType` on it, but it seems like a lot of ceremony for no benefit.

Solution: allow PostgresType to be derived on an enum

Again, this is not to be confused with `PostgresEnum` which derives Postgres enumerated type. This one does not.

Closes #726