### PR TITLE
Make us work under 1.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr_core"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
+dependencies = [
+ "cty",
+ "memchr",
+]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "custom_sql"
 version = "0.0.0"
 dependencies = [
@@ -1426,6 +1442,7 @@ dependencies = [
  "atomic-traits",
  "bitflags",
  "bitvec",
+ "cstr_core",
  "eyre",
  "heapless",
  "libc",
@@ -1518,6 +1535,7 @@ version = "0.6.0-alpha.0"
 dependencies = [
  "atty",
  "convert_case",
+ "cstr_core",
  "eyre",
  "owo-colors",
  "petgraph",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,7 @@ dependencies = [
  "pgx-utils",
  "proc-macro2",
  "quote",
+ "rayon",
  "shlex",
  "sptr",
  "syn",

--- a/articles/postgresql-aggregates-with-rust.md
+++ b/articles/postgresql-aggregates-with-rust.md
@@ -426,7 +426,7 @@ CREATE TYPE DemoSum;
 -- src/lib.rs:6
 -- exploring_aggregates::demosum_in
 CREATE OR REPLACE FUNCTION "demosum_in"(
-	"input" cstring /* &core::ffi::CStr */
+	"input" cstring /* &cstr_core::CStr */
 ) RETURNS DemoSum /* exploring_aggregates::DemoSum */
 IMMUTABLE PARALLEL SAFE STRICT
 LANGUAGE c /* Rust */
@@ -436,7 +436,7 @@ AS 'MODULE_PATHNAME', 'demosum_in_wrapper';
 -- exploring_aggregates::demosum_out
 CREATE OR REPLACE FUNCTION "demosum_out"(
 	"input" DemoSum /* exploring_aggregates::DemoSum */
-) RETURNS cstring /* &core::ffi::CStr */
+) RETURNS cstring /* &cstr_core::CStr */
 IMMUTABLE PARALLEL SAFE STRICT
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'demosum_out_wrapper';

--- a/pgx-examples/aggregate/src/lib.rs
+++ b/pgx-examples/aggregate/src/lib.rs
@@ -6,8 +6,8 @@ All rights reserved.
 
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
-use core::ffi::CStr;
 use pgx::aggregate::*;
+use pgx::cstr_core::CStr;
 use pgx::prelude::*;
 use pgx::{pgx, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use serde::{Deserialize, Serialize};

--- a/pgx-examples/custom_types/src/fixed_size.rs
+++ b/pgx-examples/custom_types/src/fixed_size.rs
@@ -6,7 +6,7 @@ All rights reserved.
 
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
-use core::ffi::CStr;
+use pgx::cstr_core::CStr;
 use pgx::prelude::*;
 use pgx::{opname, pg_operator, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use std::str::FromStr;

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -328,12 +328,12 @@ extension_sql!(r#"\
 );
 
 #[pg_extern(immutable)]
-fn complex_in(input: &core::ffi::CStr) -> PgBox<Complex> {
+fn complex_in(input: &pgx::cstr_core::CStr) -> PgBox<Complex> {
     todo!()
 }
 
 #[pg_extern(immutable)]
-fn complex_out(complex: PgBox<Complex>) -> &'static core::ffi::CStr {
+fn complex_out(complex: PgBox<Complex>) -> &'static pgx::cstr_core::CStr {
     todo!()
 }
 
@@ -738,7 +738,7 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
 
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<#name #generics> {
+            pub fn #funcname_in #generics(input: Option<&#lifetime ::pgx::cstr_core::CStr>) -> Option<#name #generics> {
                 input.map_or_else(|| {
                     for m in <#name as ::pgx::JsonInOutFuncs>::NULL_ERROR_MESSAGE {
                         ::pgx::error!("{}", m);
@@ -749,7 +749,7 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
 
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_out #generics(input: #name #generics) -> &#lifetime ::core::ffi::CStr {
+            pub fn #funcname_out #generics(input: #name #generics) -> &#lifetime ::pgx::cstr_core::CStr {
                 let mut buffer = ::pgx::StringInfo::new();
                 ::pgx::JsonInOutFuncs::output(&input, &mut buffer);
                 buffer.into()
@@ -761,7 +761,7 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
         stream.extend(quote! {
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<#name #generics> {
+            pub fn #funcname_in #generics(input: Option<&#lifetime ::pgx::cstr_core::CStr>) -> Option<#name #generics> {
                 input.map_or_else(|| {
                     for m in <#name as ::pgx::InOutFuncs>::NULL_ERROR_MESSAGE {
                         ::pgx::error!("{}", m);
@@ -772,7 +772,7 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
 
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_out #generics(input: #name #generics) -> &#lifetime ::core::ffi::CStr {
+            pub fn #funcname_out #generics(input: #name #generics) -> &#lifetime ::pgx::cstr_core::CStr {
                 let mut buffer = ::pgx::StringInfo::new();
                 ::pgx::InOutFuncs::output(&input, &mut buffer);
                 buffer.into()
@@ -783,7 +783,7 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
         stream.extend(quote! {
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<::pgx::PgVarlena<#name #generics>> {
+            pub fn #funcname_in #generics(input: Option<&#lifetime ::pgx::cstr_core::CStr>) -> Option<::pgx::PgVarlena<#name #generics>> {
                 input.map_or_else(|| {
                     for m in <#name as ::pgx::PgVarlenaInOutFuncs>::NULL_ERROR_MESSAGE {
                         ::pgx::error!("{}", m);
@@ -794,7 +794,7 @@ fn impl_postgres_type(ast: DeriveInput) -> proc_macro2::TokenStream {
 
             #[doc(hidden)]
             #[pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_out #generics(input: ::pgx::PgVarlena<#name #generics>) -> &#lifetime ::core::ffi::CStr {
+            pub fn #funcname_out #generics(input: ::pgx::PgVarlena<#name #generics>) -> &#lifetime ::pgx::cstr_core::CStr {
                 let mut buffer = ::pgx::StringInfo::new();
                 ::pgx::PgVarlenaInOutFuncs::output(&*input, &mut buffer);
                 buffer.into()

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -42,6 +42,7 @@ pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.6.0-alpha.0" }
 pgx-utils = { path = "../pgx-utils/", version = "=0.6.0-alpha.0" }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
+rayon = "1.5.3"
 syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgx-tests/src/tests/fcinfo_tests.rs
+++ b/pgx-tests/src/tests/fcinfo_tests.rs
@@ -133,7 +133,7 @@ fn fcinfo_not_named_no_arg(fcinfo: pg_sys::FunctionCallInfo) -> i32 {
 pub struct NullStrict {}
 
 impl InOutFuncs for NullStrict {
-    fn input(_input: &core::ffi::CStr) -> Self
+    fn input(_input: &pgx::cstr_core::CStr) -> Self
     where
         Self: Sized,
     {
@@ -149,7 +149,7 @@ impl InOutFuncs for NullStrict {
 pub struct NullError {}
 
 impl InOutFuncs for NullError {
-    fn input(_input: &core::ffi::CStr) -> Self
+    fn input(_input: &pgx::cstr_core::CStr) -> Self
     where
         Self: Sized,
     {

--- a/pgx-tests/src/tests/postgres_type_tests.rs
+++ b/pgx-tests/src/tests/postgres_type_tests.rs
@@ -6,7 +6,7 @@ All rights reserved.
 
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
-use core::ffi::CStr;
+use pgx::cstr_core::CStr;
 use pgx::prelude::*;
 use pgx::{InOutFuncs, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use serde::{Deserialize, Serialize};

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -15,6 +15,7 @@ syntax-highlighting = ["dep:syntect", "dep:owo-colors"]
 
 [dependencies]
 seq-macro = "0.3"
+cstr_core = "0.2"
 atty = "0.2.14"
 convert_case = "0.5.0"
 eyre = "0.6.8"

--- a/pgx-utils/src/sql_entity_graph/metadata/sql_translatable.rs
+++ b/pgx-utils/src/sql_entity_graph/metadata/sql_translatable.rs
@@ -322,7 +322,7 @@ unsafe impl SqlTranslatable for f64 {
     }
 }
 
-unsafe impl SqlTranslatable for &'static core::ffi::CStr {
+unsafe impl SqlTranslatable for std::ffi::CStr {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("cstring"))
     }
@@ -331,7 +331,25 @@ unsafe impl SqlTranslatable for &'static core::ffi::CStr {
     }
 }
 
-unsafe impl SqlTranslatable for core::ffi::CStr {
+unsafe impl SqlTranslatable for &'static std::ffi::CStr {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("cstring"))
+    }
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("cstring")))
+    }
+}
+
+unsafe impl SqlTranslatable for &'static cstr_core::CStr {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("cstring"))
+    }
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("cstring")))
+    }
+}
+
+unsafe impl SqlTranslatable for cstr_core::CStr {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("cstring"))
     }

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -53,6 +53,7 @@ tracing-error = "0.2.0"
 atomic-traits = "0.3.0" # PgAtomic and shmem init
 bitflags = "1.3.2" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
+cstr_core = "0.2.6" # no std compat
 heapless = "0.7.16" # shmem and PgLwLock
 libc = "0.2.137" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -13,6 +13,7 @@ use crate::{
     pg_sys, text_to_rust_str_unchecked, varlena_to_byte_slice, AllocatedByPostgres, IntoDatum,
     PgBox, PgMemoryContexts,
 };
+use std::ffi::CStr;
 use std::num::NonZeroUsize;
 
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
@@ -337,17 +338,32 @@ impl FromDatum for char {
 }
 
 /// for cstring
-impl<'a> FromDatum for &'a core::ffi::CStr {
+impl<'a> FromDatum for &'a std::ffi::CStr {
     #[inline]
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
         _: pg_sys::Oid,
-    ) -> Option<&'a core::ffi::CStr> {
+    ) -> Option<&'a CStr> {
         if is_null || datum.is_null() {
             None
         } else {
-            Some(core::ffi::CStr::from_ptr(datum.cast_mut_ptr()))
+            Some(std::ffi::CStr::from_ptr(datum.cast_mut_ptr()))
+        }
+    }
+}
+
+impl<'a> FromDatum for &'a crate::cstr_core::CStr {
+    #[inline]
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<&'a crate::cstr_core::CStr> {
+        if is_null || datum.is_null() {
+            None
+        } else {
+            Some(crate::cstr_core::CStr::from_ptr(datum.cast_mut_ptr()))
         }
     }
 }

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -307,7 +307,18 @@ impl IntoDatum for char {
 /// ## Safety
 ///
 /// The `&CStr` better be allocated by Postgres
-impl<'a> IntoDatum for &'a core::ffi::CStr {
+impl<'a> IntoDatum for &'a std::ffi::CStr {
+    #[inline]
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        Some(self.as_ptr().into())
+    }
+
+    fn type_oid() -> u32 {
+        pg_sys::CSTRINGOID
+    }
+}
+
+impl<'a> IntoDatum for &'a crate::cstr_core::CStr {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         Some(self.as_ptr().into())

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -67,7 +67,7 @@ impl Clone for PallocdVarlena {
 /// }
 ///
 /// impl PgVarlenaInOutFuncs for MyType {
-///     fn input(input: &core::ffi::CStr) -> PgVarlena<Self> {
+///     fn input(input: &pgx::cstr_core::CStr) -> PgVarlena<Self> {
 ///         let mut iter = input.to_str().unwrap().split(',');
 ///         let (a, b, c) = (iter.next(), iter.next(), iter.next());
 ///

--- a/pgx/src/inoutfuncs.rs
+++ b/pgx/src/inoutfuncs.rs
@@ -21,7 +21,7 @@ pub trait PgVarlenaInOutFuncs {
     /// Given a string representation of `Self`, parse it into a `PgVarlena<Self>`.
     ///
     /// It is expected that malformed input will raise an `error!()` or `panic!()`
-    fn input(input: &core::ffi::CStr) -> PgVarlena<Self>
+    fn input(input: &crate::cstr_core::CStr) -> PgVarlena<Self>
     where
         Self: Copy + Sized;
 
@@ -39,7 +39,7 @@ pub trait InOutFuncs {
     /// Given a string representation of `Self`, parse it into `Self`.
     ///
     /// It is expected that malformed input will raise an `error!()` or `panic!()`
-    fn input(input: &core::ffi::CStr) -> Self
+    fn input(input: &crate::cstr_core::CStr) -> Self
     where
         Self: Sized;
 
@@ -55,7 +55,7 @@ pub trait InOutFuncs {
 /// **not** also have the `#[inoutfuncs]` attribute macro
 pub trait JsonInOutFuncs<'de>: serde::de::Deserialize<'de> + serde::ser::Serialize {
     /// Uses `serde_json` to deserialize the input, which is assumed to be JSON
-    fn input(input: &'de core::ffi::CStr) -> Self {
+    fn input(input: &'de crate::cstr_core::CStr) -> Self {
         serde_json::from_str(input.to_str().expect("text input is not valid UTF8"))
             .expect("failed to deserialize json")
     }

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -116,11 +116,7 @@ pub use pg_sys::{
 };
 pub use pgx_utils as utils;
 
-#[deprecated = "Please use the types in `{core,alloc,std}::ffi` instead"]
-pub mod cstr_core {
-    pub use alloc::ffi::{CString, FromVecWithNulError, NulError};
-    pub use core::ffi::{c_char, CStr, FromBytesWithNulError};
-}
+pub use cstr_core;
 
 use once_cell::sync::Lazy;
 use pgx_utils::sql_entity_graph::RustSourceOnlySqlMapping;

--- a/pgx/src/stringinfo.rs
+++ b/pgx/src/stringinfo.rs
@@ -26,13 +26,27 @@ impl From<StringInfo> for pg_sys::StringInfo {
     }
 }
 
-impl From<StringInfo> for &'static core::ffi::CStr {
+impl From<StringInfo> for &'static std::ffi::CStr {
     fn from(val: StringInfo) -> Self {
         let len = val.len();
         let ptr = val.into_char_ptr();
 
         unsafe {
-            core::ffi::CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
+            std::ffi::CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
+                ptr as *const u8,
+                (len + 1) as usize, // +1 to get the trailing null byte
+            ))
+        }
+    }
+}
+
+impl From<StringInfo> for &'static crate::cstr_core::CStr {
+    fn from(val: StringInfo) -> Self {
+        let len = val.len();
+        let ptr = val.into_char_ptr();
+
+        unsafe {
+            crate::cstr_core::CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
                 ptr as *const u8,
                 (len + 1) as usize, // +1 to get the trailing null byte
             ))

--- a/pgx/src/trigger_support/pg_trigger.rs
+++ b/pgx/src/trigger_support/pg_trigger.rs
@@ -6,7 +6,7 @@ use crate::trigger_support::{
     called_as_trigger, PgTriggerError, PgTriggerLevel, PgTriggerOperation, PgTriggerSafe,
     PgTriggerWhen, TriggerEvent, TriggerTuple,
 };
-use core::ffi::c_char;
+use cstr_core::c_char;
 use std::borrow::Borrow;
 
 /**
@@ -96,7 +96,7 @@ impl PgTrigger {
         // containing a known good `TriggerData` which also contains a known good `Trigger`... and the user aggreed to
         // our `unsafe` constructor safety rules, we choose to trust this is indeed a valid pointer offered to us by
         // PostgreSQL, and that it trusts it.
-        let name_cstr = unsafe { core::ffi::CStr::from_ptr(name_ptr) };
+        let name_cstr = unsafe { cstr_core::CStr::from_ptr(name_ptr) };
         let name_str = name_cstr.to_str()?;
         Ok(name_str)
     }
@@ -136,7 +136,7 @@ impl PgTrigger {
             // containing a known good `TriggerData` which also contains a known good `Trigger`... and the user aggreed to
             // our `unsafe` constructor safety rules, we choose to trust this is indeed a valid pointer offered to us by
             // PostgreSQL, and that it trusts it.
-            let table_name_cstr = unsafe { core::ffi::CStr::from_ptr(tgoldtable) };
+            let table_name_cstr = unsafe { cstr_core::CStr::from_ptr(tgoldtable) };
             let table_name_str = table_name_cstr.to_str()?;
             Ok(Some(table_name_str))
         } else {
@@ -152,7 +152,7 @@ impl PgTrigger {
             // containing a known good `TriggerData` which also contains a known good `Trigger`... and the user aggreed to
             // our `unsafe` constructor safety rules, we choose to trust this is indeed a valid pointer offered to us by
             // PostgreSQL, and that it trusts it.
-            let table_name_cstr = unsafe { core::ffi::CStr::from_ptr(tgnewtable) };
+            let table_name_cstr = unsafe { cstr_core::CStr::from_ptr(tgnewtable) };
             let table_name_str = table_name_cstr.to_str()?;
             Ok(Some(table_name_str))
         } else {
@@ -222,7 +222,7 @@ impl PgTrigger {
                 // containing a known good `TriggerData` which also contains a known good `Trigger`... and the user aggreed to
                 // our `unsafe` constructor safety rules, we choose to trust this is indeed a valid pointer offered to us by
                 // PostgreSQL, and that it trusts it.
-                unsafe { core::ffi::CStr::from_ptr(*v) }.to_str().map(ToString::to_string)
+                unsafe { cstr_core::CStr::from_ptr(*v) }.to_str().map(ToString::to_string)
             })
             .collect::<Result<_, core::str::Utf8Error>>()?;
         Ok(args)


### PR DESCRIPTION
I'd prefer we didn't keep `core_cstr` in 0.6.0, since removing it is a breaking change, but...