### PR TITLE
`WhoAllocated<T>` doesn't need to be generic over any `T`

### DIFF
--- a/pgx-examples/triggers/src/lib.rs
+++ b/pgx-examples/triggers/src/lib.rs
@@ -26,7 +26,7 @@ enum TriggerError {
 #[pg_trigger]
 fn trigger_example(
     trigger: &pgx::PgTrigger,
-) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, TriggerError> {
+) -> Result<PgHeapTuple<'_, impl WhoAllocated>, TriggerError> {
     let old = trigger.current().ok_or(TriggerError::NullOld)?;
 
     let mut current = old.into_owned();

--- a/pgx-tests/src/tests/trigger_tests.rs
+++ b/pgx-tests/src/tests/trigger_tests.rs
@@ -29,16 +29,14 @@ mod tests {
         #[pg_trigger]
         fn signature_standard(
             trigger: &pgx::PgTrigger,
-        ) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, PgHeapTupleError>
-        {
+        ) -> Result<PgHeapTuple<'_, impl WhoAllocated>, PgHeapTupleError> {
             Ok(trigger.current().unwrap().into_owned())
         }
 
         #[pg_trigger]
         fn signature_explicit_lifetimes<'a>(
             trigger: &'a pgx::PgTrigger,
-        ) -> Result<PgHeapTuple<'a, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, PgHeapTupleError>
-        {
+        ) -> Result<PgHeapTuple<'a, impl WhoAllocated>, PgHeapTupleError> {
             Ok(trigger.current().unwrap().into_owned())
         }
 
@@ -62,10 +60,7 @@ mod tests {
         #[pg_trigger]
         fn signature_aliased_argument<'a>(
             trigger: AliasedBorrowedPgTrigger<'a>,
-        ) -> Result<
-            PgHeapTuple<'a, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>,
-            core::str::Utf8Error,
-        > {
+        ) -> Result<PgHeapTuple<'a, impl WhoAllocated>, core::str::Utf8Error> {
             Ok(trigger.current().unwrap().into_owned())
         }
 
@@ -99,7 +94,7 @@ mod tests {
     #[pg_trigger]
     fn field_species_fox_to_bear(
         trigger: &pgx::PgTrigger,
-    ) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, TriggerError> {
+    ) -> Result<PgHeapTuple<'_, impl WhoAllocated>, TriggerError> {
         let current = trigger.current().ok_or(TriggerError::NullCurrent)?;
         let mut current = current.into_owned();
 
@@ -144,7 +139,7 @@ mod tests {
     #[pg_trigger]
     fn add_field_boopers(
         trigger: &pgx::PgTrigger,
-    ) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, TriggerError> {
+    ) -> Result<PgHeapTuple<'_, impl WhoAllocated>, TriggerError> {
         let current = trigger.current().ok_or(TriggerError::NullCurrent)?;
         let mut current = current.into_owned();
 
@@ -189,7 +184,7 @@ mod tests {
     #[pg_trigger]
     fn intercept_bears(
         trigger: &pgx::PgTrigger,
-    ) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, TriggerError> {
+    ) -> Result<PgHeapTuple<'_, impl WhoAllocated>, TriggerError> {
         let new = trigger.new().ok_or(TriggerError::NullCurrent)?;
 
         for index in 1..(new.len() + 1) {
@@ -243,7 +238,7 @@ mod tests {
     #[pg_trigger]
     fn inserts_trigger_metadata(
         trigger: &pgx::PgTrigger,
-    ) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, TriggerError> {
+    ) -> Result<PgHeapTuple<'_, impl WhoAllocated>, TriggerError> {
         let current = trigger.current().ok_or(TriggerError::NullCurrent)?;
         let mut current = current.into_owned();
 
@@ -363,7 +358,7 @@ mod tests {
     #[pg_trigger]
     fn inserts_trigger_metadata_safe(
         trigger: &pgx::PgTrigger,
-    ) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, TriggerError> {
+    ) -> Result<PgHeapTuple<'_, impl WhoAllocated>, TriggerError> {
         let pgx::PgTriggerSafe {
             name,
             new: _new,
@@ -489,7 +484,7 @@ mod tests {
     "#)]
     fn has_sql_option_set(
         trigger: &pgx::PgTrigger,
-    ) -> Result<PgHeapTuple<'_, impl WhoAllocated<pgx::pg_sys::HeapTupleData>>, TriggerError> {
+    ) -> Result<PgHeapTuple<'_, impl WhoAllocated>, TriggerError> {
         let current = trigger.current().ok_or(TriggerError::NullCurrent)?;
         let current = current.into_owned();
 

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -372,7 +372,7 @@ impl IntoDatum for () {
 }
 
 /// for user types
-impl<T, AllocatedBy: WhoAllocated<T>> IntoDatum for PgBox<T, AllocatedBy> {
+impl<T, AllocatedBy: WhoAllocated> IntoDatum for PgBox<T, AllocatedBy> {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         if self.is_null() {

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -33,7 +33,7 @@ pub enum PgHeapTupleError {
 /// allocated by Postgres, it is not mutable until [`PgHeapTuple::into_owned`] is called.
 ///
 /// [`PgHeapTuple`]s also describe composite types as defined by [`pgx::composite_type!()`][crate::composite_type].
-pub struct PgHeapTuple<'a, AllocatedBy: WhoAllocated<pg_sys::HeapTupleData>> {
+pub struct PgHeapTuple<'a, AllocatedBy: WhoAllocated> {
     tuple: PgBox<pg_sys::HeapTupleData, AllocatedBy>,
     tupdesc: PgTupleDesc<'a>,
 }
@@ -304,9 +304,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
     }
 }
 
-impl<'a, AllocatedBy: WhoAllocated<pg_sys::HeapTupleData>> IntoDatum
-    for PgHeapTuple<'a, AllocatedBy>
-{
+impl<'a, AllocatedBy: WhoAllocated> IntoDatum for PgHeapTuple<'a, AllocatedBy> {
     // Delegate to `into_composite_datum()` as this will normally be used with composite types.
     // See `into_trigger_datum()` if using as a trigger.
     fn into_datum(self) -> Option<pg_sys::Datum> {
@@ -322,7 +320,7 @@ impl<'a, AllocatedBy: WhoAllocated<pg_sys::HeapTupleData>> IntoDatum
     }
 }
 
-impl<'a, AllocatedBy: WhoAllocated<pg_sys::HeapTupleData>> PgHeapTuple<'a, AllocatedBy> {
+impl<'a, AllocatedBy: WhoAllocated> PgHeapTuple<'a, AllocatedBy> {
     /// Consume this [`PgHeapTuple`] and return a composite Datum representation, containing the tuple
     /// data and the corresponding tuple descriptor information.
     pub fn into_composite_datum(self) -> Option<pg_sys::Datum> {

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -94,10 +94,7 @@ extern "C" {
 ///
 /// `attno` is 1-based
 #[inline]
-pub fn heap_getattr<
-    T: FromDatum,
-    AllocatedBy: WhoAllocated<T> + WhoAllocated<pg_sys::HeapTupleData>,
->(
+pub fn heap_getattr<T: FromDatum, AllocatedBy: WhoAllocated>(
     tuple: &PgBox<pg_sys::HeapTupleData, AllocatedBy>,
     attno: NonZeroUsize,
     tupdesc: &PgTupleDesc,

--- a/pgx/src/trigger_support/mod.rs
+++ b/pgx/src/trigger_support/mod.rs
@@ -17,7 +17,7 @@ use pgx::{pg_trigger, pg_sys, heap_tuple::{PgHeapTuple, PgHeapTupleError}, WhoAl
 
 #[pg_trigger]
 fn trigger_example(trigger: &PgTrigger) -> Result<
-    PgHeapTuple<'_, impl WhoAllocated<pg_sys::HeapTupleData>>,
+    PgHeapTuple<'_, impl WhoAllocated>,
     PgHeapTupleError,
 > {
     Ok(unsafe { trigger.current() }.expect("No current HeapTuple"))
@@ -66,7 +66,7 @@ This can also be done via the [`extension_sql`][crate::extension_sql] attribute:
 #
 # #[pg_trigger]
 # fn trigger_example(trigger: &PgTrigger) -> Result<
-#    PgHeapTuple<'_, impl WhoAllocated<pg_sys::HeapTupleData>>,
+#    PgHeapTuple<'_, impl WhoAllocated>,
 #    PgHeapTupleError,
 # > {
 #     Ok(unsafe { trigger.current() }.expect("No current HeapTuple"))
@@ -138,7 +138,7 @@ enum CustomTriggerError {
 
 #[pg_trigger]
 fn example_custom_error(trigger: &PgTrigger) -> Result<
-    PgHeapTuple<'_, impl WhoAllocated<pg_sys::HeapTupleData>>,
+    PgHeapTuple<'_, impl WhoAllocated>,
     CustomTriggerError,
 > {
     unsafe { trigger.current() }.ok_or(CustomTriggerError::NoCurrentHeapTuple)
@@ -191,7 +191,7 @@ use pgx::{pg_trigger, pg_sys, heap_tuple::{PgHeapTuple, PgHeapTupleError}, WhoAl
 
 #[pg_trigger]
 fn trigger_safe(trigger: &PgTrigger) -> Result<
-    PgHeapTuple<'_, impl WhoAllocated<pg_sys::HeapTupleData>>,
+    PgHeapTuple<'_, impl WhoAllocated>,
     PgTriggerError,
 > {
     let trigger_safe = unsafe { trigger.to_safe() }?;


### PR DESCRIPTION
... so this changes it to just `WhoAllocated`.

I wanted to put it up now as I'm going to be working on some stuff that this will make better.