### PR TITLE
SpiClient::update no longer requires &mut self

### DIFF
--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -216,4 +216,15 @@ mod tests {
         struct T;
         assert!(matches!(Spi::connect(|_| Ok(Some(T))).unwrap(), T));
     }
+
+    #[pg_test]
+    fn test_spi_unwind_safe() {
+        Spi::connect(|client| {
+            PgTryBuilder::new(|| {
+                client.update("SELECT 1", None, None);
+            })
+            .execute();
+            Ok(Some(()))
+        });
+    }
 }

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -232,7 +232,7 @@ impl Spi {
     }
 
     /// execute SPI commands via the provided `SpiClient`
-    pub fn execute<F: FnOnce(&mut SpiClient) + std::panic::UnwindSafe>(f: F) {
+    pub fn execute<F: FnOnce(&SpiClient) + std::panic::UnwindSafe>(f: F) {
         Spi::connect(|client| {
             f(client);
             Ok(Some(()))
@@ -241,7 +241,7 @@ impl Spi {
 
     /// execute SPI commands via the provided `SpiClient` and return a value from SPI which is
     /// automatically copied into the `CurrentMemoryContext` at the time of this function call
-    pub fn connect<R, F: FnOnce(&mut SpiClient) -> std::result::Result<Option<R>, SpiError>>(
+    pub fn connect<R, F: FnOnce(&SpiClient) -> std::result::Result<Option<R>, SpiError>>(
         f: F,
     ) -> Option<R> {
         /// a struct to manage our SPI connection lifetime
@@ -270,7 +270,7 @@ impl Spi {
         // just put us un.  We'll disconnect from SPI when the closure is finished.
         // If there's a panic or elog(ERROR), we don't care about also disconnecting from
         // SPI b/c Postgres will do that for us automatically
-        f(&mut SpiClient(())).unwrap()
+        f(&SpiClient(())).unwrap()
     }
 
     pub fn check_status(status_code: i32) -> SpiOk {
@@ -306,7 +306,7 @@ impl SpiClient {
 
     /// perform any query (including utility statements) that modify the database in some way
     pub fn update(
-        &mut self,
+        &self,
         query: &str,
         limit: Option<i64>,
         args: Option<Vec<(PgOid, Option<pg_sys::Datum>)>>,


### PR DESCRIPTION
Problem: &mut SpiClient is not UnwindSafe as a mutable reference

This causes this code to not compile:

```rust
Spi::connect(|client| {
    PgTryBuilder::new(|| {
        client.update("SELECT 1", None, None);
    }).execute();
    Ok(Some(()))
});
```

Solution: let `SpiClient::update` take a non-mutable reference

Strictly speaking, `&mut self` was not necessary there

This is a follow-up to #896