### PR TITLE
Drop pg 10 from Nix

### DIFF
--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,13 +1,8 @@
 { lib
 , naersk
 , hostPlatform
-, fetchFromGitHub
-, postgresql_11
-, postgresql_12
-, postgresql_13
 , pkg-config
 , openssl
-, rustfmt
 , libiconv
 , llvmPackages
 , gitignoreSource

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -2,7 +2,6 @@
 , naersk
 , hostPlatform
 , fetchFromGitHub
-, postgresql_10
 , postgresql_11
 , postgresql_12
 , postgresql_13

--- a/cargo-pgx/default.nix
+++ b/cargo-pgx/default.nix
@@ -1,8 +1,12 @@
 { lib
 , naersk
 , hostPlatform
+, postgresql_11
+, postgresql_12
+, postgresql_13
 , pkg-config
 , openssl
+, rustfmt
 , libiconv
 , llvmPackages
 , gitignoreSource

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,6 @@
         in
         pkgs.mkShell {
           inputsFrom = with pkgs; [
-            postgresql_10
             postgresql_11
             postgresql_12
             postgresql_13

--- a/nix/templates/default/flake.nix
+++ b/nix/templates/default/flake.nix
@@ -114,7 +114,6 @@
           #   # it worked!
           # '';
           "${cargoToml.package.name}_debug" = pkgs."${cargoToml.package.name}_debug";
-          "${cargoToml.package.name}_10_debug" = pkgs."${cargoToml.package.name}_10_debug";
           "${cargoToml.package.name}_11_debug" = pkgs."${cargoToml.package.name}_11_debug";
           "${cargoToml.package.name}_12_debug" = pkgs."${cargoToml.package.name}_12_debug";
           "${cargoToml.package.name}_13_debug" = pkgs."${cargoToml.package.name}_13_debug";


### PR DESCRIPTION
Using the flake template introduced on https://github.com/tcdi/pgx/pull/148. I get the following error:

```
$ nix develop
error: postgresql_10 has been removed from nixpkgs, as this version went EOL on 2022-11-10
```

With this change the error goes away.

```
$ nix develop
$ cargo pgx -V
cargo-pgx 0.5.6
```

I think this goes in line with https://github.com/tcdi/pgx/pull/830.

(Also removed some Nix deps from `cargo-pgx` that look unused)