### PR TITLE
Problem: BackgroundWorker::transaction `R: Copy` bound

### DIFF
--- a/pgx/src/bgworkers.rs
+++ b/pgx/src/bgworkers.rs
@@ -192,10 +192,7 @@ impl BackgroundWorker {
 
     /// Once connected to SPI via `connect_worker_to_spi()`, begin a transaction to
     /// use the `pgx::Spi` interface. Returns the return value of the `F` function.
-    pub fn transaction<
-        F: FnOnce() -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
-        R: Copy,
-    >(
+    pub fn transaction<F: FnOnce() -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe, R>(
         transaction_body: F,
     ) -> R {
         unsafe {


### PR DESCRIPTION
It's not clear why it is necessary and is fairly restrictive.

Solution: drop the bound

The tests are still passing. No other changes were required.