### PR TITLE
Don't use `addr_of!` to compare function pointers

### DIFF
--- a/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
@@ -105,33 +105,24 @@ impl ToSqlConfigEntity {
         None
     }
 }
+
 impl std::cmp::PartialEq for ToSqlConfigEntity {
     fn eq(&self, other: &Self) -> bool {
-        if self.enabled != other.enabled {
-            return false;
-        }
-        match (self.callback, other.callback) {
-            (None, None) => match (self.content, other.content) {
-                (None, None) => true,
-                (Some(a), Some(b)) => a == b,
-                _ => false,
-            },
-            (Some(a), Some(b)) => std::ptr::eq(std::ptr::addr_of!(a), std::ptr::addr_of!(b)),
-            _ => false,
-        }
+        (self.enabled, self.content, self.callback.map(|f| f as usize))
+            == (other.enabled, other.content, other.callback.map(|f| f as usize))
     }
 }
 impl std::cmp::Eq for ToSqlConfigEntity {}
 impl std::hash::Hash for ToSqlConfigEntity {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.enabled.hash(state);
-        self.callback.map(|cb| std::ptr::addr_of!(cb)).hash(state);
+        self.callback.map(|cb| cb as usize).hash(state);
         self.content.hash(state);
     }
 }
 impl std::fmt::Debug for ToSqlConfigEntity {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let callback = self.callback.map(|cb| std::ptr::addr_of!(cb));
+        let callback = self.callback.map(|cb| cb as usize);
         f.debug_struct("ToSqlConfigEntity")
             .field("enabled", &self.enabled)
             .field("callback", &format_args!("{:?}", &callback))


### PR DESCRIPTION
I happened to notice this earlier today. This doesn't seem to cause any issues at the moment, but is certainly wrong, so I figured this might save someone some time debugging if that changes.

When used like this, `addr_of!` will just return the address of the local variable on the stack, rather than the address of the function (see https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=4b18ae036c8b6de99c767e395e09b924). To get the address of the function, we can just use an `as` cast (or transmute, I suppose, but we don't care to round-trip through the integer, so there's no worries about using the `as` from a provenance perspective).

This is still imperfect, as function pointers that are not assigned to `static`s are allowed to be duplicated (and thus may return false even if they are the same), but in practice this isn't terribly common, and it's not like we have an alternative.

I also simplified the `PartialEq` implementation while I was here.