### PR TITLE
If pgx detects a Postgres FFI was called on a not-the-main-thread...

### DIFF
--- a/pgx-pg-sys/src/submodules/thread_check.rs
+++ b/pgx-pg-sys/src/submodules/thread_check.rs
@@ -50,7 +50,10 @@ fn init_active_thread(tid: NonZeroUsize) {
 #[inline(never)]
 #[track_caller]
 fn thread_id_check_failed() -> ! {
-    panic!("postgres FFI may not not be called from multiple threads.");
+    panic!(
+        "{}:  postgres FFI may not not be called from multiple threads.",
+        std::panic::Location::caller()
+    );
 }
 
 fn nonzero_thread_id() -> NonZeroUsize {

--- a/pgx-utils/src/rewriter.rs
+++ b/pgx-utils/src/rewriter.rs
@@ -118,6 +118,7 @@ impl PgGuardRewriter {
         let return_type = PgGuardRewriter::get_return_type(&func.sig);
 
         Ok(quote! {
+            #[track_caller]
             pub unsafe fn #func_name ( #arg_list_with_types ) #return_type {
                 crate::ffi::pg_guard_ffi_boundary(move || {
                     #abi { #func }


### PR DESCRIPTION
... include the caller's location information in that panic message.

This necessitates adding `#[track_caller]` to every FFI function we wrap.

FWIW, this helped me determine where ZDB was unknowingly calling FFI in a background thread.  Without it, I'm not sure I'd ever have found out what was going on.