### PR TITLE
Add a Rust version check to cargo-pgx

### DIFF
--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -55,6 +55,7 @@ SUBCOMMANDS:
 - `PGX_BUILD_FLAGS` - If set during `cargo pgx run/test/install`, these additional flags are passed to `cargo build` while building the extension
 - `PGX_BUILD_VERBOSE` - Set to true to enable verbose "build.rs" output -- useful for debugging build issues
 - `HTTPS_PROXY` - If set during `cargo pgx init`, it will download the Postgres sources using these proxy settings. For more details refer to the [env_proxy crate documentation](https://docs.rs/env_proxy/*/env_proxy/fn.for_url.html).
+- `PGX_IGNORE_RUST_VERSIONS` - Set to true to disable the `rustc` version check we have when performing schema generation (schema generation requires the same version of `rustc` be used to build `cargo-pgx` as the crate in question).
 
 ## First Time Initialization
 

--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -803,3 +803,30 @@ Postgres, so loading two versions of the shared library will cause trouble.
 These scenarios are:
 - when using shared memory
 - when using query planner hooks
+
+## Compiler Version Dependence
+
+The version of the Rust compiler and toolchain used to build `cargo-pgx` must be
+the same as the version used to build your extension.
+
+Several subcommands (including `cargo pgx schema`, `cargo pgx test`, `cargo pgx
+install`, ...) will produce an error message if these do not match.
+
+Although this may be relaxed in the future, currently schema generation involves
+`dlopen`ing the extension and calling `extern "Rust"` functions on
+`#[repr(Rust)]` types. Generally, the appropriate way to fix this is reinstall
+`cargo-pgx`, using a command like the following
+
+```shell script
+$ cargo install --locked cargo-pgx
+```
+
+Possibly with a explicit `--version`, if needed.
+
+If you are certain that in this case, it is fine, you may set
+`PGX_IGNORE_RUST_VERSIONS` in the environment (to any value other than `"0"`),
+and the check will be bypassed. However, note that while the check is not
+fool-proof, it tries to be fairly liberal in what it allows.
+
+See <https://github.com/tcdi/pgx/issues/774> and <https://github.com/tcdi/pgx/pull/873>
+for further information.

--- a/cargo-pgx/README.md
+++ b/cargo-pgx/README.md
@@ -818,7 +818,7 @@ Although this may be relaxed in the future, currently schema generation involves
 `cargo-pgx`, using a command like the following
 
 ```shell script
-$ cargo install --locked cargo-pgx
+$ cargo install --force --locked cargo-pgx
 ```
 
 Possibly with a explicit `--version`, if needed.

--- a/cargo-pgx/build.rs
+++ b/cargo-pgx/build.rs
@@ -1,0 +1,18 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if let Some(minor_version) = rust_minor_version() {
+        println!("cargo:rustc-env=MINOR_RUST_VERSION={minor_version}");
+    }
+}
+
+fn rust_minor_version() -> Option<u32> {
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let output = std::process::Command::new(rustc).arg("--version").output().ok()?;
+    let version = std::str::from_utf8(&output.stdout).ok()?;
+    let mut iter = version.split('.');
+    if iter.next() != Some("rustc 1") {
+        None
+    } else {
+        iter.next()?.parse().ok()
+    }
+}


### PR DESCRIPTION
I had done part of this a while ago, and it came up recently, so I cleaned it off.

Fixes #774, although in the future I would like to relax this requirement and remove this check.

It does not detect mismatches between 1.x.0 and 1.x.1 (which should be fine), or between different betas/nightlies (which is probably strictly required, but would be personally pretty annoying for me).

It tends to ignore errors rather than failing, in case something in the output of one of the tools changes (unlikely, given how much of the ecosystem uses checks like this). There's also an escape-hatch environment variable called `PGX_IGNORE_RUST_VERSIONS` to disable the check.

I only check in the schema generation code, since that's the only code that needs to care about this.