### PR TITLE
Reference-counted SpiClient

### DIFF
--- a/pgx-examples/spi/src/lib.rs
+++ b/pgx-examples/spi/src/lib.rs
@@ -42,16 +42,11 @@ fn spi_return_query(
     #[cfg(feature = "pg15")]
     let query = "SELECT oid, relname::text || '-pg15' FROM pg_class";
 
-    let mut results = Vec::new();
-    Spi::connect(|client| {
-        client
-            .select(query, None, None)
-            .map(|row| (row["oid"].value(), row[2].value()))
-            .for_each(|tuple| results.push(tuple));
-        Ok(Some(()))
-    });
+    let client = Spi::client().unwrap();
 
-    TableIterator::new(results.into_iter())
+    TableIterator::new(
+        client.select(query, None, None).map(|row| (row["oid"].value(), row[2].value())),
+    )
 }
 
 #[pg_extern(immutable, parallel_safe)]

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -216,4 +216,16 @@ mod tests {
         struct T;
         assert!(matches!(Spi::connect(|_| Ok(Some(T))).unwrap(), T));
     }
+
+    #[pg_test]
+    fn test_client() {
+        use pgx::SpiError;
+        let client = Spi::client().unwrap();
+        assert!(matches!(client.select("SELECT 1", None, None).first().get_one::<i32>(), Some(1)));
+        let client1 = client.clone();
+        assert!(matches!(client1.select("SELECT 1", None, None).first().get_one::<i32>(), Some(1)));
+
+        // Can create another client
+        assert!(Spi::client().is_ok());
+    }
 }


### PR DESCRIPTION
Problem: Spi::connect is rather limiting

It restricts the signature of the return type. Furthermore, it makes it much more difficult to re-use an existing connection safely as the only way to do so is to create an instance of `SpiClient` manually. However, once we're out of the closure, the connection will be dropped, and code that relies on that other instance of `SpiClient` will fail.

Solution: introduce reference-counted client instances

Without breaking _documented_ API, this change adds `Spi::client()` function that returns a reference-counted instance of `SpiClient` that will finalize the connection when there are no more clones of it left, making it much easier to have greater control over the control flow.

It _does_ break the API because one can no longer instantiate `SpiClient` themselves (without using `Spi` API surface). However, this is an error-prone technique that should rather be avoided.