### PR TITLE
Fix typo: indicies -> indices

### DIFF
--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -183,7 +183,7 @@ impl PgRelation {
     }
 
     /// Return an iterator of indices, as `PgRelation`s, attached to this relation
-    pub fn indicies(
+    pub fn indices(
         &self,
         lockmode: pg_sys::LOCKMODE,
     ) -> impl std::iter::Iterator<Item = PgRelation> {


### PR DESCRIPTION
NB: This is a breaking change since indices is in the public API