### PR TITLE
Use dlmopen to load the extension on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "env_proxy",
  "eyre",
  "fork",
+ "libc",
  "libloading",
  "num_cpus",
  "object 0.28.4",

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -46,6 +46,7 @@ color-eyre = "0.6.2"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+libc = "0.2"
 
 [features]
 default = ["ureq/native-tls"]


### PR DESCRIPTION
Hopes to address https://github.com/tcdi/plrust/issues/119, but I haven't checked yet. Pretty hairy, and needs more testing than it has gotten

As I've mentioned, I'd really like us to use a different method than `dlm?open` for this (we should put info we need for schema generation in special link-sections, and then grab them using `object`, so we never need to actually load the extension), but that's a way larger project.