### PR TITLE
Use `rustls` as the cargo-pgx feature name

### DIFF
--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -49,4 +49,4 @@ tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 
 [features]
 default = ["ureq/native-tls"]
-rustls-tls = ["ureq/tls"]
+rustls = ["ureq/tls"]


### PR DESCRIPTION
It is... unlikely we would use this feature name for anything else in `cargo-pgx` features.