### PR TITLE
Aarch64 compatibility fix 

### DIFF
--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -260,7 +260,7 @@ macro_rules! pg_magic_func {
                 abi_extra: {
                     // array::from_fn isn't const yet, boohoo, so const-copy a bstr
                     let magic = b"PostgreSQL";
-                    let mut abi = [0 as std::os::raw::c_char; 32];
+                    let mut abi = [0 as libc::c_char; 32];
                     let mut i = 0;
                     while i < magic.len() {
                         abi[i] = magic[i] as _;

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -260,7 +260,7 @@ macro_rules! pg_magic_func {
                 abi_extra: {
                     // array::from_fn isn't const yet, boohoo, so const-copy a bstr
                     let magic = b"PostgreSQL";
-                    let mut abi = [0 as i8; 32];
+                    let mut abi = [0 as std::os::raw::c_char; 32];
                     let mut i = 0;
                     while i < magic.len() {
                         abi[i] = magic[i] as _;


### PR DESCRIPTION
Builds error out on `aarch64` when using `pg_module_magic` as c_char is aliased to `u8` on linux/arm64, whereas it's `i8` on linux/amd64

* c_char definition here: https://doc.rust-lang.org/src/core/ffi/mod.rs.html#104-156

```
"error[E0308]: mismatched types", 
"  --> src/lib.rs:16:1", 
"   |", 
"16 | pg_module_magic!();", 
"   | ^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`", 
"   |", "   = note: expected array `[u8; 32]`", 
"              found array `[i8; 32]`", "   = note: this error originates in the macro `$crate::pg_magic_func` which comes from the expansion of the macro `pg_module_magic`
```