### PR TITLE
Ensure SpiClient is only used within boundaries of a connection

### DIFF
--- a/pgx-tests/src/tests/bgworker_tests.rs
+++ b/pgx-tests/src/tests/bgworker_tests.rs
@@ -25,7 +25,7 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
     if arg > 0 {
         BackgroundWorker::transaction(|| {
             Spi::run("CREATE TABLE tests.bgworker_test (v INTEGER);");
-            Spi::execute(|mut client| {
+            Spi::execute(|client| {
                 client.update(
                     "INSERT INTO tests.bgworker_test VALUES ($1);",
                     None,
@@ -70,7 +70,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
     };
     while BackgroundWorker::wait_latch(Some(Duration::from_millis(100))) {}
     BackgroundWorker::transaction(|| {
-        Spi::execute(|mut c| {
+        Spi::execute(|c| {
             c.update(
                 "INSERT INTO tests.bgworker_test_return VALUES ($1)",
                 None,

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[pg_test]
     fn test_inserting_null() {
-        Spi::execute(|mut client| {
+        Spi::execute(|client| {
             client.update("CREATE TABLE tests.null_test (id uuid)", None, None);
         });
         let result = Spi::get_one_with_args::<i32>(
@@ -204,7 +204,7 @@ mod tests {
             assert_eq!(res.column_name(2).unwrap(), "b");
         });
 
-        Spi::execute(|mut client| {
+        Spi::execute(|client| {
             let res = client.update("SET TIME ZONE 'PST8PDT'", None, None);
 
             assert_eq!(0, res.columns());

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[pg_test]
     fn test_srf_setof_datum_detoasting_with_borrow() {
-        let cnt = Spi::connect(|mut client| {
+        let cnt = Spi::connect(|client| {
             // build up a table with one large column that Postgres will be forced to TOAST
             client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None);
 
@@ -195,7 +195,7 @@ mod tests {
 
     #[pg_test]
     fn test_srf_table_datum_detoasting_with_borrow() {
-        let cnt = Spi::connect(|mut client| {
+        let cnt = Spi::connect(|client| {
             // build up a table with one large column that Postgres will be forced to TOAST
             client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None);
 

--- a/pgx-tests/src/tests/struct_type_tests.rs
+++ b/pgx-tests/src/tests/struct_type_tests.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[pg_test]
     fn test_complex_storage_and_retrieval() {
-        let complex = Spi::connect(|mut client| {
+        let complex = Spi::connect(|client| {
             Ok(client.update(
                 "CREATE TABLE complex_test AS SELECT s as id, (s || '.0, 2.0' || s)::complex as value FROM generate_series(1, 1000) s;\
                 SELECT value FROM complex_test ORDER BY id;", None, None).first().get_one::<PgBox<Complex>>())


### PR DESCRIPTION
Problem: SpiClient can created out of thin air and leaked

One can create `SpiClient` when there's no connection.

One can also return it from `connnect`:

```rust
Spi::connect(|client| Ok(Some(client)))
```

Solution: make its construction private and give out a reference

This way it can only be used within `Spi::connect` and friends.