### PR TITLE
Avoid some clippy warnings in macro-generated code

### DIFF
--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -311,7 +311,9 @@ impl PgExtern {
                     file: file!(),
                     line: line!(),
                     extern_attrs: vec![#extern_attrs],
+                    #[allow(clippy::or_fun_call)]
                     search_path: None #( .unwrap_or_else(|| Some(vec![#search_path])) )*,
+                    #[allow(clippy::or_fun_call)]
                     operator: None #( .unwrap_or_else(|| Some(#operator)) )*,
                     to_sql_config: #to_sql_config,
                 };

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -306,12 +306,12 @@ impl PgExtern {
                     metadata: pgx::utils::sql_entity_graph::metadata::FunctionMetadata::entity(&metadata),
                     fn_args: vec![#(#inputs_iter),*],
                     fn_return: #returns,
-                    schema: None #( .unwrap_or(Some(#schema_iter)) )*,
+                    schema: None #( .unwrap_or_else(|| Some(#schema_iter)) )*,
                     file: file!(),
                     line: line!(),
                     extern_attrs: vec![#extern_attrs],
-                    search_path: None #( .unwrap_or(Some(vec![#search_path])) )*,
-                    operator: None #( .unwrap_or(Some(#operator)) )*,
+                    search_path: None #( .unwrap_or_else(|| Some(vec![#search_path])) )*,
+                    operator: None #( .unwrap_or_else(|| Some(#operator)) )*,
                     to_sql_config: #to_sql_config,
                 };
                 ::pgx::utils::sql_entity_graph::SqlGraphEntity::Function(submission)
@@ -621,7 +621,7 @@ impl PgExtern {
                                 let datum = pgx::heap_tuple_get_datum(heap_tuple);
                                 // SAFETY: what is an srf if it does not return?
                                 unsafe { pgx::srf_return_next(#fcinfo_ident, &mut funcctx) };
-                                pgx::pg_sys::Datum::from(datum)
+                                datum
                             },
                             None => {
                                 // leak the iterator here too, even tho we're done, b/c our MemoryContextCallback

--- a/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/mod.rs
@@ -306,6 +306,7 @@ impl PgExtern {
                     metadata: pgx::utils::sql_entity_graph::metadata::FunctionMetadata::entity(&metadata),
                     fn_args: vec![#(#inputs_iter),*],
                     fn_return: #returns,
+                    #[allow(clippy::or_fun_call)]
                     schema: None #( .unwrap_or_else(|| Some(#schema_iter)) )*,
                     file: file!(),
                     line: line!(),


### PR DESCRIPTION
Problem: clippy warnings in macro-generated code

First one on any `#[pg_extern]` function:

```
warning: use of `unwrap_or` followed by a function call
   --> src/lib.rs:LINE:1
    |
496 | fn function_name(...) -> ... {
    | ^^ help: try this: `unwrap_or_else(|| fn)`
```

The other one on SRF functions:

```
warning: useless conversion to the same type: `pgx::pgx_pg_sys::Datum`
 --> src/lib.rs:6:1
  |
6 | fn random_values(num_rows: i32) -> TableIterator<'static, (name!(index, i32), name!(value, f64))> {
  | ^^ help: consider removing `fn()`: `fn`
  |
  = note: `#[warn(clippy::useless_conversion)]` on by default
```

Having these warnings may obscure other warnings that may be of higher importance.

Solution: improve macros' output to avoid these warnings