### PR TITLE
Problem: pg_shmem_init doesn't work on pg15

### DIFF
--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod pg_try_tests;
 mod pgbox_tests;
 mod postgres_type_tests;
 mod schema_tests;
+mod shmem_tests;
 mod spi_tests;
 mod srf_tests;
 mod struct_type_tests;

--- a/pgx-tests/src/tests/shmem_tests.rs
+++ b/pgx-tests/src/tests/shmem_tests.rs
@@ -1,0 +1,19 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+use pgx::prelude::*;
+use pgx::{pg_shmem_init, PgAtomic, PgSharedMemoryInitialization};
+use std::sync::atomic::AtomicBool;
+
+static ATOMIC: PgAtomic<AtomicBool> = PgAtomic::new();
+
+#[pg_guard]
+pub extern "C" fn _PG_init() {
+    // This ensures that this functionality works across PostgreSQL versions
+    pg_shmem_init!(ATOMIC);
+}

--- a/pgx-utils/src/rewriter.rs
+++ b/pgx-utils/src/rewriter.rs
@@ -59,8 +59,10 @@ impl PgGuardRewriter {
         let arg_list = PgGuardRewriter::build_arg_list(&sig, false)?;
         let func_name = PgGuardRewriter::build_func_name(&func.sig);
 
-        let prolog = if input_func_name == "__pgx_private_shmem_hook" {
-            // we do not want "no_mangle" on this function
+        let prolog = if input_func_name == "__pgx_private_shmem_hook"
+            || input_func_name == "__pgx_private_shmem_request_hook"
+        {
+            // we do not want "no_mangle" on these functions
             quote! {}
         } else if input_func_name == "_PG_init" || input_func_name == "_PG_fini" {
             quote! {


### PR DESCRIPTION
It results in the following error:

```
FATAL:  cannot request additional shared memory outside shmem_request_hook
```

Solution: ensure use of that hook in pg15