### PR TITLE
Allow installing cargo-pgx using rustls instead of native-tls

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -30,7 +30,7 @@ proc-macro2 = { version = "1.0.47", features = [ "span-locations" ] }
 quote = "1.0.21"
 rayon = "1.5.3"
 regex = "1.6.0"
-ureq = { version = "2.5.0", features = ["native-tls"] }
+ureq = "2.5.0"
 url = "2.3.1"
 serde = { version = "1.0.146", features = [ "derive" ] }
 serde_derive = "1.0.146"
@@ -46,3 +46,7 @@ color-eyre = "0.6.2"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+
+[features]
+default = ["ureq/native-tls"]
+rustls-tls = ["ureq/tls"]


### PR DESCRIPTION
This adds a feature flag `rustls-tls`, switching the `ureq` feature flags from the default `native-tls` to `tls`.
Unless explicitly disabling default features and enabling the new flag, the default behavior is unchanged.