### PR TITLE
Fix `pgx_utils::sql_entity_graph` Eq/PartialEq/Ord/PartialOrd/Hash impls.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
+ "rustc-hash",
  "seq-macro",
  "serde",
  "serde_derive",

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -20,7 +20,6 @@ use pgx_utils::*;
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use quote::{quote, ToTokens};
-use std::collections::HashSet;
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, Attribute, Data, DeriveInput, Item, ItemImpl};
 
@@ -898,8 +897,8 @@ enum PostgresTypeAttribute {
     Default,
 }
 
-fn parse_postgres_type_args(attributes: &[Attribute]) -> HashSet<PostgresTypeAttribute> {
-    let mut categorized_attributes = HashSet::new();
+fn parse_postgres_type_args(attributes: &[Attribute]) -> FastHashSet<PostgresTypeAttribute> {
+    let mut categorized_attributes = FastHashSet::default();
 
     for a in attributes {
         let path = &a.path;

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -33,3 +33,4 @@ unescape = "0.1.0"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+rustc-hash = "1.1.0"

--- a/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/aggregate/entity.rs
@@ -22,16 +22,15 @@ use crate::sql_entity_graph::to_sql::entity::ToSqlConfigEntity;
 use crate::sql_entity_graph::to_sql::ToSql;
 use crate::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier, UsedTypeEntity};
 use core::any::TypeId;
-use core::cmp::Ordering;
 use eyre::{eyre, WrapErr};
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AggregateTypeEntity {
     pub used_ty: UsedTypeEntity,
     pub name: Option<&'static str>,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PgAggregateEntity {
     pub full_path: &'static str,
     pub module_path: &'static str,
@@ -145,18 +144,6 @@ pub struct PgAggregateEntity {
     /// Corresponds to `hypothetical` in [`pgx::aggregate::Aggregate`].
     pub hypothetical: bool,
     pub to_sql_config: ToSqlConfigEntity,
-}
-
-impl Ord for PgAggregateEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.file.cmp(other.full_path).then_with(|| self.file.cmp(other.full_path))
-    }
-}
-
-impl PartialOrd for PgAggregateEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl From<PgAggregateEntity> for SqlGraphEntity {

--- a/pgx-utils/src/sql_entity_graph/control_file.rs
+++ b/pgx-utils/src/sql_entity_graph/control_file.rs
@@ -15,8 +15,8 @@ to the `pgx` framework and very subject to change between versions. While you ma
 
 */
 use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
+use crate::FastHashMap;
 use core::convert::TryFrom;
-use std::collections::HashMap;
 use tracing_error::SpanTrace;
 
 /// The parsed contents of a `.control` file.
@@ -53,7 +53,7 @@ impl ControlFile {
     /// ```
     #[tracing::instrument(level = "error")]
     pub fn from_str(input: &str) -> Result<Self, ControlFileError> {
-        let mut temp = HashMap::new();
+        let mut temp = FastHashMap::default();
         for line in input.lines() {
             let parts: Vec<&str> = line.split('=').collect();
 

--- a/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_extern/entity/mod.rs
@@ -30,10 +30,9 @@ use crate::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier};
 use crate::ExternArgs;
 
 use eyre::{eyre, WrapErr};
-use std::cmp::Ordering;
 
 /// The output of a [`PgExtern`](crate::sql_entity_graph::pg_extern::PgExtern) from `quote::ToTokens::to_tokens`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct PgExternEntity {
     pub name: &'static str,
     pub unaliased_name: &'static str,
@@ -49,32 +48,6 @@ pub struct PgExternEntity {
     pub search_path: Option<Vec<&'static str>>,
     pub operator: Option<PgOperatorEntity>,
     pub to_sql_config: ToSqlConfigEntity,
-}
-
-impl std::hash::Hash for PgExternEntity {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.full_path.hash(state);
-    }
-}
-
-impl PartialEq for PgExternEntity {
-    fn eq(&self, other: &Self) -> bool {
-        self.full_path.eq(other.full_path)
-    }
-}
-
-impl Eq for PgExternEntity {}
-
-impl Ord for PgExternEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.full_path.cmp(&other.full_path)
-    }
-}
-
-impl PartialOrd for PgExternEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl From<PgExternEntity> for SqlGraphEntity {

--- a/pgx-utils/src/sql_entity_graph/pg_trigger/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/pg_trigger/entity.rs
@@ -9,11 +9,8 @@ to the `pgx` framework and very subject to change between versions. While you ma
 use crate::sql_entity_graph::{
     PgxSql, SqlGraphEntity, SqlGraphIdentifier, ToSql, ToSqlConfigEntity,
 };
-use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use core::fmt::Debug;
-use core::hash::Hash;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PgTriggerEntity {
     pub function_name: &'static str,
     pub to_sql_config: ToSqlConfigEntity,
@@ -26,18 +23,6 @@ pub struct PgTriggerEntity {
 impl PgTriggerEntity {
     fn wrapper_function_name(&self) -> String {
         self.function_name.to_string() + "_wrapper"
-    }
-}
-
-impl Ord for PgTriggerEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.full_path.cmp(other.full_path)
-    }
-}
-
-impl PartialOrd for PgTriggerEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/entity.rs
@@ -19,39 +19,19 @@ use crate::sql_entity_graph::pgx_sql::PgxSql;
 use crate::sql_entity_graph::to_sql::entity::ToSqlConfigEntity;
 use crate::sql_entity_graph::to_sql::ToSql;
 use crate::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier};
-
-use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
+use std::collections::BTreeSet;
 
 /// The output of a [`PostgresEnum`](crate::sql_entity_graph::postgres_enum::PostgresEnum) from `quote::ToTokens::to_tokens`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct PostgresEnumEntity {
     pub name: &'static str,
     pub file: &'static str,
     pub line: u32,
     pub full_path: &'static str,
     pub module_path: &'static str,
-    pub mappings: std::collections::HashSet<RustSqlMapping>,
+    pub mappings: BTreeSet<RustSqlMapping>,
     pub variants: Vec<&'static str>,
     pub to_sql_config: ToSqlConfigEntity,
-}
-
-impl Hash for PostgresEnumEntity {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.full_path.hash(state);
-    }
-}
-
-impl Ord for PostgresEnumEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.file.cmp(other.file).then_with(|| self.file.cmp(other.file))
-    }
-}
-
-impl PartialOrd for PostgresEnumEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl PostgresEnumEntity {

--- a/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_enum/mod.rs
@@ -161,7 +161,7 @@ impl ToTokens for PostgresEnum {
                     line: line!(),
                     module_path: module_path!(),
                     full_path: core::any::type_name::<#name #static_ty_generics>(),
-                    mappings,
+                    mappings: mappings.into_iter().collect(),
                     variants: vec![ #(  stringify!(#variants)  ),* ],
                     to_sql_config: #to_sql_config,
                 };

--- a/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_hash/entity.rs
@@ -18,10 +18,9 @@ use crate::sql_entity_graph::pgx_sql::PgxSql;
 use crate::sql_entity_graph::to_sql::entity::ToSqlConfigEntity;
 use crate::sql_entity_graph::to_sql::ToSql;
 use crate::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier};
-use std::cmp::Ordering;
 
 /// The output of a [`PostgresHash`](crate::sql_entity_graph::postgres_hash::PostgresHash) from `quote::ToTokens::to_tokens`.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PostgresHashEntity {
     pub name: &'static str,
     pub file: &'static str,
@@ -35,18 +34,6 @@ pub struct PostgresHashEntity {
 impl PostgresHashEntity {
     pub(crate) fn fn_name(&self) -> String {
         format!("{}_hash", self.name.to_lowercase())
-    }
-}
-
-impl Ord for PostgresHashEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.file.cmp(other.file).then_with(|| self.file.cmp(other.file))
-    }
-}
-
-impl PartialOrd for PostgresHashEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_ord/entity.rs
@@ -18,10 +18,9 @@ use crate::sql_entity_graph::pgx_sql::PgxSql;
 use crate::sql_entity_graph::to_sql::entity::ToSqlConfigEntity;
 use crate::sql_entity_graph::to_sql::ToSql;
 use crate::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier};
-use std::cmp::Ordering;
 
 /// The output of a [`PostgresOrd`](crate::sql_entity_graph::postgres_ord::PostgresOrd) from `quote::ToTokens::to_tokens`.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct PostgresOrdEntity {
     pub name: &'static str,
     pub file: &'static str,
@@ -55,18 +54,6 @@ impl PostgresOrdEntity {
 
     pub(crate) fn ge_fn_name(&self) -> String {
         format!("{}_ge", self.name.to_lowercase())
-    }
-}
-
-impl Ord for PostgresOrdEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.file.cmp(other.file).then_with(|| self.file.cmp(other.file))
-    }
-}
-
-impl PartialOrd for PostgresOrdEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/entity.rs
@@ -19,43 +19,23 @@ use crate::sql_entity_graph::pgx_sql::PgxSql;
 use crate::sql_entity_graph::to_sql::entity::ToSqlConfigEntity;
 use crate::sql_entity_graph::to_sql::ToSql;
 use crate::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier};
-
 use eyre::eyre;
-use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
+use std::collections::BTreeSet;
 
 /// The output of a [`PostgresType`](crate::sql_entity_graph::postgres_type::PostgresType) from `quote::ToTokens::to_tokens`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct PostgresTypeEntity {
     pub name: &'static str,
     pub file: &'static str,
     pub line: u32,
     pub full_path: &'static str,
     pub module_path: &'static str,
-    pub mappings: std::collections::HashSet<RustSqlMapping>,
+    pub mappings: BTreeSet<RustSqlMapping>,
     pub in_fn: &'static str,
     pub in_fn_module_path: String,
     pub out_fn: &'static str,
     pub out_fn_module_path: String,
     pub to_sql_config: ToSqlConfigEntity,
-}
-
-impl Hash for PostgresTypeEntity {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.full_path.hash(state);
-    }
-}
-
-impl Ord for PostgresTypeEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.file.cmp(other.file).then_with(|| self.file.cmp(other.file))
-    }
-}
-
-impl PartialOrd for PostgresTypeEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl PostgresTypeEntity {

--- a/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
+++ b/pgx-utils/src/sql_entity_graph/postgres_type/mod.rs
@@ -195,7 +195,7 @@ impl ToTokens for PostgresType {
                     line: line!(),
                     module_path: module_path!(),
                     full_path: core::any::type_name::<#name #static_ty_generics>(),
-                    mappings,
+                    mappings: mappings.into_iter().collect(),
                     in_fn: stringify!(#in_fn),
                     in_fn_module_path: {
                         let in_fn = stringify!(#in_fn);

--- a/pgx-utils/src/sql_entity_graph/schema/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/schema/entity.rs
@@ -18,27 +18,13 @@ use crate::sql_entity_graph::pgx_sql::PgxSql;
 use crate::sql_entity_graph::to_sql::ToSql;
 use crate::sql_entity_graph::{SqlGraphEntity, SqlGraphIdentifier};
 
-use std::cmp::Ordering;
-
 /// The output of a [`Schema`](crate::sql_entity_graph::schema::Schema) from `quote::ToTokens::to_tokens`.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct SchemaEntity {
     pub module_path: &'static str,
     pub name: &'static str,
     pub file: &'static str,
     pub line: u32,
-}
-
-impl Ord for SchemaEntity {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.file.cmp(other.file).then_with(|| self.file.cmp(other.file))
-    }
-}
-
-impl PartialOrd for SchemaEntity {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl From<SchemaEntity> for SqlGraphEntity {

--- a/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
+++ b/pgx-utils/src/sql_entity_graph/to_sql/entity.rs
@@ -39,6 +39,13 @@ pub struct ToSqlConfigEntity {
     pub content: Option<&'static str>,
 }
 impl ToSqlConfigEntity {
+    /// Helper used to implement traits (`Eq`, `Ord`, etc) despite `ToSqlFn` not
+    /// having an implementation for them.
+    #[inline]
+    fn fields(&self) -> (bool, Option<&str>, Option<usize>) {
+        (self.enabled, self.content, self.callback.map(|f| f as usize))
+    }
+
     /// Given a SqlGraphEntity, this function converts it to SQL based on the current configuration.
     ///
     /// If the config overrides the default behavior (i.e. using the `ToSql` trait), then `Some(eyre::Result)`
@@ -106,27 +113,38 @@ impl ToSqlConfigEntity {
     }
 }
 
-impl std::cmp::PartialEq for ToSqlConfigEntity {
+impl Eq for ToSqlConfigEntity {}
+impl PartialEq for ToSqlConfigEntity {
     fn eq(&self, other: &Self) -> bool {
-        (self.enabled, self.content, self.callback.map(|f| f as usize))
-            == (other.enabled, other.content, other.callback.map(|f| f as usize))
+        self.fields() == other.fields()
     }
 }
-impl std::cmp::Eq for ToSqlConfigEntity {}
+
+impl Ord for ToSqlConfigEntity {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.fields().cmp(&other.fields())
+    }
+}
+
+impl PartialOrd for ToSqlConfigEntity {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.fields().cmp(&other.fields()))
+    }
+}
+
 impl std::hash::Hash for ToSqlConfigEntity {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.enabled.hash(state);
-        self.callback.map(|cb| cb as usize).hash(state);
-        self.content.hash(state);
+        self.fields().hash(state)
     }
 }
+
 impl std::fmt::Debug for ToSqlConfigEntity {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let callback = self.callback.map(|cb| cb as usize);
+        let (enabled, content, callback) = self.fields();
         f.debug_struct("ToSqlConfigEntity")
-            .field("enabled", &self.enabled)
-            .field("callback", &format_args!("{:?}", &callback))
-            .field("content", &self.content)
+            .field("enabled", &enabled)
+            .field("callback", &callback)
+            .field("content", &content)
             .finish()
     }
 }

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -298,7 +298,7 @@ macro_rules! pg_sql_graph_magic {
         #[rustfmt::skip] // explict extern "Rust" is more clear here
         pub extern "Rust" fn __pgx_sql_mappings() -> ::pgx::utils::sql_entity_graph::RustToSqlMapping {
             ::pgx::utils::sql_entity_graph::RustToSqlMapping {
-                rust_source_to_sql: ::pgx::DEFAULT_RUST_SOURCE_TO_SQL.clone(),
+                rust_source_to_sql: ::pgx::DEFAULT_RUST_SOURCE_TO_SQL.iter().cloned().collect(),
             }
         }
 


### PR DESCRIPTION
Currently we have a number of incorrect manual implementations of the `PartialEq`/`Eq`/`PartialOrd`/`Ord`/`Hash` traits in `pgx_utils::sql_entity_graph`, and this fixes them to be derived instead.

1. This required using `BTree{Set,Map}` rather than `Hash{Set,Map}` for types that require implementations of `Ord`, `PartialOrd`, or `Hash`. (This is required because `Hash{Set,Map}` do not implement those traits)

2. For the hashing, this potentially comes with a bit of a performance cost (because now many more fields are hashed). To mitigate this, I switched us to use maps that use [`rustc-hash`](https://crates.io/crates/rustc-hash)'s[^why] `Hasher` which is significantly faster as well as being deterministic[^1]

This is cherry-picked from #892, since it's the only part of that that's worth doing on its own.

[^1]: The item order is still arbitrary, but it does not use randomized seeds.

[^why]: It's already in our dep tree, used by rustc, and on typical workloads (from `#[derive]`d structs and small-ish strings), it's much faster than any Hasher that I've tested, aside from ones that don't hash the whole input.