### PR TITLE
Release pgx 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
 ]
@@ -86,7 +86,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -107,7 +107,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.5.4",
  "object 0.29.0",
  "rustc-demangle",
 ]
@@ -121,21 +121,6 @@ dependencies = [
  "rand",
  "ureq",
 ]
-
-[[package]]
-name = "bare-metal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "base64"
@@ -196,18 +181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,9 +230,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "camino"
@@ -272,12 +245,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 dependencies = [
  "atty",
  "cargo_metadata",
  "cargo_toml",
- "clap 4.0.26",
+ "clap 4.0.29",
  "clap-cargo",
  "color-eyre",
  "env_proxy",
@@ -319,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
+checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -344,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 
 [[package]]
 name = "cexpr"
@@ -399,14 +372,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.26"
+version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive 4.0.21",
  "clap_lex 0.3.0",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -419,7 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca953650a7350560b61db95a0ab1d9c6f7b74d146a9e08fb258b834f3cf7e2c"
 dependencies = [
  "cargo_metadata",
- "clap 4.0.26",
+ "clap 4.0.29",
  "doc-comment",
 ]
 
@@ -536,18 +509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "cortex-m"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70858629a458fdfd39f9675c4dc309411f2a3f83bede76988d81bf1a0ecee9e0"
-dependencies = [
- "bare-metal 0.2.5",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,15 +528,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "0.2.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
-dependencies = [
- "bare-metal 1.0.0",
- "cfg-if",
- "cortex-m",
- "riscv",
-]
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -600,22 +555,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -709,16 +664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
-name = "embedded-hal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
-
-[[package]]
 name = "env_proxy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +671,27 @@ checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
 dependencies = [
  "log",
  "url",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -779,12 +745,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -969,6 +935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +985,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1106,6 +1103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1186,15 @@ name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1207,21 +1228,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "nom"
@@ -1258,7 +1264,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1298,9 +1304,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1330,9 +1336,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
 dependencies = [
  "autocfg",
  "cc",
@@ -1353,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -1384,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1409,9 +1415,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1437,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1465,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1477,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "eyre",
@@ -1491,12 +1497,12 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 dependencies = [
  "bindgen",
  "eyre",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "once_cell",
  "pgx-macros",
  "pgx-pg-config",
@@ -1511,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 dependencies = [
  "eyre",
  "libc",
@@ -1531,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 dependencies = [
  "atty",
  "convert_case",
@@ -1753,11 +1759,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1765,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1846,27 +1851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "riscv"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "riscv-target",
-]
-
-[[package]]
-name = "riscv-target"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,15 +1870,6 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -1909,6 +1884,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.14",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2010,20 +1999,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -2034,12 +2014,6 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2058,9 +2032,9 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -2089,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2100,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -2270,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2410,9 +2384,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2653,12 +2627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,21 +2644,6 @@ version = "0.0.0"
 dependencies = [
  "pgx",
  "pgx-tests",
-]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
-dependencies = [
- "vcell",
 ]
 
 [[package]]

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgx' to make Postgres extension development easy"
@@ -15,27 +15,27 @@ edition = "2021"
 
 [dependencies]
 atty = "0.2.14"
-cargo_metadata = "0.15.1"
+cargo_metadata = "0.15.2"
 cargo_toml = "0.11.8"
-clap = { version = "4.0.26", features = [ "env", "suggestions", "cargo", "derive" ] }
+clap = { version = "4.0.29", features = [ "env", "suggestions", "cargo", "derive" ] }
 clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.14"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.14.0"
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.6.0-alpha.2" }
-pgx-utils = { path = "../pgx-utils", version = "=0.6.0-alpha.2", features = ["syntax-highlighting"] }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.6.0" }
+pgx-utils = { path = "../pgx-utils", version = "=0.6.0", features = ["syntax-highlighting"] }
 prettyplease = "0.1.21"
 proc-macro2 = { version = "1.0.47", features = [ "span-locations" ] }
 quote = "1.0.21"
-rayon = "1.5.3"
+rayon = "1.6.0"
 regex = "1.7.0"
 ureq = "2.5.0"
 url = "2.3.1"
-serde = { version = "1.0.147", features = [ "derive" ] }
-serde_derive = "1.0.147"
+serde = { version = "1.0.148", features = [ "derive" ] }
+serde_derive = "1.0.148"
 serde-xml-rs = "0.5.1"
-syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.104", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 fork = "0.1.20"
 libloading = "0.7.4"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.6.0-alpha.2"
+pgx = "=0.6.0"
 
 [dev-dependencies]
-pgx-tests = "=0.6.0-alpha.2"
+pgx-tests = "=0.6.0"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,13 +16,13 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.6.0-alpha.2"
-pgx-macros = "=0.6.0-alpha.2"
-pgx-utils = "=0.6.0-alpha.2"
+pgx = "=0.6.0"
+pgx-macros = "=0.6.0"
+pgx-utils = "=0.6.0"
 
 
 [dev-dependencies]
-pgx-tests = "=0.6.0-alpha.2"
+pgx-tests = "=0.6.0"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/arrays/Cargo.toml
+++ b/pgx-examples/arrays/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/composite_type/Cargo.toml
+++ b/pgx-examples/composite_type/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/custom_sql/Cargo.toml
+++ b/pgx-examples/custom_sql/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
 maplit = "1.0.2"
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/nostd/Cargo.toml
+++ b/pgx-examples/nostd/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/operators/Cargo.toml
+++ b/pgx-examples/operators/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
 maplit = "1.0.2"
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/schemas/Cargo.toml
+++ b/pgx-examples/schemas/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-serde = "1.0.147"
+serde = "1.0.148"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-examples/shmem/Cargo.toml
+++ b/pgx-examples/shmem/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 heapless = "0.7.16"
 pgx = { path = "../../pgx", default-features = false }
-serde = { version = "1.0.147", features = [ "derive" ] }
+serde = { version = "1.0.148", features = [ "derive" ] }
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgx'"
@@ -18,11 +18,11 @@ proc-macro = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-utils = { path = "../pgx-utils", version = "=0.6.0-alpha.2" }
+pgx-utils = { path = "../pgx-utils", version = "=0.6.0" }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
-syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.104", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 
 [dev-dependencies]
-serde = { version = "1.0.147", features = ["derive"] }
+serde = { version = "1.0.148", features = ["derive"] }

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-config"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgx'"
@@ -16,8 +16,8 @@ edition = "2021"
 dirs = "4.0.0"
 eyre = "0.6.8"
 owo-colors = "3.5.0"
-serde = { version = "1.0.147", features = [ "derive" ] }
-serde_derive = "1.0.147"
-serde_json = "1.0.88"
+serde = { version = "1.0.148", features = [ "derive" ] }
+serde_derive = "1.0.148"
+serde_json = "1.0.89"
 toml = "0.5.9"
 url = "2.3.1"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgx'"
@@ -30,19 +30,19 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 memoffset = "0.6.5"
 once_cell = "1.16.0"
-pgx-macros = { path = "../pgx-macros/", version = "=0.6.0-alpha.2" }
-pgx-utils = { path = "../pgx-utils/", version = "=0.6.0-alpha.2" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.6.0" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.6.0" }
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
 libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.6.0-alpha.2" }
-pgx-utils = { path = "../pgx-utils/", version = "=0.6.0-alpha.2" }
+pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.6.0" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.6.0" }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
-rayon = "1.5.3"
-syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
+rayon = "1.6.0"
+syn = { version = "1.0.104", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -167,24 +167,25 @@ pub const BLCKSZ: u32 = 8192;
 pub const DEF_PGPORT: u32 = 28811;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28811\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_CRYPT_H: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_SNPRINTF: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DECL_VSNPRINTF: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -194,11 +195,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -208,7 +209,6 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -219,7 +219,6 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -227,8 +226,9 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
 pub const HAVE_READLINE_HISTORY_H: u32 = 1;
@@ -238,6 +238,7 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
 pub const HAVE_SNPRINTF: u32 = 1;
@@ -250,8 +251,6 @@ pub const HAVE_STRERROR: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRONG_RANDOM: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
@@ -259,29 +258,26 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -292,7 +288,6 @@ pub const HAVE_UTIMES: u32 = 1;
 pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_VSNPRINTF: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP16: u32 = 1;
@@ -302,23 +297,24 @@ pub const HAVE__BUILTIN_CONSTANT_P: u32 = 1;
 pub const HAVE__BUILTIN_OP_OVERFLOW: u32 = 1;
 pub const HAVE__BUILTIN_TYPES_COMPATIBLE_P: u32 = 1;
 pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
+pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const HAVE__VA_ARGS: u32 = 1;
 pub const INT64_MODIFIER: &[u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 26usize] = b"pgsql-bugs@postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 11.17\0";
+pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 11.18\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1usize] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6usize] = b"11.17\0";
+pub const PACKAGE_VERSION: &[u8; 6usize] = b"11.18\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"11\0";
-pub const PG_VERSION: &[u8; 6usize] = b"11.17\0";
-pub const PG_VERSION_NUM: u32 = 110017;
-pub const PG_VERSION_STR : & [u8 ; 113usize] = b"PostgreSQL 11.17 on arm-apple-darwin22.1.0, compiled by Apple clang version 14.0.0 (clang-1400.0.29.202), 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6usize] = b"11.18\0";
+pub const PG_VERSION_NUM: u32 = 110018;
+pub const PG_VERSION_STR: &[u8; 78usize] =
+    b"PostgreSQL 11.18 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -326,15 +322,13 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
-pub const USE_ARMV8_CRC32C: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
+pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -349,566 +343,214 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &[u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &[u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_13_0: u32 = 130000;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 130000;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 36;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
+pub const P_tmpdir: &[u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -919,7 +561,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -943,92 +585,151 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const USE_STDBOOL: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4usize] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4usize] = b"%lu\0";
@@ -1054,376 +755,366 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &[u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &[u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &[u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_PRIMARY_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const SO_RESOLVER_SIGNATURE: u32 = 4401;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MCTP: u32 = 45;
+pub const PF_MAX: u32 = 46;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MCTP: u32 = 45;
+pub const AF_MAX: u32 = 46;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_NETNS_COOKIE: u32 = 71;
+pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_RECVERR_RFC4884: u32 = 26;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_RECVERR_RFC4884: u32 = 31;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1435,283 +1126,66 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &[u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_ULA_USETEMPADDR: u32 = 51;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &[u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &[u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &[u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &[u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &[u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &[u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &[u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &[u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &[u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &[u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &[u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &[u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &[u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &[u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &[u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &[u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &[u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 11.17\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 11.18\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1725,13 +1199,9 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 48;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
+pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1849,121 +1319,84 @@ pub const LP_DEAD: u32 = 3;
 pub const OffsetNumberMask: u32 = 65535;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const DSM_IMPL_NONE: u32 = 0;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
@@ -1991,162 +1424,136 @@ pub const AccessExclusiveLock: u32 = 8;
 pub const BITS_PER_BITMAPWORD: u32 = 32;
 pub const RELCACHE_INIT_FILENAME: &[u8; 17usize] = b"pg_internal.init\0";
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const O_EXEC: u32 = 1073741824;
-pub const O_SEARCH: u32 = 1074790400;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const AT_SYMLINK_NOFOLLOW_ANY: u32 = 2048;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const O_DP_AUTHENTICATE: u32 = 4;
-pub const AUTH_OPEN_NOAUTHFD: i32 = -1;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const F_SETLEASE: u32 = 106;
-pub const F_GETLEASE: u32 = 107;
-pub const F_TRANSFEREXTENTS: u32 = 110;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_ALLOCATEPERSIST: u32 = 8;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const MAX_TIMESTAMP_PRECISION: u32 = 6;
 pub const MAX_INTERVAL_PRECISION: u32 = 6;
 pub const TS_PREC_INV: f64 = 1000000.0;
@@ -2192,7 +1599,24 @@ pub const HEAP_INSERT_SKIP_FSM: u32 = 2;
 pub const HEAP_INSERT_FROZEN: u32 = 4;
 pub const HEAP_INSERT_SPECULATIVE: u32 = 8;
 pub const HEAP_INSERT_NO_LOGICAL: u32 = 16;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const HASH_PARTITION: u32 = 1;
 pub const HASH_SEGMENT: u32 = 2;
@@ -2209,25 +1633,9 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const DEFAULT_SPINS_PER_DELAY: u32 = 100;
@@ -2321,7 +1729,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const GROUPING_CAN_USE_SORT: u32 = 1;
 pub const GROUPING_CAN_USE_HASH: u32 = 2;
@@ -2344,6 +1751,85 @@ pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_OIDS: u32 = 32;
 pub const EXEC_FLAG_WITHOUT_OIDS: u32 = 64;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 128;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2362,13 +1848,7 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -3566,7 +3046,6 @@ pub const PROCARRAY_FLAGS_DEFAULT: u32 = 16;
 pub const PROCARRAY_FLAGS_VACUUM: u32 = 18;
 pub const PROCARRAY_FLAGS_ANALYZE: u32 = 20;
 pub const PROCARRAY_FLAGS_VACUUM_ANALYZE: u32 = 22;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3735,22 +3214,95 @@ pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
@@ -3761,45 +3313,13 @@ impl Default for __mbstate_t {
         }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
 }
-impl Default for __darwin_pthread_handler_rec {
+impl Default for _G_fpos_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3808,13 +3328,14 @@ impl Default for __darwin_pthread_handler_rec {
         }
     }
 }
+pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
 }
-impl Default for _opaque_pthread_attr_t {
+impl Default for _G_fpos64_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3823,241 +3344,59 @@ impl Default for _opaque_pthread_attr_t {
         }
     }
 }
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[track_caller]
-pub unsafe fn renameat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameat(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn renamex_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renamex_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renamex_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn renameatx_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameatx_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameatx_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -4066,327 +3405,24 @@ impl Default for __sFILE {
         }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
-}
-extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stdout: *mut FILE;
+}
+extern "C" {
+    pub static mut stderr: *mut FILE;
 }
 #[track_caller]
-pub unsafe fn clearerr(arg_arg1: *mut FILE) {
+pub unsafe fn remove(arg___filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn clearerr(arg1: *mut FILE);
+            pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        clearerr(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn feof(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        feof(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ferror(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        ferror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fflush(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fflush(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fgetc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetpos(arg_arg1: *mut FILE, arg_arg2: *mut fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-        }
-        fgetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fgets(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut FILE,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgets(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut FILE,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fgets(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fopen(
-    arg___filename: *const ::std::os::raw::c_char,
-    arg___mode: *const ::std::os::raw::c_char,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fopen(
-                __filename: *const ::std::os::raw::c_char,
-                __mode: *const ::std::os::raw::c_char,
-            ) -> *mut FILE;
-        }
-        fopen(arg___filename, arg___mode)
-    })
-}
-#[track_caller]
-pub unsafe fn fprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fputc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputs(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputs(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut FILE,
-            ) -> ::std::os::raw::c_int;
-        }
-        fputs(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fread(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fread(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fread(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn freopen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut FILE,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freopen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut FILE,
-            ) -> *mut FILE;
-        }
-        freopen(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fscanf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fseek(
-    arg_arg1: *mut FILE,
-    arg_arg2: ::std::os::raw::c_long,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fseek(
-                arg1: *mut FILE,
-                arg2: ::std::os::raw::c_long,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        fseek(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fsetpos(arg_arg1: *mut FILE, arg_arg2: *const fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-        }
-        fsetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn ftell(arg_arg1: *mut FILE) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-        }
-        ftell(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fwrite(
-    arg___ptr: *const ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fwrite(
-                __ptr: *const ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fwrite(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn getc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        getc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getchar() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getchar() -> ::std::os::raw::c_int;
-        }
-        getchar()
-    })
-}
-#[track_caller]
-pub unsafe fn perror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn perror(arg1: *const ::std::os::raw::c_char);
-        }
-        perror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn printf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        printf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn putc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        putc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn putchar(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        putchar(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn puts(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        puts(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn remove(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        remove(arg_arg1)
+        remove(arg___filename)
     })
 }
 #[track_caller]
@@ -4405,81 +3441,31 @@ pub unsafe fn rename(
     })
 }
 #[track_caller]
-pub unsafe fn rewind(arg_arg1: *mut FILE) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rewind(arg1: *mut FILE);
-        }
-        rewind(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn scanf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        scanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuf(arg_arg1: *mut FILE, arg_arg2: *mut ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-        }
-        setbuf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setvbuf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
+pub unsafe fn renameat(
+    arg___oldfd: ::std::os::raw::c_int,
+    arg___old: *const ::std::os::raw::c_char,
+    arg___newfd: ::std::os::raw::c_int,
+    arg___new: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setvbuf(
-                arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
+            pub fn renameat(
+                __oldfd: ::std::os::raw::c_int,
+                __old: *const ::std::os::raw::c_char,
+                __newfd: ::std::os::raw::c_int,
+                __new: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        setvbuf(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        renameat(arg___oldfd, arg___old, arg___newfd, arg___new)
     })
 }
 #[track_caller]
-pub unsafe fn sprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        sprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sscanf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sscanf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        sscanf(arg_arg1, arg_arg2)
+        fclose(arg___stream)
     })
 }
 #[track_caller]
@@ -4492,195 +3478,540 @@ pub unsafe fn tmpfile() -> *mut FILE {
     })
 }
 #[track_caller]
-pub unsafe fn ungetc(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ungetc(arg_arg1, arg_arg2)
+        fflush(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vfprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vfprintf(arg_arg1, arg_arg2, arg_arg3)
+        fflush_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vprintf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vprintf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+            ) -> *mut FILE;
         }
-        vprintf(arg_arg1, arg_arg2)
+        fopen(arg___filename, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn vsprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn freopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn freopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> *mut FILE;
         }
-        vsprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ctermid(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        ctermid(arg_arg1)
+        freopen(arg___filename, arg___modes, arg___stream)
     })
 }
 #[track_caller]
 pub unsafe fn fdopen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
+    arg___fd: ::std::os::raw::c_int,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fdopen(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
+                __fd: ::std::os::raw::c_int,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fdopen(arg_arg1, arg_arg2)
+        fdopen(arg___fd, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn fileno(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fileno(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn pclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        pclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn popen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
+pub unsafe fn fmemopen(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___len: usize,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn popen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
+            pub fn fmemopen(
+                __s: *mut ::std::os::raw::c_void,
+                __len: usize,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        popen(arg_arg1, arg_arg2)
+        fmemopen(arg___s, arg___len, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn __srget(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn open_memstream(
+    arg___bufloc: *mut *mut ::std::os::raw::c_char,
+    arg___sizeloc: *mut usize,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn open_memstream(
+                __bufloc: *mut *mut ::std::os::raw::c_char,
+                __sizeloc: *mut usize,
+            ) -> *mut FILE;
         }
-        __srget(arg_arg1)
+        open_memstream(arg___bufloc, arg___sizeloc)
     })
 }
 #[track_caller]
-pub unsafe fn __svfscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
+pub unsafe fn setbuf(arg___stream: *mut FILE, arg___buf: *mut ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+        }
+        setbuf(arg___stream, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setvbuf(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___modes: ::std::os::raw::c_int,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __svfscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
+            pub fn setvbuf(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __modes: ::std::os::raw::c_int,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        __svfscanf(arg_arg1, arg_arg2, arg_arg3)
+        setvbuf(arg___stream, arg___buf, arg___modes, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn __swbuf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+pub unsafe fn setbuffer(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___size: usize,
+) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuffer(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __size: usize,
+            );
+        }
+        setbuffer(arg___stream, arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn setlinebuf(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlinebuf(__stream: *mut FILE);
+        }
+        setlinebuf(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fprintf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fprintf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        __swbuf(arg_arg1, arg_arg2)
+        fprintf(arg___stream, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn flockfile(arg_arg1: *mut FILE) {
+pub unsafe fn printf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flockfile(arg1: *mut FILE);
+            pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
         }
-        flockfile(arg_arg1)
+        printf(arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn ftrylockfile(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn sprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn sprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        ftrylockfile(arg_arg1)
+        sprintf(arg___s, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn funlockfile(arg_arg1: *mut FILE) {
+pub unsafe fn vfprintf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn funlockfile(arg1: *mut FILE);
+            pub fn vfprintf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        funlockfile(arg_arg1)
+        vfprintf(arg___s, arg___format, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn getc_unlocked(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn vprintf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn vprintf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        getc_unlocked(arg_arg1)
+        vprintf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsprintf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn snprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn snprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        snprintf(arg___s, arg___maxlen, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vsnprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsnprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsnprintf(arg___s, arg___maxlen, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vdprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vdprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vdprintf(arg___fd, arg___fmt, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn dprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        dprintf(arg___fd, arg___fmt)
+    })
+}
+#[track_caller]
+pub unsafe fn fscanf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fscanf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf(arg___s, arg___format)
+    })
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[track_caller]
+pub unsafe fn fscanf1(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_fscanf"]
+            pub fn fscanf1(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf1(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf1(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_scanf"]
+            pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf1(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_sscanf"]
+            pub fn sscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf1(arg___s, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vfscanf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vscanf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf1(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vfscanf"]
+            pub fn vfscanf1(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf1(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vscanf"]
+            pub fn vscanf1(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf1(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vsscanf"]
+            pub fn vsscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getchar() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getchar() -> ::std::os::raw::c_int;
+        }
+        getchar()
+    })
+}
+#[track_caller]
+pub unsafe fn getc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc_unlocked(arg___stream)
     })
 }
 #[track_caller]
@@ -4693,1508 +4024,537 @@ pub unsafe fn getchar_unlocked() -> ::std::os::raw::c_int {
     })
 }
 #[track_caller]
+pub unsafe fn fgetc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fputc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putchar(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        putchar(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc_unlocked(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc_unlocked(
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputc_unlocked(arg___c, arg___stream)
+    })
+}
+#[track_caller]
 pub unsafe fn putc_unlocked(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn putc_unlocked(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut FILE,
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
             ) -> ::std::os::raw::c_int;
         }
-        putc_unlocked(arg_arg1, arg_arg2)
+        putc_unlocked(arg___c, arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putchar_unlocked(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn putchar_unlocked(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        putchar_unlocked(arg_arg1)
+        putchar_unlocked(arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn getw(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn getw(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getw(arg_arg1)
+        getw(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putw(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn putw(
+    arg___w: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        putw(arg_arg1, arg_arg2)
+        putw(arg___w, arg___stream)
     })
 }
-pub type off_t = __darwin_off_t;
+#[track_caller]
+pub unsafe fn fgets(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgets(
+                __s: *mut ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fgets(arg___s, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn __getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        __getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getline(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getline(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getline(arg___lineptr, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputs(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputs(
+                __s: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputs(arg___s, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn puts(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        puts(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn ungetc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+                -> ::std::os::raw::c_int;
+        }
+        ungetc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fread(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fread(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___s: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __s: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fwrite(arg___ptr, arg___size, arg___n, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn fread_unlocked(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread_unlocked(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fread_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite_unlocked(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite_unlocked(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fwrite_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fseek(
+    arg___stream: *mut FILE,
+    arg___off: ::std::os::raw::c_long,
+    arg___whence: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fseek(
+                __stream: *mut FILE,
+                __off: ::std::os::raw::c_long,
+                __whence: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        fseek(arg___stream, arg___off, arg___whence)
+    })
+}
+#[track_caller]
+pub unsafe fn ftell(arg___stream: *mut FILE) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+        }
+        ftell(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn rewind(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rewind(__stream: *mut FILE);
+        }
+        rewind(arg___stream)
+    })
+}
 #[track_caller]
 pub unsafe fn fseeko(
     arg___stream: *mut FILE,
-    arg___offset: off_t,
+    arg___off: __off_t,
     arg___whence: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fseeko(
                 __stream: *mut FILE,
-                __offset: off_t,
+                __off: __off_t,
                 __whence: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        fseeko(arg___stream, arg___offset, arg___whence)
+        fseeko(arg___stream, arg___off, arg___whence)
     })
 }
 #[track_caller]
-pub unsafe fn ftello(arg___stream: *mut FILE) -> off_t {
+pub unsafe fn ftello(arg___stream: *mut FILE) -> __off_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftello(__stream: *mut FILE) -> off_t;
+            pub fn ftello(__stream: *mut FILE) -> __off_t;
         }
         ftello(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn snprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fgetpos(arg___stream: *mut FILE, arg___pos: *mut fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn snprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
         }
-        snprintf(arg___str, arg___size, arg___format)
+        fgetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vfscanf(
-    arg___stream: *mut FILE,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fsetpos(arg___stream: *mut FILE, arg___pos: *const fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfscanf(
-                __stream: *mut FILE,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
         }
-        vfscanf(arg___stream, arg___format, arg_arg1)
+        fsetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vscanf(
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vscanf(
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr(__stream: *mut FILE);
         }
-        vscanf(arg___format, arg_arg1)
+        clearerr(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsnprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsnprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsnprintf(arg___str, arg___size, arg___format, arg_arg1)
+        feof(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsscanf(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ferror(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsscanf(
-                __str: *const ::std::os::raw::c_char,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsscanf(arg___str, arg___format, arg_arg1)
+        ferror(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn dprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr_unlocked(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn dprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr_unlocked(__stream: *mut FILE);
         }
-        dprintf(arg_arg1, arg_arg2)
+        clearerr_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vdprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vdprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vdprintf(arg_arg1, arg_arg2, arg_arg3)
+        feof_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getdelim(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___delimiter: ::std::os::raw::c_int,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn ferror_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdelim(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __delimiter: ::std::os::raw::c_int,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getdelim(arg___linep, arg___linecapp, arg___delimiter, arg___stream)
+        ferror_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getline(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn perror(arg___s: *const ::std::os::raw::c_char) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getline(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn perror(__s: *const ::std::os::raw::c_char);
         }
-        getline(arg___linep, arg___linecapp, arg___stream)
+        perror(arg___s)
     })
 }
 #[track_caller]
-pub unsafe fn fmemopen(
-    arg___buf: *mut ::std::os::raw::c_void,
-    arg___size: usize,
-    arg___mode: *const ::std::os::raw::c_char,
+pub unsafe fn fileno(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fileno_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn pclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        pclose(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn popen(
+    arg___command: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmemopen(
-                __buf: *mut ::std::os::raw::c_void,
-                __size: usize,
-                __mode: *const ::std::os::raw::c_char,
+            pub fn popen(
+                __command: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fmemopen(arg___buf, arg___size, arg___mode)
+        popen(arg___command, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn open_memstream(
-    arg___bufp: *mut *mut ::std::os::raw::c_char,
-    arg___sizep: *mut usize,
-) -> *mut FILE {
+pub unsafe fn ctermid(arg___s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn open_memstream(
-                __bufp: *mut *mut ::std::os::raw::c_char,
-                __sizep: *mut usize,
-            ) -> *mut FILE;
+            pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
         }
-        open_memstream(arg___bufp, arg___sizep)
+        ctermid(arg___s)
     })
 }
-extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
-}
 #[track_caller]
-pub unsafe fn asprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn flockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn flockfile(__stream: *mut FILE);
         }
-        asprintf(arg_arg1, arg_arg2)
+        flockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn ctermid_r(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ftrylockfile(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ctermid_r(arg_arg1)
+        ftrylockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fgetln(arg_arg1: *mut FILE, arg_arg2: *mut usize) -> *mut ::std::os::raw::c_char {
+pub unsafe fn funlockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+            pub fn funlockfile(__stream: *mut FILE);
         }
-        fgetln(arg_arg1, arg_arg2)
+        funlockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fmtcheck(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *const ::std::os::raw::c_char {
+pub unsafe fn __uflow(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmtcheck(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *const ::std::os::raw::c_char;
+            pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
         }
-        fmtcheck(arg_arg1, arg_arg2)
+        __uflow(arg_arg1)
     })
 }
 #[track_caller]
-pub unsafe fn fpurge(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fpurge(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuffer(
+pub unsafe fn __overflow(
     arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) {
+    arg_arg2: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setbuffer(
+            pub fn __overflow(
                 arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            );
-        }
-        setbuffer(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setlinebuf(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        setlinebuf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn vasprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn vasprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        vasprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn funopen(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg3: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg4: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    arg_arg5: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn funopen(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *mut ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg3: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg4: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: fpos_t,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> fpos_t,
-                >,
-                arg5: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> *mut FILE;
-        }
-        funopen(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __sprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __sprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __snprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __snprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __snprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsnprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-    arg_arg6: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsnprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                arg6: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsnprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
-}
-impl Default for __darwin_arm_vfp_state {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
-        }
-        signal(arg_arg1, arg_arg2)
-    })
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_reserved: [u64; 14usize],
-}
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[track_caller]
-pub unsafe fn getpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-        }
-        getpriority(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getiopolicy_np(
-                arg1: ::std::os::raw::c_int,
                 arg2: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getiopolicy_np(arg_arg1, arg_arg2)
+        __overflow(arg_arg1, arg_arg2)
     })
 }
-#[track_caller]
-pub unsafe fn getrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getrusage(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rusage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrusage(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rusage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrusage(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpriority(
-                arg1: ::std::os::raw::c_int,
-                arg2: id_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setpriority(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setiopolicy_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setiopolicy_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        setrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn wait(arg_arg1: *mut ::std::os::raw::c_int) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-        }
-        wait(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn waitpid(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitpid(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> pid_t;
-        }
-        waitpid(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn waitid(
-    arg_arg1: idtype_t,
-    arg_arg2: id_t,
-    arg_arg3: *mut siginfo_t,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitid(
-                arg1: idtype_t,
-                arg2: id_t,
-                arg3: *mut siginfo_t,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        waitid(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn wait3(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait3(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut rusage,
-            ) -> pid_t;
-        }
-        wait3(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn wait4(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait4(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut rusage,
-            ) -> pid_t;
-        }
-        wait4(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn alloca(arg_arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-        }
-        alloca(arg_arg1)
-    })
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6213,8 +4573,1000 @@ pub struct lldiv_t {
     pub quot: ::std::os::raw::c_longlong,
     pub rem: ::std::os::raw::c_longlong,
 }
-extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+#[track_caller]
+pub unsafe fn __ctype_get_mb_cur_max() -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ctype_get_mb_cur_max() -> usize;
+        }
+        __ctype_get_mb_cur_max()
+    })
+}
+#[track_caller]
+pub unsafe fn atof(arg___nptr: *const ::std::os::raw::c_char) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+        }
+        atof(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoi(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        atoi(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atol(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        atol(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoll(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+        }
+        atoll(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtod(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtod(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f64;
+        }
+        strtod(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtof(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtof(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f32;
+        }
+        strtof(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtold(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtold(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> u128;
+        }
+        strtold(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtol(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtol(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_long;
+        }
+        strtol(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoul(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoul(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strtoul(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtouq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtouq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtouq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoll(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoll(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoll(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoull(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoull(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtoull(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn l64a(arg___n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+        }
+        l64a(arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn a64l(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        a64l(arg___s)
+    })
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[track_caller]
+pub unsafe fn select(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *mut timeval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn select(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *mut timeval,
+            ) -> ::std::os::raw::c_int;
+        }
+        select(arg___nfds, arg___readfds, arg___writefds, arg___exceptfds, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn pselect(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *const timespec,
+    arg___sigmask: *const __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pselect(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *const timespec,
+                __sigmask: *const __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pselect(
+            arg___nfds,
+            arg___readfds,
+            arg___writefds,
+            arg___exceptfds,
+            arg___timeout,
+            arg___sigmask,
+        )
+    })
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __atomic_wide_counter {
+    pub __value64: ::std::os::raw::c_ulonglong,
+    pub __value32: __atomic_wide_counter__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __atomic_wide_counter__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __atomic_wide_counter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __wseq: __atomic_wide_counter,
+    pub __g1_start: __atomic_wide_counter,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random() -> ::std::os::raw::c_long;
+        }
+        random()
+    })
+}
+#[track_caller]
+pub unsafe fn srandom(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom(__seed: ::std::os::raw::c_uint);
+        }
+        srandom(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        initstate(arg___seed, arg___statebuf, arg___statelen)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate(arg___statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate(__statebuf: *mut ::std::os::raw::c_char)
+                -> *mut ::std::os::raw::c_char;
+        }
+        setstate(arg___statebuf)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random_r(
+    arg___buf: *mut random_data,
+    arg___result: *mut i32,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+        }
+        random_r(arg___buf, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srandom_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom_r(
+                __seed: ::std::os::raw::c_uint,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srandom_r(arg___seed, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate_r(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        initstate_r(arg___seed, arg___statebuf, arg___statelen, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate_r(
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate_r(
+                __statebuf: *mut ::std::os::raw::c_char,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        setstate_r(arg___statebuf, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn rand() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand() -> ::std::os::raw::c_int;
+        }
+        rand()
+    })
+}
+#[track_caller]
+pub unsafe fn srand(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand(__seed: ::std::os::raw::c_uint);
+        }
+        srand(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn rand_r(arg___seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+        }
+        rand_r(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn drand48() -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48() -> f64;
+        }
+        drand48()
+    })
+}
+#[track_caller]
+pub unsafe fn erand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+        }
+        erand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48() -> ::std::os::raw::c_long;
+        }
+        lrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        nrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48() -> ::std::os::raw::c_long;
+        }
+        mrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        jrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48(arg___seedval: ::std::os::raw::c_long) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48(__seedval: ::std::os::raw::c_long);
+        }
+        srand48(arg___seedval)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+) -> *mut ::std::os::raw::c_ushort {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+            ) -> *mut ::std::os::raw::c_ushort;
+        }
+        seed48(arg___seed16v)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48(arg___param: *mut ::std::os::raw::c_ushort) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+        }
+        lcong48(arg___param)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[track_caller]
+pub unsafe fn drand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        drand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn erand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        erand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        lrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        nrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        mrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        jrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48_r(
+    arg___seedval: ::std::os::raw::c_long,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48_r(
+                __seedval: ::std::os::raw::c_long,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srand48_r(arg___seedval, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48_r(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48_r(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        seed48_r(arg___seed16v, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48_r(
+    arg___param: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48_r(
+                __param: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        lcong48_r(arg___param, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random() -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random() -> __uint32_t;
+        }
+        arc4random()
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___size: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+        }
+        arc4random_buf(arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_uniform(arg___upper_bound: __uint32_t) -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+        }
+        arc4random_uniform(arg___upper_bound)
+    })
 }
 #[track_caller]
 pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
@@ -6227,26 +5579,17 @@ pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw
 }
 #[track_caller]
 pub unsafe fn calloc(
-    arg___count: ::std::os::raw::c_ulong,
+    arg___nmemb: ::std::os::raw::c_ulong,
     arg___size: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn calloc(
-                __count: ::std::os::raw::c_ulong,
+                __nmemb: ::std::os::raw::c_ulong,
                 __size: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        calloc(arg___count, arg___size)
-    })
-}
-#[track_caller]
-pub unsafe fn free(arg_arg1: *mut ::std::os::raw::c_void) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn free(arg1: *mut ::std::os::raw::c_void);
-        }
-        free(arg_arg1)
+        calloc(arg___nmemb, arg___size)
     })
 }
 #[track_caller]
@@ -6265,27 +5608,47 @@ pub unsafe fn realloc(
     })
 }
 #[track_caller]
-pub unsafe fn valloc(arg_arg1: usize) -> *mut ::std::os::raw::c_void {
+pub unsafe fn free(arg___ptr: *mut ::std::os::raw::c_void) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+            pub fn free(__ptr: *mut ::std::os::raw::c_void);
         }
-        valloc(arg_arg1)
+        free(arg___ptr)
     })
 }
 #[track_caller]
-pub unsafe fn aligned_alloc(
-    arg___alignment: ::std::os::raw::c_ulong,
-    arg___size: ::std::os::raw::c_ulong,
+pub unsafe fn reallocarray(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn aligned_alloc(
-                __alignment: ::std::os::raw::c_ulong,
-                __size: ::std::os::raw::c_ulong,
+            pub fn reallocarray(
+                __ptr: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
             ) -> *mut ::std::os::raw::c_void;
         }
-        aligned_alloc(arg___alignment, arg___size)
+        reallocarray(arg___ptr, arg___nmemb, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn alloca(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+        }
+        alloca(arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn valloc(arg___size: usize) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+        }
+        valloc(arg___size)
     })
 }
 #[track_caller]
@@ -6306,6 +5669,21 @@ pub unsafe fn posix_memalign(
     })
 }
 #[track_caller]
+pub unsafe fn aligned_alloc(
+    arg___alignment: ::std::os::raw::c_ulong,
+    arg___size: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn aligned_alloc(
+                __alignment: ::std::os::raw::c_ulong,
+                __size: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        aligned_alloc(arg___alignment, arg___size)
+    })
+}
+#[track_caller]
 pub unsafe fn abort() {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -6315,161 +5693,500 @@ pub unsafe fn abort() {
     })
 }
 #[track_caller]
-pub unsafe fn abs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        abs(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn atexit(
-    arg_arg1: ::std::option::Option<unsafe extern "C" fn()>,
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn atexit(
-                arg1: ::std::option::Option<unsafe extern "C" fn()>,
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
             ) -> ::std::os::raw::c_int;
         }
-        atexit(arg_arg1)
+        atexit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atof(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
+pub unsafe fn at_quick_exit(
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+            pub fn at_quick_exit(
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
+            ) -> ::std::os::raw::c_int;
         }
-        atof(arg_arg1)
+        at_quick_exit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atoi(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+pub unsafe fn on_exit(
+    arg___func: ::std::option::Option<
+        unsafe extern "C" fn(__status: ::std::os::raw::c_int, __arg: *mut ::std::os::raw::c_void),
+    >,
+    arg___arg: *mut ::std::os::raw::c_void,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+            pub fn on_exit(
+                __func: ::std::option::Option<
+                    unsafe extern "C" fn(
+                        __status: ::std::os::raw::c_int,
+                        __arg: *mut ::std::os::raw::c_void,
+                    ),
+                >,
+                __arg: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int;
         }
-        atoi(arg_arg1)
+        on_exit(arg___func, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn atol(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn exit(__status: ::std::os::raw::c_int);
         }
-        atol(arg_arg1)
+        exit(arg___status)
     })
 }
 #[track_caller]
-pub unsafe fn atoll(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+pub unsafe fn quick_exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+            pub fn quick_exit(__status: ::std::os::raw::c_int);
         }
-        atoll(arg_arg1)
+        quick_exit(arg___status)
     })
 }
+#[track_caller]
+pub unsafe fn _Exit(arg___status: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _Exit(__status: ::std::os::raw::c_int);
+        }
+        _Exit(arg___status)
+    })
+}
+#[track_caller]
+pub unsafe fn getenv(arg___name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        getenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn putenv(arg___string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        putenv(arg___string)
+    })
+}
+#[track_caller]
+pub unsafe fn setenv(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___value: *const ::std::os::raw::c_char,
+    arg___replace: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setenv(
+                __name: *const ::std::os::raw::c_char,
+                __value: *const ::std::os::raw::c_char,
+                __replace: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        setenv(arg___name, arg___value, arg___replace)
+    })
+}
+#[track_caller]
+pub unsafe fn unsetenv(arg___name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        unsetenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn clearenv() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clearenv() -> ::std::os::raw::c_int;
+        }
+        clearenv()
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemp(arg___template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        mkstemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemps(
+    arg___template: *mut ::std::os::raw::c_char,
+    arg___suffixlen: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemps(
+                __template: *mut ::std::os::raw::c_char,
+                __suffixlen: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        mkstemps(arg___template, arg___suffixlen)
+    })
+}
+#[track_caller]
+pub unsafe fn mkdtemp(arg___template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        mkdtemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn system(arg___command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        system(arg___command)
+    })
+}
+#[track_caller]
+pub unsafe fn realpath(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resolved: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn realpath(
+                __name: *const ::std::os::raw::c_char,
+                __resolved: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        realpath(arg___name, arg___resolved)
+    })
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[track_caller]
 pub unsafe fn bsearch(
     arg___key: *const ::std::os::raw::c_void,
     arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bsearch(
                 __key: *const ::std::os::raw::c_void,
                 __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
             ) -> *mut ::std::os::raw::c_void;
         }
-        bsearch(arg___key, arg___base, arg___nel, arg___width, arg___compar)
+        bsearch(arg___key, arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn div(arg_arg1: ::std::os::raw::c_int, arg_arg2: ::std::os::raw::c_int) -> div_t {
+pub unsafe fn qsort(
+    arg___base: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+            pub fn qsort(
+                __base: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
+            );
         }
-        div(arg_arg1, arg_arg2)
+        qsort(arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn abs(arg___x: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exit(arg1: ::std::os::raw::c_int);
+            pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        exit(arg_arg1)
+        abs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn getenv(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn labs(arg___x: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
         }
-        getenv(arg_arg1)
+        labs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn labs(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
+pub unsafe fn llabs(arg___x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+            pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
         }
-        labs(arg_arg1)
+        llabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ldiv(arg_arg1: ::std::os::raw::c_long, arg_arg2: ::std::os::raw::c_long) -> ldiv_t {
+pub unsafe fn div(arg___numer: ::std::os::raw::c_int, arg___denom: ::std::os::raw::c_int) -> div_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+            pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
         }
-        ldiv(arg_arg1, arg_arg2)
+        div(arg___numer, arg___denom)
     })
 }
 #[track_caller]
-pub unsafe fn llabs(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
+pub unsafe fn ldiv(
+    arg___numer: ::std::os::raw::c_long,
+    arg___denom: ::std::os::raw::c_long,
+) -> ldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+            pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long)
+                -> ldiv_t;
         }
-        llabs(arg_arg1)
+        ldiv(arg___numer, arg___denom)
     })
 }
 #[track_caller]
 pub unsafe fn lldiv(
-    arg_arg1: ::std::os::raw::c_longlong,
-    arg_arg2: ::std::os::raw::c_longlong,
+    arg___numer: ::std::os::raw::c_longlong,
+    arg___denom: ::std::os::raw::c_longlong,
 ) -> lldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn lldiv(
-                arg1: ::std::os::raw::c_longlong,
-                arg2: ::std::os::raw::c_longlong,
+                __numer: ::std::os::raw::c_longlong,
+                __denom: ::std::os::raw::c_longlong,
             ) -> lldiv_t;
         }
-        lldiv(arg_arg1, arg_arg2)
+        lldiv(arg___numer, arg___denom)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        ecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn gcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        gcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qfcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qgcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qgcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qgcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        ecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        fcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qfcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
     })
 }
 #[track_caller]
@@ -6485,1295 +6202,180 @@ pub unsafe fn mblen(
     })
 }
 #[track_caller]
-pub unsafe fn mbstowcs(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mbstowcs(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> usize;
-        }
-        mbstowcs(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
 pub unsafe fn mbtowc(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
+    arg___pwc: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn mbtowc(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
+                __pwc: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        mbtowc(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn rand() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand() -> ::std::os::raw::c_int;
-        }
-        rand()
-    })
-}
-#[track_caller]
-pub unsafe fn srand(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand(arg1: ::std::os::raw::c_uint);
-        }
-        srand(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn strtod(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtod(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtof(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtof(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f32;
-        }
-        strtof(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtol(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtol(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_long;
-        }
-        strtol(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtold(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtold(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtold(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoll(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoll(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoll(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoul(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoul(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strtoul(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoull(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoull(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtoull(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn system(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        system(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn wcstombs(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const wchar_t,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wcstombs(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const wchar_t,
-                arg3: usize,
-            ) -> usize;
-        }
-        wcstombs(arg_arg1, arg_arg2, arg_arg3)
+        mbtowc(arg___pwc, arg___s, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn wctomb(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: wchar_t,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___wchar: wchar_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn wctomb(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: wchar_t,
+                __s: *mut ::std::os::raw::c_char,
+                __wchar: wchar_t,
             ) -> ::std::os::raw::c_int;
         }
-        wctomb(arg_arg1, arg_arg2)
+        wctomb(arg___s, arg___wchar)
     })
 }
 #[track_caller]
-pub unsafe fn _Exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn mbstowcs(
+    arg___pwcs: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn _Exit(arg1: ::std::os::raw::c_int);
+            pub fn mbstowcs(
+                __pwcs: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> usize;
         }
-        _Exit(arg_arg1)
+        mbstowcs(arg___pwcs, arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn a64l(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn wcstombs(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___pwcs: *const wchar_t,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn wcstombs(
+                __s: *mut ::std::os::raw::c_char,
+                __pwcs: *const wchar_t,
+                __n: usize,
+            ) -> usize;
         }
-        a64l(arg_arg1)
+        wcstombs(arg___s, arg___pwcs, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn drand48() -> f64 {
+pub unsafe fn rpmatch(arg___response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn drand48() -> f64;
+            pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        drand48()
-    })
-}
-#[track_caller]
-pub unsafe fn ecvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ecvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        ecvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn erand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-        }
-        erand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fcvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        gcvt(arg_arg1, arg_arg2, arg_arg3)
+        rpmatch(arg___response)
     })
 }
 #[track_caller]
 pub unsafe fn getsubopt(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+    arg___optionp: *mut *mut ::std::os::raw::c_char,
+    arg___tokens: *const *mut ::std::os::raw::c_char,
+    arg___valuep: *mut *mut ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn getsubopt(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+                __optionp: *mut *mut ::std::os::raw::c_char,
+                __tokens: *const *mut ::std::os::raw::c_char,
+                __valuep: *mut *mut ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        getsubopt(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn grantpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        grantpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn initstate(
-    arg_arg1: ::std::os::raw::c_uint,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn initstate(
-                arg1: ::std::os::raw::c_uint,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        initstate(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn jrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        jrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn l64a(arg_arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-        }
-        l64a(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lcong48(arg_arg1: *mut ::std::os::raw::c_ushort) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-        }
-        lcong48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrand48() -> ::std::os::raw::c_long;
-        }
-        lrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn mkstemp(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        mkstemp(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mrand48() -> ::std::os::raw::c_long;
-        }
-        mrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn nrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        nrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn posix_openpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        posix_openpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname(arg_arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        ptsname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname_r(
-    arg_fildes: ::std::os::raw::c_int,
-    arg_buffer: *mut ::std::os::raw::c_char,
-    arg_buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname_r(
-                fildes: ::std::os::raw::c_int,
-                buffer: *mut ::std::os::raw::c_char,
-                buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        ptsname_r(arg_fildes, arg_buffer, arg_buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn putenv(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        putenv(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn random() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn random() -> ::std::os::raw::c_long;
-        }
-        random()
-    })
-}
-#[track_caller]
-pub unsafe fn rand_r(arg_arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-        }
-        rand_r(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn realpath(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-            pub fn realpath(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        realpath(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn seed48(arg_arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-        }
-        seed48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setenv(
-    arg___name: *const ::std::os::raw::c_char,
-    arg___value: *const ::std::os::raw::c_char,
-    arg___overwrite: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setenv(
-                __name: *const ::std::os::raw::c_char,
-                __value: *const ::std::os::raw::c_char,
-                __overwrite: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setenv(arg___name, arg___value, arg___overwrite)
-    })
-}
-#[track_caller]
-pub unsafe fn setkey(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setkey(arg1: *const ::std::os::raw::c_char);
-        }
-        setkey(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setstate(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        setstate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srand48(arg_arg1: ::std::os::raw::c_long) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand48(arg1: ::std::os::raw::c_long);
-        }
-        srand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srandom(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandom(arg1: ::std::os::raw::c_uint);
-        }
-        srandom(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unlockpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        unlockpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unsetenv(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        unsetenv(arg_arg1)
-    })
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[track_caller]
-pub unsafe fn arc4random() -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random() -> u32;
-        }
-        arc4random()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_addrandom(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: ::std::os::raw::c_int,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_addrandom(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: ::std::os::raw::c_int,
-            );
-        }
-        arc4random_addrandom(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___nbytes: usize) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-        }
-        arc4random_buf(arg___buf, arg___nbytes)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_stir() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_stir();
-        }
-        arc4random_stir()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_uniform(arg___upper_bound: u32) -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-        }
-        arc4random_uniform(arg___upper_bound)
-    })
-}
-#[track_caller]
-pub unsafe fn atexit_b(arg_arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-        }
-        atexit_b(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn bsearch_b(
-    arg___key: *const ::std::os::raw::c_void,
-    arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bsearch_b(
-                __key: *const ::std::os::raw::c_void,
-                __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        bsearch_b(arg___key, arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetcap(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetcap(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        cgetcap(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetclose() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetclose() -> ::std::os::raw::c_int;
-        }
-        cgetclose()
-    })
-}
-#[track_caller]
-pub unsafe fn cgetent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetent(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetfirst(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetfirst(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetfirst(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetmatch(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetmatch(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetmatch(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnext(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnext(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnext(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnum(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnum(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnum(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetset(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        cgetset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetstr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetstr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetstr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetustr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetustr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetustr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn daemon(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn daemon(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        daemon(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname(arg_arg1: dev_t, arg_arg2: mode_t) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-        }
-        devname(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname_r(
-    arg_arg1: dev_t,
-    arg_arg2: mode_t,
-    arg_buf: *mut ::std::os::raw::c_char,
-    arg_len: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname_r(
-                arg1: dev_t,
-                arg2: mode_t,
-                buf: *mut ::std::os::raw::c_char,
-                len: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        devname_r(arg_arg1, arg_arg2, arg_buf, arg_len)
-    })
-}
-#[track_caller]
-pub unsafe fn getbsize(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_long,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getbsize(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_long,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        getbsize(arg_arg1, arg_arg2)
+        getsubopt(arg___optionp, arg___tokens, arg___valuep)
     })
 }
 #[track_caller]
 pub unsafe fn getloadavg(
-    arg_arg1: *mut f64,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___loadavg: *mut f64,
+    arg___nelem: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int)
-                -> ::std::os::raw::c_int;
-        }
-        getloadavg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getprogname() -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprogname() -> *const ::std::os::raw::c_char;
-        }
-        getprogname()
-    })
-}
-#[track_caller]
-pub unsafe fn setprogname(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-        }
-        setprogname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn heapsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+            pub fn getloadavg(
+                __loadavg: *mut f64,
+                __nelem: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        heapsort(arg___base, arg___nel, arg___width, arg___compar)
+        getloadavg(arg___loadavg, arg___nelem)
     })
 }
 #[track_caller]
-pub unsafe fn heapsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        heapsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        psort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        qsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn radixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn radixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        radixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn rpmatch(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        rpmatch(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sradixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sradixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        sradixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn sranddev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sranddev();
-        }
-        sranddev()
-    })
-}
-#[track_caller]
-pub unsafe fn srandomdev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandomdev();
-        }
-        srandomdev()
-    })
-}
-#[track_caller]
-pub unsafe fn reallocf(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: usize,
+pub unsafe fn memcpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn reallocf(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: usize,
+            pub fn memcpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        reallocf(arg___ptr, arg___size)
+        memcpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtonum(
-    arg___numstr: *const ::std::os::raw::c_char,
-    arg___minval: ::std::os::raw::c_longlong,
-    arg___maxval: ::std::os::raw::c_longlong,
-    arg___errstrp: *mut *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_longlong {
+pub unsafe fn memmove(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strtonum(
-                __numstr: *const ::std::os::raw::c_char,
-                __minval: ::std::os::raw::c_longlong,
-                __maxval: ::std::os::raw::c_longlong,
-                __errstrp: *mut *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_longlong;
+            pub fn memmove(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
         }
-        strtonum(arg___numstr, arg___minval, arg___maxval, arg___errstrp)
+        memmove(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtoq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoq(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtouq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtouq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtouq(arg___str, arg___endptr, arg___base)
-    })
-}
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[track_caller]
-pub unsafe fn memchr(
-    arg___s: *const ::std::os::raw::c_void,
+pub unsafe fn memccpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
     arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memchr(
-                __s: *const ::std::os::raw::c_void,
+            pub fn memccpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
                 __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memchr(arg___s, arg___c, arg___n)
+        memccpy(arg___dest, arg___src, arg___c, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memset(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn memset(
+                __s: *mut ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        memset(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
@@ -7794,84 +6396,101 @@ pub unsafe fn memcmp(
     })
 }
 #[track_caller]
-pub unsafe fn memcpy(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
+pub unsafe fn __memcmpeq(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __memcmpeq(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        __memcmpeq(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memchr(
+    arg___s: *const ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memcpy(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
+            pub fn memchr(
+                __s: *const ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memcpy(arg___dst, arg___src, arg___n)
+        memchr(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn memmove(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memmove(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memmove(arg___dst, arg___src, arg___len)
+        strcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn memset(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset(
-                __b: *mut ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset(arg___b, arg___c, arg___len)
+        strncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn strcat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strcat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcat(arg___s1, arg___s2)
+        strcat(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn strchr(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___c: ::std::os::raw::c_int,
+pub unsafe fn strncat(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strchr(
-                __s: *const ::std::os::raw::c_char,
-                __c: ::std::os::raw::c_int,
+            pub fn strncat(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strchr(arg___s, arg___c)
+        strncat(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
@@ -7887,86 +6506,6 @@ pub unsafe fn strcmp(
             ) -> ::std::os::raw::c_int;
         }
         strcmp(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcoll(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcoll(
-                __s1: *const ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        strcoll(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strcpy(arg___dst, arg___src)
-    })
-}
-#[track_caller]
-pub unsafe fn strcspn(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcspn(
-                __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strcspn(arg___s, arg___charset)
-    })
-}
-#[track_caller]
-pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strerror(arg___errnum)
-    })
-}
-#[track_caller]
-pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-        }
-        strlen(arg___s)
-    })
-}
-#[track_caller]
-pub unsafe fn strncat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strncat(arg___s1, arg___s2, arg___n)
     })
 }
 #[track_caller]
@@ -7987,35 +6526,130 @@ pub unsafe fn strncmp(
     })
 }
 #[track_caller]
-pub unsafe fn strncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
+pub unsafe fn strcoll(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm(
+    arg___dest: *mut ::std::os::raw::c_char,
     arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strxfrm(arg___dest, arg___src, arg___n)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[track_caller]
+pub unsafe fn strcoll_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __l: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll_l(arg___s1, arg___s2, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm_l(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___l: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm_l(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+                __l: locale_t,
+            ) -> usize;
+        }
+        strxfrm_l(arg___dest, arg___src, arg___n, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strdup(arg___s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        strdup(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strndup(
+    arg___string: *const ::std::os::raw::c_char,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
+            pub fn strndup(
+                __string: *const ::std::os::raw::c_char,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strncpy(arg___dst, arg___src, arg___n)
+        strndup(arg___string, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strpbrk(
+pub unsafe fn strchr(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strpbrk(
+            pub fn strchr(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strpbrk(arg___s, arg___charset)
+        strchr(arg___s, arg___c)
     })
 }
 #[track_caller]
@@ -8034,358 +6668,349 @@ pub unsafe fn strrchr(
     })
 }
 #[track_caller]
+pub unsafe fn strcspn(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___reject: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcspn(
+                __s: *const ::std::os::raw::c_char,
+                __reject: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strcspn(arg___s, arg___reject)
+    })
+}
+#[track_caller]
 pub unsafe fn strspn(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strspn(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_ulong;
         }
-        strspn(arg___s, arg___charset)
+        strspn(arg___s, arg___accept)
+    })
+}
+#[track_caller]
+pub unsafe fn strpbrk(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strpbrk(
+                __s: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        strpbrk(arg___s, arg___accept)
     })
 }
 #[track_caller]
 pub unsafe fn strstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+    arg___haystack: *const ::std::os::raw::c_char,
+    arg___needle: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+                __haystack: *const ::std::os::raw::c_char,
+                __needle: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strstr(arg___big, arg___little)
+        strstr(arg___haystack, arg___needle)
     })
 }
 #[track_caller]
 pub unsafe fn strtok(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok(arg___str, arg___sep)
+        strtok(arg___s, arg___delim)
     })
 }
 #[track_caller]
-pub unsafe fn strxfrm(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn __strtok_r(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strxfrm(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn __strtok_r(
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strxfrm(arg___s1, arg___s2, arg___n)
+        __strtok_r(arg___s, arg___delim, arg___save_ptr)
     })
 }
 #[track_caller]
 pub unsafe fn strtok_r(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
-    arg___lasts: *mut *mut ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok_r(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
-                __lasts: *mut *mut ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok_r(arg___str, arg___sep, arg___lasts)
+        strtok_r(arg___s, arg___delim, arg___save_ptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+        }
+        strlen(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strnlen(arg___string: *const ::std::os::raw::c_char, arg___maxlen: usize) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+        }
+        strnlen(arg___string, arg___maxlen)
+    })
+}
+#[track_caller]
+pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+        }
+        strerror(arg___errnum)
     })
 }
 #[track_caller]
 pub unsafe fn strerror_r(
     arg___errnum: ::std::os::raw::c_int,
-    arg___strerrbuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut ::std::os::raw::c_char,
     arg___buflen: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
+            #[link_name = "\u{1}__xpg_strerror_r"]
             pub fn strerror_r(
                 __errnum: ::std::os::raw::c_int,
-                __strerrbuf: *mut ::std::os::raw::c_char,
+                __buf: *mut ::std::os::raw::c_char,
                 __buflen: usize,
             ) -> ::std::os::raw::c_int;
         }
-        strerror_r(arg___errnum, arg___strerrbuf, arg___buflen)
+        strerror_r(arg___errnum, arg___buf, arg___buflen)
     })
 }
 #[track_caller]
-pub unsafe fn strdup(arg___s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn strerror_l(
+    arg___errnum: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn strerror_l(
+                __errnum: ::std::os::raw::c_int,
+                __l: locale_t,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strdup(arg___s1)
+        strerror_l(arg___errnum, arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn memccpy(
-    arg___dst: *mut ::std::os::raw::c_void,
+pub unsafe fn bcmp(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn bcmp(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        bcmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn bcopy(
     arg___src: *const ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memccpy(
-                __dst: *mut ::std::os::raw::c_void,
+            pub fn bcopy(
                 __src: *const ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+                __dest: *mut ::std::os::raw::c_void,
+                __n: usize,
+            );
         }
-        memccpy(arg___dst, arg___src, arg___c, arg___n)
+        bcopy(arg___src, arg___dest, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: ::std::os::raw::c_ulong) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn stpcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
         }
-        stpcpy(arg___dst, arg___src)
+        bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn stpncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        stpncpy(arg___dst, arg___src, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strndup(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strndup(
-                __s1: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strndup(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strnlen(arg___s1: *const ::std::os::raw::c_char, arg___n: usize) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
-        }
-        strnlen(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strsignal(arg___sig)
-    })
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[track_caller]
-pub unsafe fn memset_s(
-    arg___s: *mut ::std::os::raw::c_void,
-    arg___smax: rsize_t,
+pub unsafe fn index(
+    arg___s: *const ::std::os::raw::c_char,
     arg___c: ::std::os::raw::c_int,
-    arg___n: rsize_t,
-) -> errno_t {
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset_s(
-                __s: *mut ::std::os::raw::c_void,
-                __smax: rsize_t,
+            pub fn index(
+                __s: *const ::std::os::raw::c_char,
                 __c: ::std::os::raw::c_int,
-                __n: rsize_t,
-            ) -> errno_t;
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset_s(arg___s, arg___smax, arg___c, arg___n)
+        index(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn memmem(
-    arg___big: *const ::std::os::raw::c_void,
-    arg___big_len: usize,
-    arg___little: *const ::std::os::raw::c_void,
-    arg___little_len: usize,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memmem(
-                __big: *const ::std::os::raw::c_void,
-                __big_len: usize,
-                __little: *const ::std::os::raw::c_void,
-                __little_len: usize,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        memmem(arg___big, arg___big_len, arg___little, arg___little_len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern4(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern4: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern4(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern4: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern4(arg___b, arg___pattern4, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern8(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern8: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern8(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern8: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern8(arg___b, arg___pattern8, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern16(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern16: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern16(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern16: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern16(arg___b, arg___pattern16, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strcasestr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+pub unsafe fn rindex(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasestr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+            pub fn rindex(
+                __s: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcasestr(arg___big, arg___little)
+        rindex(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn strnstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
-    arg___len: usize,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ffs(arg___i: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strnstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
-                __len: usize,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        strnstr(arg___big, arg___little, arg___len)
+        ffs(arg___i)
     })
 }
 #[track_caller]
-pub unsafe fn strlcat(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsl(arg___l: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcat(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
         }
-        strlcat(arg___dst, arg___source, arg___size)
+        ffsl(arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn strlcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsll(arg___ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
         }
-        strlcpy(arg___dst, arg___source, arg___size)
+        ffsll(arg___ll)
     })
 }
 #[track_caller]
-pub unsafe fn strmode(arg___mode: ::std::os::raw::c_int, arg___bp: *mut ::std::os::raw::c_char) {
+pub unsafe fn strcasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+            pub fn strcasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        strmode(arg___mode, arg___bp)
+        strcasecmp(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn strcasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcasecmp_l(arg___s1, arg___s2, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: usize,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp_l(arg___s1, arg___s2, arg___n, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn explicit_bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+        }
+        explicit_bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
@@ -8404,285 +7029,111 @@ pub unsafe fn strsep(
     })
 }
 #[track_caller]
-pub unsafe fn swab(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: isize,
-) {
+pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn swab(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: isize,
-            );
+            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
         }
-        swab(arg_arg1, arg_arg2, arg_arg3)
+        strsignal(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn timingsafe_bcmp(
-    arg___b1: *const ::std::os::raw::c_void,
-    arg___b2: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timingsafe_bcmp(
-                __b1: *const ::std::os::raw::c_void,
-                __b2: *const ::std::os::raw::c_void,
-                __len: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        timingsafe_bcmp(arg___b1, arg___b2, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal_r(
-    arg___sig: ::std::os::raw::c_int,
-    arg___strsignalbuf: *mut ::std::os::raw::c_char,
-    arg___buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal_r(
-                __sig: ::std::os::raw::c_int,
-                __strsignalbuf: *mut ::std::os::raw::c_char,
-                __buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        strsignal_r(arg___sig, arg___strsignalbuf, arg___buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn bcmp(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcmp(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        bcmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bcopy(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcopy(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-            );
-        }
-        bcopy(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bzero(arg_arg1: *mut ::std::os::raw::c_void, arg_arg2: ::std::os::raw::c_ulong) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-        }
-        bzero(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn index(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn __stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn index(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn __stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        index(arg_arg1, arg_arg2)
+        __stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn rindex(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rindex(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        rindex(arg_arg1, arg_arg2)
+        stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn ffs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        ffs(arg_arg1)
+        __stpncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strcasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
+            pub fn stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strcasecmp(arg_arg1, arg_arg2)
+        stpncpy(arg___dest, arg___src, arg___n)
     })
 }
-#[track_caller]
-pub unsafe fn strncasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        strncasecmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        ffsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        ffsll(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fls(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        fls(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        flsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        flsll(arg_arg1)
-    })
-}
-pub type max_align_t = f64;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[track_caller]
-pub unsafe fn __darwin_check_fd_set_overflow(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn __errno_location() -> *mut ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __darwin_check_fd_set_overflow(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn __errno_location() -> *mut ::std::os::raw::c_int;
         }
-        __darwin_check_fd_set_overflow(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[track_caller]
-pub unsafe fn __error() -> *mut ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __error() -> *mut ::std::os::raw::c_int;
-        }
-        __error()
+        __errno_location()
     })
 }
 #[repr(C)]
@@ -8707,8 +7158,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -8723,6 +7174,21 @@ impl Default for lconv {
     }
 }
 #[track_caller]
+pub unsafe fn setlocale(
+    arg___category: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlocale(
+                __category: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        setlocale(arg___category, arg___locale)
+    })
+}
+#[track_caller]
 pub unsafe fn localeconv() -> *mut lconv {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -8732,18 +7198,47 @@ pub unsafe fn localeconv() -> *mut lconv {
     })
 }
 #[track_caller]
-pub unsafe fn setlocale(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn newlocale(
+    arg___category_mask: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+    arg___base: locale_t,
+) -> locale_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setlocale(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn newlocale(
+                __category_mask: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+                __base: locale_t,
+            ) -> locale_t;
         }
-        setlocale(arg_arg1, arg_arg2)
+        newlocale(arg___category_mask, arg___locale, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn duplocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn duplocale(__dataset: locale_t) -> locale_t;
+        }
+        duplocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn freelocale(arg___dataset: locale_t) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freelocale(__dataset: locale_t);
+        }
+        freelocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn uselocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn uselocale(__dataset: locale_t) -> locale_t;
+        }
+        uselocale(arg___dataset)
     })
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
@@ -8877,163 +7372,401 @@ impl Default for PGAlignedXLogBlock {
         }
     }
 }
+pub const _ISupper: _bindgen_ty_1 = 256;
+pub const _ISlower: _bindgen_ty_1 = 512;
+pub const _ISalpha: _bindgen_ty_1 = 1024;
+pub const _ISdigit: _bindgen_ty_1 = 2048;
+pub const _ISxdigit: _bindgen_ty_1 = 4096;
+pub const _ISspace: _bindgen_ty_1 = 8192;
+pub const _ISprint: _bindgen_ty_1 = 16384;
+pub const _ISgraph: _bindgen_ty_1 = 32768;
+pub const _ISblank: _bindgen_ty_1 = 1;
+pub const _IScntrl: _bindgen_ty_1 = 2;
+pub const _ISpunct: _bindgen_ty_1 = 4;
+pub const _ISalnum: _bindgen_ty_1 = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn fdatasync(arg_fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
         }
-        fdatasync(arg_fildes)
-    })
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
-}
-extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
-}
-#[track_caller]
-pub unsafe fn ___runetype(arg_arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
-        }
-        ___runetype(arg_arg1)
+        __ctype_b_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_tolower_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
         }
-        ___tolower(arg_arg1)
+        __ctype_tolower_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_toupper_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
         }
-        ___toupper(arg_arg1)
+        __ctype_toupper_loc()
     })
 }
 #[track_caller]
-pub unsafe fn __maskrune(
-    arg_arg1: __darwin_ct_rune_t,
-    arg_arg2: ::std::os::raw::c_ulong,
+pub unsafe fn isalnum(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalnum(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalpha(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalpha(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn iscntrl(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        iscntrl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn islower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        islower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isgraph(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isprint(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        ispunct(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isspace(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isxdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        tolower(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toupper(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isblank(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn _toupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _toupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn _tolower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _tolower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalnum_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __maskrune(
-                arg1: __darwin_ct_rune_t,
-                arg2: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
+            pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __maskrune(arg_arg1, arg_arg2)
+        isalnum_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn isalpha_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __toupper(arg_arg1)
+        isalpha_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn iscntrl_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __tolower(arg_arg1)
+        iscntrl_l(arg_arg1, arg_arg2)
     })
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[track_caller]
+pub unsafe fn isdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn islower_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        islower_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isgraph_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isprint_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        ispunct_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isspace_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isupper_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t)
+                -> ::std::os::raw::c_int;
+        }
+        isxdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isblank_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn __toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __toupper_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        toupper_l(arg___c, arg___l)
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -9049,68 +7782,30 @@ impl Default for iovec {
         }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-pub type sockaddr_ref_t = *mut sockaddr;
-pub type sockaddr_ref_ref_t = *mut *mut sockaddr;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sockaddr_header {
-    pub sa_len: __uint8_t,
-    pub sa_family: sa_family_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
@@ -9121,17 +7816,37 @@ impl Default for sockaddr_storage {
         }
     }
 }
-pub type sockaddr_storage_ref_t = *mut sockaddr_storage;
-pub type sockaddr_storage_ref_ref_t = *mut *mut sockaddr_storage;
+pub const MSG_OOB: _bindgen_ty_2 = 1;
+pub const MSG_PEEK: _bindgen_ty_2 = 2;
+pub const MSG_DONTROUTE: _bindgen_ty_2 = 4;
+pub const MSG_CTRUNC: _bindgen_ty_2 = 8;
+pub const MSG_PROXY: _bindgen_ty_2 = 16;
+pub const MSG_TRUNC: _bindgen_ty_2 = 32;
+pub const MSG_DONTWAIT: _bindgen_ty_2 = 64;
+pub const MSG_EOR: _bindgen_ty_2 = 128;
+pub const MSG_WAITALL: _bindgen_ty_2 = 256;
+pub const MSG_FIN: _bindgen_ty_2 = 512;
+pub const MSG_SYN: _bindgen_ty_2 = 1024;
+pub const MSG_CONFIRM: _bindgen_ty_2 = 2048;
+pub const MSG_RST: _bindgen_ty_2 = 4096;
+pub const MSG_ERRQUEUE: _bindgen_ty_2 = 8192;
+pub const MSG_NOSIGNAL: _bindgen_ty_2 = 16384;
+pub const MSG_MORE: _bindgen_ty_2 = 32768;
+pub const MSG_WAITFORONE: _bindgen_ty_2 = 65536;
+pub const MSG_BATCH: _bindgen_ty_2 = 262144;
+pub const MSG_ZEROCOPY: _bindgen_ty_2 = 67108864;
+pub const MSG_FASTOPEN: _bindgen_ty_2 = 536870912;
+pub const MSG_CMSG_CLOEXEC: _bindgen_ty_2 = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -9144,438 +7859,423 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[track_caller]
+pub unsafe fn __cmsg_nxthdr(arg___mhdr: *mut msghdr, arg___cmsg: *mut cmsghdr) -> *mut cmsghdr {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+        }
+        __cmsg_nxthdr(arg___mhdr, arg___cmsg)
+    })
+}
+pub const SCM_RIGHTS: _bindgen_ty_3 = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn accept(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn accept(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        accept(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bind(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bind(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        bind(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn connect(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn connect(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        connect(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getpeername(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpeername(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getpeername(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockname(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockname(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockname(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_void,
-    arg_arg5: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_void,
-                arg5: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn listen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn listen(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        listen(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn recv(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recv(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recv(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn recvfrom(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *mut sockaddr,
-    arg_arg6: *mut socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvfrom(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *mut sockaddr,
-                arg6: *mut socklen_t,
-            ) -> isize;
-        }
-        recvfrom(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn recvmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recvmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn send(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn send(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        send(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn sendmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        sendmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn sendto(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *const sockaddr,
-    arg_arg6: socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendto(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const sockaddr,
-                arg6: socklen_t,
-            ) -> isize;
-        }
-        sendto(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_void,
-    arg_arg5: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_void,
-                arg5: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn shutdown(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn shutdown(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        shutdown(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sockatmark(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sockatmark(arg_arg1)
-    })
-}
+pub const SHUT_RD: _bindgen_ty_4 = 0;
+pub const SHUT_WR: _bindgen_ty_4 = 1;
+pub const SHUT_RDWR: _bindgen_ty_4 = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn socket(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socket(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socket(arg_arg1, arg_arg2, arg_arg3)
+        socket(arg___domain, arg___type, arg___protocol)
     })
 }
 #[track_caller]
 pub unsafe fn socketpair(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
+    arg___fds: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socketpair(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
+                __fds: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socketpair(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        socketpair(arg___domain, arg___type, arg___protocol, arg___fds)
     })
 }
 #[track_caller]
-pub unsafe fn sendfile(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: off_t,
-    arg_arg4: *mut off_t,
-    arg_arg5: *mut sf_hdtr,
-    arg_arg6: ::std::os::raw::c_int,
+pub unsafe fn bind(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sendfile(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: off_t,
-                arg4: *mut off_t,
-                arg5: *mut sf_hdtr,
-                arg6: ::std::os::raw::c_int,
+            pub fn bind(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        sendfile(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
+        bind(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn pfctlinput(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut sockaddr) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-        }
-        pfctlinput(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn connectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sa_endpoints_t,
-    arg_arg3: sae_associd_t,
-    arg_arg4: ::std::os::raw::c_uint,
-    arg_arg5: *const iovec,
-    arg_arg6: ::std::os::raw::c_uint,
-    arg_arg7: *mut usize,
-    arg_arg8: *mut sae_connid_t,
+pub unsafe fn getsockname(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn connectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sa_endpoints_t,
-                arg3: sae_associd_t,
-                arg4: ::std::os::raw::c_uint,
-                arg5: *const iovec,
-                arg6: ::std::os::raw::c_uint,
-                arg7: *mut usize,
-                arg8: *mut sae_connid_t,
+            pub fn getsockname(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        connectx(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7, arg_arg8)
+        getsockname(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn disconnectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: sae_associd_t,
-    arg_arg3: sae_connid_t,
+pub unsafe fn connect(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn disconnectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: sae_associd_t,
-                arg3: sae_connid_t,
+            pub fn connect(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        disconnectx(arg_arg1, arg_arg2, arg_arg3)
+        connect(arg___fd, arg___addr, arg___len)
     })
 }
+#[track_caller]
+pub unsafe fn getpeername(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeername(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeername(arg___fd, arg___addr, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn send(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn send(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        send(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recv(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recv(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recv(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn sendto(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___addr_len: socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendto(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __addr_len: socklen_t,
+            ) -> isize;
+        }
+        sendto(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn recvfrom(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvfrom(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> isize;
+        }
+        recvfrom(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn sendmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *const msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *const msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        sendmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recvmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *mut msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *mut msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recvmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn getsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *mut ::std::os::raw::c_void,
+    arg___optlen: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *mut ::std::os::raw::c_void,
+                __optlen: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn setsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *const ::std::os::raw::c_void,
+    arg___optlen: socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *const ::std::os::raw::c_void,
+                __optlen: socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        setsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn listen(
+    arg___fd: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn listen(
+                __fd: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        listen(arg___fd, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn accept(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn accept(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        accept(arg___fd, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn shutdown(
+    arg___fd: ::std::os::raw::c_int,
+    arg___how: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn shutdown(
+                __fd: ::std::os::raw::c_int,
+                __how: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        shutdown(arg___fd, arg___how)
+    })
+}
+#[track_caller]
+pub unsafe fn sockatmark(arg___fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sockatmark(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn isfdtype(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fdtype: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isfdtype(
+                __fd: ::std::os::raw::c_int,
+                __fdtype: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        isfdtype(arg___fd, arg___fdtype)
+    })
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9594,12 +8294,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -9607,175 +8301,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn setipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: u32,
-    arg_arg5: u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: u32,
-                arg5: u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        setipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn getipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: *mut u32,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: *mut u32,
-                arg5: *mut u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        getipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: u32,
-    arg_arg6: u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: u32,
-                arg6: u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: *mut u32,
-                arg6: *mut u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: _bindgen_ty_5 = 0;
+pub const IPPROTO_ICMP: _bindgen_ty_5 = 1;
+pub const IPPROTO_IGMP: _bindgen_ty_5 = 2;
+pub const IPPROTO_IPIP: _bindgen_ty_5 = 4;
+pub const IPPROTO_TCP: _bindgen_ty_5 = 6;
+pub const IPPROTO_EGP: _bindgen_ty_5 = 8;
+pub const IPPROTO_PUP: _bindgen_ty_5 = 12;
+pub const IPPROTO_UDP: _bindgen_ty_5 = 17;
+pub const IPPROTO_IDP: _bindgen_ty_5 = 22;
+pub const IPPROTO_TP: _bindgen_ty_5 = 29;
+pub const IPPROTO_DCCP: _bindgen_ty_5 = 33;
+pub const IPPROTO_IPV6: _bindgen_ty_5 = 41;
+pub const IPPROTO_RSVP: _bindgen_ty_5 = 46;
+pub const IPPROTO_GRE: _bindgen_ty_5 = 47;
+pub const IPPROTO_ESP: _bindgen_ty_5 = 50;
+pub const IPPROTO_AH: _bindgen_ty_5 = 51;
+pub const IPPROTO_MTP: _bindgen_ty_5 = 92;
+pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
+pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
+pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
+pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
+pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
+pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
+pub const IPPROTO_ETHERNET: _bindgen_ty_5 = 143;
+pub const IPPROTO_RAW: _bindgen_ty_5 = 255;
+pub const IPPROTO_MPTCP: _bindgen_ty_5 = 262;
+pub const IPPROTO_MAX: _bindgen_ty_5 = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: _bindgen_ty_6 = 0;
+pub const IPPROTO_ROUTING: _bindgen_ty_6 = 43;
+pub const IPPROTO_FRAGMENT: _bindgen_ty_6 = 44;
+pub const IPPROTO_ICMPV6: _bindgen_ty_6 = 58;
+pub const IPPROTO_NONE: _bindgen_ty_6 = 59;
+pub const IPPROTO_DSTOPTS: _bindgen_ty_6 = 60;
+pub const IPPROTO_MH: _bindgen_ty_6 = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: _bindgen_ty_7 = 7;
+pub const IPPORT_DISCARD: _bindgen_ty_7 = 9;
+pub const IPPORT_SYSTAT: _bindgen_ty_7 = 11;
+pub const IPPORT_DAYTIME: _bindgen_ty_7 = 13;
+pub const IPPORT_NETSTAT: _bindgen_ty_7 = 15;
+pub const IPPORT_FTP: _bindgen_ty_7 = 21;
+pub const IPPORT_TELNET: _bindgen_ty_7 = 23;
+pub const IPPORT_SMTP: _bindgen_ty_7 = 25;
+pub const IPPORT_TIMESERVER: _bindgen_ty_7 = 37;
+pub const IPPORT_NAMESERVER: _bindgen_ty_7 = 42;
+pub const IPPORT_WHOIS: _bindgen_ty_7 = 43;
+pub const IPPORT_MTP: _bindgen_ty_7 = 57;
+pub const IPPORT_TFTP: _bindgen_ty_7 = 69;
+pub const IPPORT_RJE: _bindgen_ty_7 = 77;
+pub const IPPORT_FINGER: _bindgen_ty_7 = 79;
+pub const IPPORT_TTYLINK: _bindgen_ty_7 = 87;
+pub const IPPORT_SUPDUP: _bindgen_ty_7 = 95;
+pub const IPPORT_EXECSERVER: _bindgen_ty_7 = 512;
+pub const IPPORT_LOGINSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_CMDSERVER: _bindgen_ty_7 = 514;
+pub const IPPORT_EFSSERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_BIFFUDP: _bindgen_ty_7 = 512;
+pub const IPPORT_WHOSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_ROUTESERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_RESERVED: _bindgen_ty_7 = 1024;
+pub const IPPORT_USERRESERVED: _bindgen_ty_7 = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -9795,16 +8401,28 @@ impl Default for in6_addr {
         }
     }
 }
-pub type in6_addr_t = in6_addr;
+extern "C" {
+    pub static in6addr_any: in6_addr;
+}
+extern "C" {
+    pub static in6addr_loopback: in6_addr;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
     pub sin6_family: sa_family_t,
     pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
+    pub sin6_flowinfo: u32,
     pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
+    pub sin6_scope_id: u32,
 }
 impl Default for sockaddr_in6 {
     fn default() -> Self {
@@ -9815,23 +8433,18 @@ impl Default for sockaddr_in6 {
         }
     }
 }
-extern "C" {
-    pub static in6addr_any: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
 }
-extern "C" {
-    pub static in6addr_loopback: in6_addr;
-}
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -9849,12 +8462,12 @@ impl Default for ipv6_mreq {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+#[derive(Debug, Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9864,12 +8477,40 @@ impl Default for in6_pktinfo {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+#[derive(Debug, Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9879,464 +8520,236 @@ impl Default for ip6_mtuinfo {
     }
 }
 #[track_caller]
-pub unsafe fn inet6_option_space(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn ntohl(arg___netlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn ntohl(__netlong: u32) -> u32;
         }
-        inet6_option_space(arg_arg1)
+        ntohl(arg___netlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *mut *mut cmsghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ntohs(arg___netshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut *mut cmsghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn ntohs(__netshort: u16) -> u16;
         }
-        inet6_option_init(arg_arg1, arg_arg2, arg_arg3)
+        ntohs(arg___netshort)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_append(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn htonl(arg___hostlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_append(
-                arg1: *mut cmsghdr,
-                arg2: *const __uint8_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn htonl(__hostlong: u32) -> u32;
         }
-        inet6_option_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        htonl(arg___hostlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_alloc(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut __uint8_t {
+pub unsafe fn htons(arg___hostshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_alloc(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut __uint8_t;
+            pub fn htons(__hostshort: u16) -> u16;
         }
-        inet6_option_alloc(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_next(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_next(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_next(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_find(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_find(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_find(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> usize;
-        }
-        inet6_rthdr_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut cmsghdr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut cmsghdr;
-        }
-        inet6_rthdr_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_add(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const in6_addr,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_add(
-                arg1: *mut cmsghdr,
-                arg2: *const in6_addr,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_add(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_lasthop(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_lasthop(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_lasthop(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_segments(arg_arg1: *const cmsghdr) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getaddr(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getaddr(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rthdr_getaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getflags(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getflags(
-                arg1: *const cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_getflags(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_append(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: socklen_t,
-    arg_arg6: __uint8_t,
-    arg_arg7: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_append(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: socklen_t,
-                arg6: __uint8_t,
-                arg7: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_finish(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_finish(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_finish(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_set_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_set_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_set_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_next(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_next(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_next(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_find(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_find(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_find(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_get_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_get_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_get_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> socklen_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> socklen_t;
-        }
-        inet6_rth_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        inet6_rth_init(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_add(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *const in6_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_add(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const in6_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_add(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_reverse(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_reverse(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_reverse(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_segments(arg_arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void)
-                -> ::std::os::raw::c_int;
-        }
-        inet6_rth_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_getaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_getaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rth_getaddr(arg_arg1, arg_arg2)
+        htons(arg___hostshort)
     })
 }
 #[track_caller]
 pub unsafe fn bindresvport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr_in,
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bindresvport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr_in,
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport(arg_arg1, arg_arg2)
+        bindresvport(arg___sockfd, arg___sock_in)
     })
 }
 #[track_caller]
-pub unsafe fn bindresvport_sa(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
+pub unsafe fn bindresvport6(
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in6,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bindresvport_sa(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
+            pub fn bindresvport6(
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in6,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport_sa(arg_arg1, arg_arg2)
+        bindresvport6(arg___sockfd, arg___sock_in)
     })
 }
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn setrpcent(arg___stayopen: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
+        }
+        setrpcent(arg___stayopen)
+    })
+}
+#[track_caller]
+pub unsafe fn endrpcent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endrpcent();
+        }
+        endrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname(arg___name: *const ::std::os::raw::c_char) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
+        }
+        getrpcbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber(arg___number: ::std::os::raw::c_int) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
+        }
+        getrpcbynumber(arg___number)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent() -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent() -> *mut rpcent;
+        }
+        getrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbyname_r(arg___name, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber_r(
+    arg___number: ::std::os::raw::c_int,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber_r(
+                __number: ::std::os::raw::c_int,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbynumber_r(arg___number, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent_r(
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent_r(
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcent_r(arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn __h_errno_location() -> *mut ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+        }
+        __h_errno_location()
+    })
+}
+#[track_caller]
+pub unsafe fn herror(arg___str: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn herror(__str: *const ::std::os::raw::c_char);
+        }
+        herror(arg___str)
+    })
+}
+#[track_caller]
+pub unsafe fn hstrerror(arg___err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        hstrerror(arg___err_num)
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10356,22 +8769,322 @@ impl Default for hostent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
+#[track_caller]
+pub unsafe fn sethostent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sethostent(__stay_open: ::std::os::raw::c_int);
         }
-    }
+        sethostent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endhostent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endhostent();
+        }
+        endhostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent() -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent() -> *mut hostent;
+        }
+        gethostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyaddr(arg___addr, arg___len, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname(arg___name: *const ::std::os::raw::c_char) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+        }
+        gethostbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyname2(arg___name, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent_r(
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent_r(
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr_r(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr_r(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyaddr_r(
+            arg___addr,
+            arg___len,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2_r(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname2_r(
+            arg___name,
+            arg___af,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn setnetent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+        }
+        setnetent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endnetent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endnetent();
+        }
+        endnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent() -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent() -> *mut netent;
+        }
+        getnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr(arg___net: u32, arg___type: ::std::os::raw::c_int) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+        }
+        getnetbyaddr(arg___net, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname(arg___name: *const ::std::os::raw::c_char) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+        }
+        getnetbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent_r(
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent_r(
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr_r(
+    arg___net: u32,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr_r(
+                __net: u32,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyaddr_r(
+            arg___net,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10390,6 +9103,142 @@ impl Default for servent {
         }
     }
 }
+#[track_caller]
+pub unsafe fn setservent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setservent(__stay_open: ::std::os::raw::c_int);
+        }
+        setservent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endservent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endservent();
+        }
+        endservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservent() -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent() -> *mut servent;
+        }
+        getservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyname(arg___name, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyport(arg___port, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservent_r(
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent_r(
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyname_r(
+            arg___name,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport_r(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport_r(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyport_r(
+            arg___port,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -10406,59 +9255,13 @@ impl Default for protoent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
 #[track_caller]
-pub unsafe fn endhostent() {
+pub unsafe fn setprotoent(arg___stay_open: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn endhostent();
+            pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
         }
-        endhostent()
-    })
-}
-#[track_caller]
-pub unsafe fn endnetent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endnetent();
-        }
-        endnetent()
+        setprotoent(arg___stay_open)
     })
 }
 #[track_caller]
@@ -10471,157 +9274,6 @@ pub unsafe fn endprotoent() {
     })
 }
 #[track_caller]
-pub unsafe fn endservent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endservent();
-        }
-        endservent()
-    })
-}
-#[track_caller]
-pub unsafe fn freeaddrinfo(arg_arg1: *mut addrinfo) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freeaddrinfo(arg1: *mut addrinfo);
-        }
-        freeaddrinfo(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gai_strerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        gai_strerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getaddrinfo(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const addrinfo,
-    arg_arg4: *mut *mut addrinfo,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getaddrinfo(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const addrinfo,
-                arg4: *mut *mut addrinfo,
-            ) -> ::std::os::raw::c_int;
-        }
-        getaddrinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyaddr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-        }
-        gethostbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostent() -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostent() -> *mut hostent;
-        }
-        gethostent()
-    })
-}
-#[track_caller]
-pub unsafe fn getnameinfo(
-    arg_arg1: *const sockaddr,
-    arg_arg2: socklen_t,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut ::std::os::raw::c_char,
-    arg_arg6: socklen_t,
-    arg_arg7: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnameinfo(
-                arg1: *const sockaddr,
-                arg2: socklen_t,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: socklen_t,
-                arg5: *mut ::std::os::raw::c_char,
-                arg6: socklen_t,
-                arg7: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        getnameinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyaddr(arg_arg1: u32, arg_arg2: ::std::os::raw::c_int) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-        }
-        getnetbyaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-        }
-        getnetbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetent() -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetent() -> *mut netent;
-        }
-        getnetent()
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-        }
-        getprotobyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobynumber(arg_arg1: ::std::os::raw::c_int) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-        }
-        getprotobynumber(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn getprotoent() -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -10631,239 +9283,91 @@ pub unsafe fn getprotoent() -> *mut protoent {
     })
 }
 #[track_caller]
-pub unsafe fn getservbyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobyname(arg___name: *const ::std::os::raw::c_char) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
         }
-        getservbyname(arg_arg1, arg_arg2)
+        getprotobyname(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn getservbyport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobynumber(arg___proto: ::std::os::raw::c_int) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
         }
-        getservbyport(arg_arg1, arg_arg2)
+        getprotobynumber(arg___proto)
     })
 }
 #[track_caller]
-pub unsafe fn getservent() -> *mut servent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getservent() -> *mut servent;
-        }
-        getservent()
-    })
-}
-#[track_caller]
-pub unsafe fn sethostent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sethostent(arg1: ::std::os::raw::c_int);
-        }
-        sethostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setnetent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setnetent(arg1: ::std::os::raw::c_int);
-        }
-        setnetent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setprotoent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprotoent(arg1: ::std::os::raw::c_int);
-        }
-        setprotoent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setservent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setservent(arg1: ::std::os::raw::c_int);
-        }
-        setservent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn freehostent(arg_arg1: *mut hostent) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freehostent(arg1: *mut hostent);
-        }
-        freehostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyname2(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyaddr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyname(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbyname(arg_name: *const ::std::os::raw::c_char) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-        }
-        getrpcbyname(arg_name)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbynumber(arg_number: ::std::os::raw::c_int) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-        }
-        getrpcbynumber(arg_number)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcent() -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcent() -> *mut rpcent;
-        }
-        getrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn setrpcent(arg_stayopen: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrpcent(stayopen: ::std::os::raw::c_int);
-        }
-        setrpcent(arg_stayopen)
-    })
-}
-#[track_caller]
-pub unsafe fn endrpcent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endrpcent();
-        }
-        endrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn herror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn herror(arg1: *const ::std::os::raw::c_char);
-        }
-        herror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hstrerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        hstrerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn innetgr(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const ::std::os::raw::c_char,
+pub unsafe fn getprotoent_r(
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn innetgr(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const ::std::os::raw::c_char,
+            pub fn getprotoent_r(
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        innetgr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        getprotoent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn getnetgrent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+pub unsafe fn getprotobyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getnetgrent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+            pub fn getprotobyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        getnetgrent(arg_arg1, arg_arg2, arg_arg3)
+        getprotobyname_r(arg___name, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getprotobynumber_r(
+    arg___proto: ::std::os::raw::c_int,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getprotobynumber_r(
+                __proto: ::std::os::raw::c_int,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getprotobynumber_r(arg___proto, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn setnetgrent(arg___netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        setnetgrent(arg___netgroup)
     })
 }
 #[track_caller]
@@ -10876,29 +9380,283 @@ pub unsafe fn endnetgrent() {
     })
 }
 #[track_caller]
-pub unsafe fn setnetgrent(arg_arg1: *const ::std::os::raw::c_char) {
+pub unsafe fn getnetgrent(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+            pub fn getnetgrent(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        setnetgrent(arg_arg1)
+        getnetgrent(arg___hostp, arg___userp, arg___domainp)
+    })
+}
+#[track_caller]
+pub unsafe fn innetgr(
+    arg___netgroup: *const ::std::os::raw::c_char,
+    arg___host: *const ::std::os::raw::c_char,
+    arg___user: *const ::std::os::raw::c_char,
+    arg___domain: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn innetgr(
+                __netgroup: *const ::std::os::raw::c_char,
+                __host: *const ::std::os::raw::c_char,
+                __user: *const ::std::os::raw::c_char,
+                __domain: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        innetgr(arg___netgroup, arg___host, arg___user, arg___domain)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetgrent_r(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetgrent_r(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetgrent_r(arg___hostp, arg___userp, arg___domainp, arg___buffer, arg___buflen)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd(arg___ahost, arg___rport, arg___locuser, arg___remuser, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd_af(
+            arg___ahost,
+            arg___rport,
+            arg___locuser,
+            arg___remuser,
+            arg___cmd,
+            arg___fd2p,
+            arg___af,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn rexec(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rexec_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec_af(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok(arg___rhost, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok_af(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok_af(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok_af(arg___rhost, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok(
+    arg___raddr: u32,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok(
+                __raddr: u32,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok(arg___raddr, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok_af(
+    arg___raddr: *const ::std::os::raw::c_void,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok_af(
+                __raddr: *const ::std::os::raw::c_void,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok_af(arg___raddr, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport(arg___alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        rresvport(arg___alport)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport_af(
+    arg___alport: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport_af(
+                __alport: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rresvport_af(arg___alport, arg___af)
     })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -10908,73 +9666,94 @@ impl Default for passwd {
     }
 }
 #[track_caller]
-pub unsafe fn getpwuid(arg_arg1: uid_t) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-        }
-        getpwuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwnam(arg_arg1: *const ::std::os::raw::c_char) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-        }
-        getpwnam(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuid_r(
-    arg_arg1: uid_t,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getaddrinfo(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___service: *const ::std::os::raw::c_char,
+    arg___req: *const addrinfo,
+    arg___pai: *mut *mut addrinfo,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuid_r(
-                arg1: uid_t,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getaddrinfo(
+                __name: *const ::std::os::raw::c_char,
+                __service: *const ::std::os::raw::c_char,
+                __req: *const addrinfo,
+                __pai: *mut *mut addrinfo,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getaddrinfo(arg___name, arg___service, arg___req, arg___pai)
     })
 }
 #[track_caller]
-pub unsafe fn getpwnam_r(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn freeaddrinfo(arg___ai: *mut addrinfo) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freeaddrinfo(__ai: *mut addrinfo);
+        }
+        freeaddrinfo(arg___ai)
+    })
+}
+#[track_caller]
+pub unsafe fn gai_strerror(arg___ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        gai_strerror(arg___ecode)
+    })
+}
+#[track_caller]
+pub unsafe fn getnameinfo(
+    arg___sa: *const sockaddr,
+    arg___salen: socklen_t,
+    arg___host: *mut ::std::os::raw::c_char,
+    arg___hostlen: socklen_t,
+    arg___serv: *mut ::std::os::raw::c_char,
+    arg___servlen: socklen_t,
+    arg___flags: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwnam_r(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getnameinfo(
+                __sa: *const sockaddr,
+                __salen: socklen_t,
+                __host: *mut ::std::os::raw::c_char,
+                __hostlen: socklen_t,
+                __serv: *mut ::std::os::raw::c_char,
+                __servlen: socklen_t,
+                __flags: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getpwnam_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getnameinfo(
+            arg___sa,
+            arg___salen,
+            arg___host,
+            arg___hostlen,
+            arg___serv,
+            arg___servlen,
+            arg___flags,
+        )
     })
 }
-#[track_caller]
-pub unsafe fn getpwent() -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwent() -> *mut passwd;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        getpwent()
-    })
+    }
 }
 #[track_caller]
 pub unsafe fn setpwent() {
@@ -10994,192 +9773,131 @@ pub unsafe fn endpwent() {
         endpwent()
     })
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
-extern "C" {
-    pub static UUID_NULL: uuid_t;
-}
 #[track_caller]
-pub unsafe fn uuid_clear(arg_uu: *mut ::std::os::raw::c_uchar) {
+pub unsafe fn getpwent() -> *mut passwd {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+            pub fn getpwent() -> *mut passwd;
         }
-        uuid_clear(arg_uu)
+        getpwent()
     })
 }
 #[track_caller]
-pub unsafe fn uuid_compare(
-    arg_uu1: *mut ::std::os::raw::c_uchar,
-    arg_uu2: *mut ::std::os::raw::c_uchar,
+pub unsafe fn fgetpwent(arg___stream: *mut FILE) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+        }
+        fgetpwent(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putpwent(arg___p: *const passwd, arg___f: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putpwent(arg___p, arg___f)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwuid(arg___uid: __uid_t) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+        }
+        getpwuid(arg___uid)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwnam(arg___name: *const ::std::os::raw::c_char) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+        }
+        getpwnam(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwent_r(
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_compare(
-                uu1: *mut ::std::os::raw::c_uchar,
-                uu2: *mut ::std::os::raw::c_uchar,
+            pub fn getpwent_r(
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_compare(arg_uu1, arg_uu2)
+        getpwent_r(arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_copy(
-    arg_dst: *mut ::std::os::raw::c_uchar,
-    arg_src: *mut ::std::os::raw::c_uchar,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_copy(arg_dst, arg_src)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_random(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_random(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_time(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_time(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_is_null(arg_uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-        }
-        uuid_is_null(arg_uu)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_parse(
-    arg_in_: *mut ::std::os::raw::c_char,
-    arg_uu: *mut ::std::os::raw::c_uchar,
+pub unsafe fn getpwuid_r(
+    arg___uid: __uid_t,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_parse(
-                in_: *mut ::std::os::raw::c_char,
-                uu: *mut ::std::os::raw::c_uchar,
+            pub fn getpwuid_r(
+                __uid: __uid_t,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_parse(arg_in_, arg_uu)
+        getpwuid_r(arg___uid, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_unparse(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-        }
-        uuid_unparse(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_lower(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_lower(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_lower(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_upper(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_upper(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_upper(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn setpassent(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        setpassent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn user_from_uid(
-    arg_arg1: uid_t,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn user_from_uid(
-                arg1: uid_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        user_from_uid(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid(arg_arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-        }
-        getpwuuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid_r(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getpwnam_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuuid_r(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getpwnam_r(
+                __name: *const ::std::os::raw::c_char,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getpwnam_r(arg___name, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetpwent_r(
+    arg___stream: *mut FILE,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent_r(
+                __stream: *mut FILE,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
+            ) -> ::std::os::raw::c_int;
+        }
+        fgetpwent_r(arg___stream, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -11765,1692 +10483,761 @@ pub unsafe fn pg_srand48(arg_seed: ::std::os::raw::c_long) {
         pg_srand48(arg_seed)
     })
 }
+#[track_caller]
+pub unsafe fn fls(arg_mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        fls(arg_mask)
+    })
+}
+#[track_caller]
+pub unsafe fn getpeereid(
+    arg_sock: ::std::os::raw::c_int,
+    arg_uid: *mut uid_t,
+    arg_gid: *mut gid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeereid(
+                sock: ::std::os::raw::c_int,
+                uid: *mut uid_t,
+                gid: *mut gid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeereid(arg_sock, arg_uid, arg_gid)
+    })
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[track_caller]
-pub unsafe fn __math_errhandling() -> ::std::os::raw::c_int {
+pub unsafe fn __fpclassify(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __math_errhandling() -> ::std::os::raw::c_int;
+            pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
         }
-        __math_errhandling()
+        __fpclassify(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __signbit(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyf(arg_arg1)
+        __signbit(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyd(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyd(arg_arg1)
+        __isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyl(arg_arg1)
+        __finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosf(arg1: f32) -> f32;
+            pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosf(arg_arg1)
+        __isnan(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acos(arg_arg1: f64) -> f64 {
+pub unsafe fn __iseqsig(arg___x: f64, arg___y: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acos(arg1: f64) -> f64;
+            pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
         }
-        acos(arg_arg1)
+        __iseqsig(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn acosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __issignaling(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosl(arg1: f64) -> f64;
+            pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosl(arg_arg1)
+        __issignaling(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn asinf(arg_arg1: f32) -> f32 {
+pub unsafe fn acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinf(arg1: f32) -> f32;
+            pub fn acos(__x: f64) -> f64;
         }
-        asinf(arg_arg1)
+        acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asin(arg_arg1: f64) -> f64 {
+pub unsafe fn __acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asin(arg1: f64) -> f64;
+            pub fn __acos(__x: f64) -> f64;
         }
-        asin(arg_arg1)
+        __acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinl(arg_arg1: f64) -> f64 {
+pub unsafe fn asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinl(arg1: f64) -> f64;
+            pub fn asin(__x: f64) -> f64;
         }
-        asinl(arg_arg1)
+        asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanf(arg1: f32) -> f32;
+            pub fn __asin(__x: f64) -> f64;
         }
-        atanf(arg_arg1)
+        __asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan(arg_arg1: f64) -> f64 {
+pub unsafe fn atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan(arg1: f64) -> f64;
+            pub fn atan(__x: f64) -> f64;
         }
-        atan(arg_arg1)
+        atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanl(arg1: f64) -> f64;
+            pub fn __atan(__x: f64) -> f64;
         }
-        atanl(arg_arg1)
+        __atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2f(arg_arg1: f32, arg_arg2: f32) -> f32 {
+pub unsafe fn atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+            pub fn atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2f(arg_arg1, arg_arg2)
+        atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2(arg1: f64, arg2: f64) -> f64;
+            pub fn __atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2(arg_arg1, arg_arg2)
+        __atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2l(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+            pub fn cos(__x: f64) -> f64;
         }
-        atan2l(arg_arg1, arg_arg2)
+        cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosf(arg1: f32) -> f32;
+            pub fn __cos(__x: f64) -> f64;
         }
-        cosf(arg_arg1)
+        __cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cos(arg_arg1: f64) -> f64 {
+pub unsafe fn sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cos(arg1: f64) -> f64;
+            pub fn sin(__x: f64) -> f64;
         }
-        cos(arg_arg1)
+        sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosl(arg1: f64) -> f64;
+            pub fn __sin(__x: f64) -> f64;
         }
-        cosl(arg_arg1)
+        __sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinf(arg_arg1: f32) -> f32 {
+pub unsafe fn tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinf(arg1: f32) -> f32;
+            pub fn tan(__x: f64) -> f64;
         }
-        sinf(arg_arg1)
+        tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sin(arg_arg1: f64) -> f64 {
+pub unsafe fn __tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sin(arg1: f64) -> f64;
+            pub fn __tan(__x: f64) -> f64;
         }
-        sin(arg_arg1)
+        __tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinl(arg_arg1: f64) -> f64 {
+pub unsafe fn cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinl(arg1: f64) -> f64;
+            pub fn cosh(__x: f64) -> f64;
         }
-        sinl(arg_arg1)
+        cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanf(arg1: f32) -> f32;
+            pub fn __cosh(__x: f64) -> f64;
         }
-        tanf(arg_arg1)
+        __cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tan(arg_arg1: f64) -> f64 {
+pub unsafe fn sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tan(arg1: f64) -> f64;
+            pub fn sinh(__x: f64) -> f64;
         }
-        tan(arg_arg1)
+        sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanl(arg1: f64) -> f64;
+            pub fn __sinh(__x: f64) -> f64;
         }
-        tanl(arg_arg1)
+        __sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshf(arg_arg1: f32) -> f32 {
+pub unsafe fn tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshf(arg1: f32) -> f32;
+            pub fn tanh(__x: f64) -> f64;
         }
-        acoshf(arg_arg1)
+        tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acosh(arg_arg1: f64) -> f64 {
+pub unsafe fn __tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosh(arg1: f64) -> f64;
+            pub fn __tanh(__x: f64) -> f64;
         }
-        acosh(arg_arg1)
+        __tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshl(arg_arg1: f64) -> f64 {
+pub unsafe fn acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshl(arg1: f64) -> f64;
+            pub fn acosh(__x: f64) -> f64;
         }
-        acoshl(arg_arg1)
+        acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn __acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhf(arg1: f32) -> f32;
+            pub fn __acosh(__x: f64) -> f64;
         }
-        asinhf(arg_arg1)
+        __acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinh(arg_arg1: f64) -> f64 {
+pub unsafe fn asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinh(arg1: f64) -> f64;
+            pub fn asinh(__x: f64) -> f64;
         }
-        asinh(arg_arg1)
+        asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhl(arg1: f64) -> f64;
+            pub fn __asinh(__x: f64) -> f64;
         }
-        asinhl(arg_arg1)
+        __asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhf(arg1: f32) -> f32;
+            pub fn atanh(__x: f64) -> f64;
         }
-        atanhf(arg_arg1)
+        atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanh(arg1: f64) -> f64;
+            pub fn __atanh(__x: f64) -> f64;
         }
-        atanh(arg_arg1)
+        __atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhl(arg1: f64) -> f64;
+            pub fn exp(__x: f64) -> f64;
         }
-        atanhl(arg_arg1)
+        exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn coshf(arg_arg1: f32) -> f32 {
+pub unsafe fn __exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshf(arg1: f32) -> f32;
+            pub fn __exp(__x: f64) -> f64;
         }
-        coshf(arg_arg1)
+        __exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosh(arg_arg1: f64) -> f64 {
+pub unsafe fn frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosh(arg1: f64) -> f64;
+            pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        cosh(arg_arg1)
+        frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn coshl(arg_arg1: f64) -> f64 {
+pub unsafe fn __frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshl(arg1: f64) -> f64;
+            pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        coshl(arg_arg1)
+        __frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhf(arg1: f32) -> f32;
+            pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinhf(arg_arg1)
+        ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinh(arg_arg1: f64) -> f64 {
+pub unsafe fn __ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinh(arg1: f64) -> f64;
+            pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinh(arg_arg1)
+        __ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhl(arg1: f64) -> f64;
+            pub fn __log(__x: f64) -> f64;
         }
-        sinhl(arg_arg1)
+        __log(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhf(arg1: f32) -> f32;
+            pub fn log10(__x: f64) -> f64;
         }
-        tanhf(arg_arg1)
+        log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanh(arg1: f64) -> f64;
+            pub fn __log10(__x: f64) -> f64;
         }
-        tanh(arg_arg1)
+        __log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhl(arg1: f64) -> f64;
+            pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        tanhl(arg_arg1)
+        modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn expf(arg_arg1: f32) -> f32 {
+pub unsafe fn __modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expf(arg1: f32) -> f32;
+            pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        expf(arg_arg1)
+        __modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn exp(arg_arg1: f64) -> f64 {
+pub unsafe fn expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp(arg1: f64) -> f64;
+            pub fn expm1(__x: f64) -> f64;
         }
-        exp(arg_arg1)
+        expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expl(arg_arg1: f64) -> f64 {
+pub unsafe fn __expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expl(arg1: f64) -> f64;
+            pub fn __expm1(__x: f64) -> f64;
         }
-        expl(arg_arg1)
+        __expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2f(arg_arg1: f32) -> f32 {
+pub unsafe fn log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2f(arg1: f32) -> f32;
+            pub fn log1p(__x: f64) -> f64;
         }
-        exp2f(arg_arg1)
+        log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2(arg_arg1: f64) -> f64 {
+pub unsafe fn __log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2(arg1: f64) -> f64;
+            pub fn __log1p(__x: f64) -> f64;
         }
-        exp2(arg_arg1)
+        __log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2l(arg_arg1: f64) -> f64 {
+pub unsafe fn logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2l(arg1: f64) -> f64;
+            pub fn logb(__x: f64) -> f64;
         }
-        exp2l(arg_arg1)
+        logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1f(arg_arg1: f32) -> f32 {
+pub unsafe fn __logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1f(arg1: f32) -> f32;
+            pub fn __logb(__x: f64) -> f64;
         }
-        expm1f(arg_arg1)
+        __logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1(arg_arg1: f64) -> f64 {
+pub unsafe fn exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1(arg1: f64) -> f64;
+            pub fn exp2(__x: f64) -> f64;
         }
-        expm1(arg_arg1)
+        exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1l(arg_arg1: f64) -> f64 {
+pub unsafe fn __exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1l(arg1: f64) -> f64;
+            pub fn __exp2(__x: f64) -> f64;
         }
-        expm1l(arg_arg1)
+        __exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logf(arg_arg1: f32) -> f32 {
+pub unsafe fn log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logf(arg1: f32) -> f32;
+            pub fn log2(__x: f64) -> f64;
         }
-        logf(arg_arg1)
+        log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logl(arg1: f64) -> f64;
+            pub fn __log2(__x: f64) -> f64;
         }
-        logl(arg_arg1)
+        __log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log10f(arg_arg1: f32) -> f32 {
+pub unsafe fn pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10f(arg1: f32) -> f32;
+            pub fn pow(__x: f64, __y: f64) -> f64;
         }
-        log10f(arg_arg1)
+        pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10(arg_arg1: f64) -> f64 {
+pub unsafe fn __pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10(arg1: f64) -> f64;
+            pub fn __pow(__x: f64, __y: f64) -> f64;
         }
-        log10(arg_arg1)
+        __pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10l(arg_arg1: f64) -> f64 {
+pub unsafe fn sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10l(arg1: f64) -> f64;
+            pub fn sqrt(__x: f64) -> f64;
         }
-        log10l(arg_arg1)
+        sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2f(arg_arg1: f32) -> f32 {
+pub unsafe fn __sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2f(arg1: f32) -> f32;
+            pub fn __sqrt(__x: f64) -> f64;
         }
-        log2f(arg_arg1)
+        __sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2(arg_arg1: f64) -> f64 {
+pub unsafe fn hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2(arg1: f64) -> f64;
+            pub fn hypot(__x: f64, __y: f64) -> f64;
         }
-        log2(arg_arg1)
+        hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log2l(arg_arg1: f64) -> f64 {
+pub unsafe fn __hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2l(arg1: f64) -> f64;
+            pub fn __hypot(__x: f64, __y: f64) -> f64;
         }
-        log2l(arg_arg1)
+        __hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log1pf(arg_arg1: f32) -> f32 {
+pub unsafe fn cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pf(arg1: f32) -> f32;
+            pub fn cbrt(__x: f64) -> f64;
         }
-        log1pf(arg_arg1)
+        cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1p(arg_arg1: f64) -> f64 {
+pub unsafe fn __cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1p(arg1: f64) -> f64;
+            pub fn __cbrt(__x: f64) -> f64;
         }
-        log1p(arg_arg1)
+        __cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1pl(arg_arg1: f64) -> f64 {
+pub unsafe fn ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pl(arg1: f64) -> f64;
+            pub fn ceil(__x: f64) -> f64;
         }
-        log1pl(arg_arg1)
+        ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbf(arg_arg1: f32) -> f32 {
+pub unsafe fn __ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbf(arg1: f32) -> f32;
+            pub fn __ceil(__x: f64) -> f64;
         }
-        logbf(arg_arg1)
+        __ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logb(arg_arg1: f64) -> f64 {
+pub unsafe fn fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logb(arg1: f64) -> f64;
+            pub fn fabs(__x: f64) -> f64;
         }
-        logb(arg_arg1)
+        fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbl(arg_arg1: f64) -> f64 {
+pub unsafe fn __fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbl(arg1: f64) -> f64;
+            pub fn __fabs(__x: f64) -> f64;
         }
-        logbl(arg_arg1)
+        __fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modff(arg_arg1: f32, arg_arg2: *mut f32) -> f32 {
+pub unsafe fn floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+            pub fn floor(__x: f64) -> f64;
         }
-        modff(arg_arg1, arg_arg2)
+        floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modf(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn __floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn __floor(__x: f64) -> f64;
         }
-        modf(arg_arg1, arg_arg2)
+        __floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modfl(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn fmod(__x: f64, __y: f64) -> f64;
         }
-        modfl(arg_arg1, arg_arg2)
+        fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn __fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn __fmod(__x: f64, __y: f64) -> f64;
         }
-        ldexpf(arg_arg1, arg_arg2)
+        __fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexp(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexp(arg_arg1, arg_arg2)
+        isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexpl(arg_arg1, arg_arg2)
+        finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn frexpf(arg_arg1: f32, arg_arg2: *mut ::std::os::raw::c_int) -> f32 {
+pub unsafe fn drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+            pub fn drem(__x: f64, __y: f64) -> f64;
         }
-        frexpf(arg_arg1, arg_arg2)
+        drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexp(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn __drem(__x: f64, __y: f64) -> f64;
         }
-        frexp(arg_arg1, arg_arg2)
+        __drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexpl(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn significand(__x: f64) -> f64;
         }
-        frexpl(arg_arg1, arg_arg2)
+        significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __significand(__x: f64) -> f64;
         }
-        ilogbf(arg_arg1)
+        __significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogb(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogb(arg_arg1)
+        copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogbl(arg_arg1)
+        __copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbnf(arg_arg1, arg_arg2)
+        nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbn(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbn(arg_arg1, arg_arg2)
+        __nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        scalbnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_long) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-        }
-        scalblnf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalbln(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalbln(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalblnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsf(arg1: f32) -> f32;
-        }
-        fabsf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabs(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabs(arg1: f64) -> f64;
-        }
-        fabs(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsl(arg1: f64) -> f64;
-        }
-        fabsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtf(arg1: f32) -> f32;
-        }
-        cbrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrt(arg1: f64) -> f64;
-        }
-        cbrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtl(arg1: f64) -> f64;
-        }
-        cbrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-        }
-        hypotf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypot(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypot(arg1: f64, arg2: f64) -> f64;
-        }
-        hypot(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-        }
-        hypotl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powf(arg1: f32, arg2: f32) -> f32;
-        }
-        powf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pow(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pow(arg1: f64, arg2: f64) -> f64;
-        }
-        pow(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powl(arg1: f64, arg2: f64) -> f64;
-        }
-        powl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtf(arg1: f32) -> f32;
-        }
-        sqrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrt(arg1: f64) -> f64;
-        }
-        sqrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtl(arg1: f64) -> f64;
-        }
-        sqrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erff(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erff(arg1: f32) -> f32;
-        }
-        erff(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erf(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erf(arg1: f64) -> f64;
-        }
-        erf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfl(arg1: f64) -> f64;
-        }
-        erfl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcf(arg1: f32) -> f32;
-        }
-        erfcf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfc(arg1: f64) -> f64;
-        }
-        erfc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcl(arg1: f64) -> f64;
-        }
-        erfcl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammaf(arg1: f32) -> f32;
-        }
-        lgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgamma(arg1: f64) -> f64;
-        }
-        lgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammal(arg1: f64) -> f64;
-        }
-        lgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammaf(arg1: f32) -> f32;
-        }
-        tgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgamma(arg1: f64) -> f64;
-        }
-        tgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammal(arg1: f64) -> f64;
-        }
-        tgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceilf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceilf(arg1: f32) -> f32;
-        }
-        ceilf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceil(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceil(arg1: f64) -> f64;
-        }
-        ceil(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceill(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceill(arg1: f64) -> f64;
-        }
-        ceill(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorf(arg1: f32) -> f32;
-        }
-        floorf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floor(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floor(arg1: f64) -> f64;
-        }
-        floor(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorl(arg1: f64) -> f64;
-        }
-        floorl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintf(arg1: f32) -> f32;
-        }
-        nearbyintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyint(arg1: f64) -> f64;
-        }
-        nearbyint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintl(arg1: f64) -> f64;
-        }
-        nearbyintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintf(arg1: f32) -> f32;
-        }
-        rintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rint(arg1: f64) -> f64;
-        }
-        rint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintl(arg1: f64) -> f64;
-        }
-        rintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrint(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundf(arg1: f32) -> f32;
-        }
-        roundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn round(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn round(arg1: f64) -> f64;
-        }
-        round(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundl(arg1: f64) -> f64;
-        }
-        roundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lround(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrint(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llround(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncf(arg1: f32) -> f32;
-        }
-        truncf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn trunc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn trunc(arg1: f64) -> f64;
-        }
-        trunc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncl(arg1: f64) -> f64;
-        }
-        truncl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmodf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmod(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmod(arg1: f64, arg2: f64) -> f64;
-        }
-        fmod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmodl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-        }
-        remainderf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainder(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainder(arg1: f64, arg2: f64) -> f64;
-        }
-        remainder(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-        }
-        remainderl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remquof(arg_arg1: f32, arg_arg2: f32, arg_arg3: *mut ::std::os::raw::c_int) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-        }
-        remquof(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquo(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquo(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquol(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquol(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-        }
-        copysignf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysign(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysign(arg1: f64, arg2: f64) -> f64;
-        }
-        copysign(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-        }
-        copysignl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nanf(arg_arg1: *const ::std::os::raw::c_char) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-        }
-        nanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nan(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nan(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nanl(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nanl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-        }
-        nextafterf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafter(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafter(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafterl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttoward(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttoward(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardf(arg_arg1: f32, arg_arg2: f64) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-        }
-        nexttowardf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttowardl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdimf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-        }
-        fdimf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdim(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdim(arg1: f64, arg2: f64) -> f64;
-        }
-        fdim(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdiml(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-        }
-        fdiml(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmaxf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmax(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmax(arg1: f64, arg2: f64) -> f64;
-        }
-        fmax(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmaxl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminf(arg1: f32, arg2: f32) -> f32;
-        }
-        fminf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmin(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmin(arg1: f64, arg2: f64) -> f64;
-        }
-        fmin(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminl(arg1: f64, arg2: f64) -> f64;
-        }
-        fminl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaf(arg_arg1: f32, arg_arg2: f32, arg_arg3: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-        }
-        fmaf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fma(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fma(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fmal(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fmal(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10f(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10f(arg1: f32) -> f32;
-        }
-        __exp10f(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10(arg1: f64) -> f64;
-        }
-        __exp10(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospif(arg1: f32) -> f32;
-        }
-        __cospif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospi(arg1: f64) -> f64;
-        }
-        __cospi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpif(arg1: f32) -> f32;
-        }
-        __sinpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpi(arg1: f64) -> f64;
-        }
-        __sinpi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpif(arg1: f32) -> f32;
-        }
-        __tanpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpi(arg1: f64) -> f64;
-        }
-        __tanpi(arg_arg1)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[track_caller]
-pub unsafe fn __sincosf_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincosf_stret(arg1: f32) -> __float2;
-        }
-        __sincosf_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincos_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincos_stret(arg1: f64) -> __double2;
-        }
-        __sincos_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospif_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospif_stret(arg1: f32) -> __float2;
-        }
-        __sincospif_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospi_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospi_stret(arg1: f64) -> __double2;
-        }
-        __sincospi_stret(arg_arg1)
+        isnan(arg___value)
     })
 }
 #[track_caller]
@@ -13463,12 +11250,30 @@ pub unsafe fn j0(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __j0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0(arg1: f64) -> f64;
+        }
+        __j0(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn j1(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn j1(arg1: f64) -> f64;
         }
         j1(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1(arg1: f64) -> f64;
+        }
+        __j1(arg_arg1)
     })
 }
 #[track_caller]
@@ -13481,12 +11286,30 @@ pub unsafe fn jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+        }
+        __jn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
 pub unsafe fn y0(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn y0(arg1: f64) -> f64;
         }
         y0(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0(arg1: f64) -> f64;
+        }
+        __y0(arg_arg1)
     })
 }
 #[track_caller]
@@ -13499,6 +11322,15 @@ pub unsafe fn y1(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __y1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1(arg1: f64) -> f64;
+        }
+        __y1(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -13508,34 +11340,3156 @@ pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
-pub unsafe fn scalb(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalb(arg1: f64, arg2: f64) -> f64;
+            pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
         }
-        scalb(arg_arg1, arg_arg2)
+        __yn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erf(arg1: f64) -> f64;
+        }
+        erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erf(arg1: f64) -> f64;
+        }
+        __erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfc(arg1: f64) -> f64;
+        }
+        erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfc(arg1: f64) -> f64;
+        }
+        __erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma(arg1: f64) -> f64;
+        }
+        lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma(arg1: f64) -> f64;
+        }
+        __lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgamma(arg1: f64) -> f64;
+        }
+        tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgamma(arg1: f64) -> f64;
+        }
+        __tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gamma(arg1: f64) -> f64;
+        }
+        gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gamma(arg1: f64) -> f64;
+        }
+        __gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rint(__x: f64) -> f64;
+        }
+        rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rint(__x: f64) -> f64;
+        }
+        __rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafter(__x: f64, __y: f64) -> f64;
+        }
+        nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafter(__x: f64, __y: f64) -> f64;
+        }
+        __nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        __nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainder(__x: f64, __y: f64) -> f64;
+        }
+        remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainder(__x: f64, __y: f64) -> f64;
+        }
+        __remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        __scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        __ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        __scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyint(__x: f64) -> f64;
+        }
+        nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyint(__x: f64) -> f64;
+        }
+        __nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn round(__x: f64) -> f64;
+        }
+        round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __round(__x: f64) -> f64;
+        }
+        __round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn trunc(__x: f64) -> f64;
+        }
+        trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __trunc(__x: f64) -> f64;
+        }
+        __trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdim(__x: f64, __y: f64) -> f64;
+        }
+        fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdim(__x: f64, __y: f64) -> f64;
+        }
+        __fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmax(__x: f64, __y: f64) -> f64;
+        }
+        fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmax(__x: f64, __y: f64) -> f64;
+        }
+        __fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmin(__x: f64, __y: f64) -> f64;
+        }
+        fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmin(__x: f64, __y: f64) -> f64;
+        }
+        __fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        __fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalb(__x: f64, __n: f64) -> f64;
+        }
+        scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalb(__x: f64, __n: f64) -> f64;
+        }
+        __scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __signbitf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigf(arg___x: f32, arg___y: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+        }
+        __iseqsigf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __issignalingf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosf(__x: f32) -> f32;
+        }
+        acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosf(__x: f32) -> f32;
+        }
+        __acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinf(__x: f32) -> f32;
+        }
+        asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinf(__x: f32) -> f32;
+        }
+        __asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanf(__x: f32) -> f32;
+        }
+        atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanf(__x: f32) -> f32;
+        }
+        __atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2f(__y: f32, __x: f32) -> f32;
+        }
+        atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2f(__y: f32, __x: f32) -> f32;
+        }
+        __atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosf(__x: f32) -> f32;
+        }
+        cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosf(__x: f32) -> f32;
+        }
+        __cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinf(__x: f32) -> f32;
+        }
+        sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinf(__x: f32) -> f32;
+        }
+        __sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanf(__x: f32) -> f32;
+        }
+        tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanf(__x: f32) -> f32;
+        }
+        __tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshf(__x: f32) -> f32;
+        }
+        coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshf(__x: f32) -> f32;
+        }
+        __coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhf(__x: f32) -> f32;
+        }
+        sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhf(__x: f32) -> f32;
+        }
+        __sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhf(__x: f32) -> f32;
+        }
+        tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhf(__x: f32) -> f32;
+        }
+        __tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshf(__x: f32) -> f32;
+        }
+        acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshf(__x: f32) -> f32;
+        }
+        __acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhf(__x: f32) -> f32;
+        }
+        asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhf(__x: f32) -> f32;
+        }
+        __asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhf(__x: f32) -> f32;
+        }
+        atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhf(__x: f32) -> f32;
+        }
+        __atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expf(__x: f32) -> f32;
+        }
+        expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expf(__x: f32) -> f32;
+        }
+        __expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        __ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logf(__x: f32) -> f32;
+        }
+        logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logf(__x: f32) -> f32;
+        }
+        __logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10f(__x: f32) -> f32;
+        }
+        log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10f(__x: f32) -> f32;
+        }
+        __log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        __modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1f(__x: f32) -> f32;
+        }
+        expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1f(__x: f32) -> f32;
+        }
+        __expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pf(__x: f32) -> f32;
+        }
+        log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pf(__x: f32) -> f32;
+        }
+        __log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbf(__x: f32) -> f32;
+        }
+        logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbf(__x: f32) -> f32;
+        }
+        __logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2f(__x: f32) -> f32;
+        }
+        exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2f(__x: f32) -> f32;
+        }
+        __exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2f(__x: f32) -> f32;
+        }
+        log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2f(__x: f32) -> f32;
+        }
+        __log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powf(__x: f32, __y: f32) -> f32;
+        }
+        powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powf(__x: f32, __y: f32) -> f32;
+        }
+        __powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtf(__x: f32) -> f32;
+        }
+        sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtf(__x: f32) -> f32;
+        }
+        __sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotf(__x: f32, __y: f32) -> f32;
+        }
+        hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotf(__x: f32, __y: f32) -> f32;
+        }
+        __hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtf(__x: f32) -> f32;
+        }
+        cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtf(__x: f32) -> f32;
+        }
+        __cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceilf(__x: f32) -> f32;
+        }
+        ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceilf(__x: f32) -> f32;
+        }
+        __ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsf(__x: f32) -> f32;
+        }
+        fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsf(__x: f32) -> f32;
+        }
+        __fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorf(__x: f32) -> f32;
+        }
+        floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorf(__x: f32) -> f32;
+        }
+        __floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodf(__x: f32, __y: f32) -> f32;
+        }
+        fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodf(__x: f32, __y: f32) -> f32;
+        }
+        __fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dremf(__x: f32, __y: f32) -> f32;
+        }
+        dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dremf(__x: f32, __y: f32) -> f32;
+        }
+        __dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandf(__x: f32) -> f32;
+        }
+        significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandf(__x: f32) -> f32;
+        }
+        __significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignf(__x: f32, __y: f32) -> f32;
+        }
+        copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignf(__x: f32, __y: f32) -> f32;
+        }
+        __copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        __nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0f(arg1: f32) -> f32;
+        }
+        j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0f(arg1: f32) -> f32;
+        }
+        __j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1f(arg1: f32) -> f32;
+        }
+        j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1f(arg1: f32) -> f32;
+        }
+        __j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0f(arg1: f32) -> f32;
+        }
+        y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0f(arg1: f32) -> f32;
+        }
+        __y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1f(arg1: f32) -> f32;
+        }
+        y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1f(arg1: f32) -> f32;
+        }
+        __y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erff(arg1: f32) -> f32;
+        }
+        erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erff(arg1: f32) -> f32;
+        }
+        __erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcf(arg1: f32) -> f32;
+        }
+        erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcf(arg1: f32) -> f32;
+        }
+        __erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf(arg1: f32) -> f32;
+        }
+        lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf(arg1: f32) -> f32;
+        }
+        __lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammaf(arg1: f32) -> f32;
+        }
+        tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammaf(arg1: f32) -> f32;
+        }
+        __tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammaf(arg1: f32) -> f32;
+        }
+        gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammaf(arg1: f32) -> f32;
+        }
+        __gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintf(__x: f32) -> f32;
+        }
+        rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintf(__x: f32) -> f32;
+        }
+        __rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        __nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        __nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderf(__x: f32, __y: f32) -> f32;
+        }
+        remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderf(__x: f32, __y: f32) -> f32;
+        }
+        __remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        __scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        __ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        __scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintf(__x: f32) -> f32;
+        }
+        nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintf(__x: f32) -> f32;
+        }
+        __nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundf(__x: f32) -> f32;
+        }
+        roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundf(__x: f32) -> f32;
+        }
+        __roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncf(__x: f32) -> f32;
+        }
+        truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncf(__x: f32) -> f32;
+        }
+        __truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdimf(__x: f32, __y: f32) -> f32;
+        }
+        fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdimf(__x: f32, __y: f32) -> f32;
+        }
+        __fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        __fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminf(__x: f32, __y: f32) -> f32;
+        }
+        fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminf(__x: f32, __y: f32) -> f32;
+        }
+        __fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        __fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbf(__x: f32, __n: f32) -> f32;
+        }
+        scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbf(__x: f32, __n: f32) -> f32;
+        }
+        __scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __signbitl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigl(arg___x: u128, arg___y: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+        }
+        __iseqsigl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __issignalingl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosl(__x: u128) -> u128;
+        }
+        acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosl(__x: u128) -> u128;
+        }
+        __acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinl(__x: u128) -> u128;
+        }
+        asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinl(__x: u128) -> u128;
+        }
+        __asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanl(__x: u128) -> u128;
+        }
+        atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanl(__x: u128) -> u128;
+        }
+        __atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2l(__y: u128, __x: u128) -> u128;
+        }
+        atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2l(__y: u128, __x: u128) -> u128;
+        }
+        __atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosl(__x: u128) -> u128;
+        }
+        cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosl(__x: u128) -> u128;
+        }
+        __cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinl(__x: u128) -> u128;
+        }
+        sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinl(__x: u128) -> u128;
+        }
+        __sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanl(__x: u128) -> u128;
+        }
+        tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanl(__x: u128) -> u128;
+        }
+        __tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshl(__x: u128) -> u128;
+        }
+        coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshl(__x: u128) -> u128;
+        }
+        __coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhl(__x: u128) -> u128;
+        }
+        sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhl(__x: u128) -> u128;
+        }
+        __sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhl(__x: u128) -> u128;
+        }
+        tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhl(__x: u128) -> u128;
+        }
+        __tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshl(__x: u128) -> u128;
+        }
+        acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshl(__x: u128) -> u128;
+        }
+        __acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhl(__x: u128) -> u128;
+        }
+        asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhl(__x: u128) -> u128;
+        }
+        __asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhl(__x: u128) -> u128;
+        }
+        atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhl(__x: u128) -> u128;
+        }
+        __atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expl(__x: u128) -> u128;
+        }
+        expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expl(__x: u128) -> u128;
+        }
+        __expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        __ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logl(__x: u128) -> u128;
+        }
+        logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logl(__x: u128) -> u128;
+        }
+        __logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10l(__x: u128) -> u128;
+        }
+        log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10l(__x: u128) -> u128;
+        }
+        __log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        __modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1l(__x: u128) -> u128;
+        }
+        expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1l(__x: u128) -> u128;
+        }
+        __expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pl(__x: u128) -> u128;
+        }
+        log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pl(__x: u128) -> u128;
+        }
+        __log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbl(__x: u128) -> u128;
+        }
+        logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbl(__x: u128) -> u128;
+        }
+        __logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2l(__x: u128) -> u128;
+        }
+        exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2l(__x: u128) -> u128;
+        }
+        __exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2l(__x: u128) -> u128;
+        }
+        log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2l(__x: u128) -> u128;
+        }
+        __log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powl(__x: u128, __y: u128) -> u128;
+        }
+        powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powl(__x: u128, __y: u128) -> u128;
+        }
+        __powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtl(__x: u128) -> u128;
+        }
+        sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtl(__x: u128) -> u128;
+        }
+        __sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotl(__x: u128, __y: u128) -> u128;
+        }
+        hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotl(__x: u128, __y: u128) -> u128;
+        }
+        __hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtl(__x: u128) -> u128;
+        }
+        cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtl(__x: u128) -> u128;
+        }
+        __cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceill(__x: u128) -> u128;
+        }
+        ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceill(__x: u128) -> u128;
+        }
+        __ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsl(__x: u128) -> u128;
+        }
+        fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsl(__x: u128) -> u128;
+        }
+        __fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorl(__x: u128) -> u128;
+        }
+        floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorl(__x: u128) -> u128;
+        }
+        __floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodl(__x: u128, __y: u128) -> u128;
+        }
+        fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodl(__x: u128, __y: u128) -> u128;
+        }
+        __fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dreml(__x: u128, __y: u128) -> u128;
+        }
+        dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dreml(__x: u128, __y: u128) -> u128;
+        }
+        __dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandl(__x: u128) -> u128;
+        }
+        significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandl(__x: u128) -> u128;
+        }
+        __significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignl(__x: u128, __y: u128) -> u128;
+        }
+        copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignl(__x: u128, __y: u128) -> u128;
+        }
+        __copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        __nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0l(arg1: u128) -> u128;
+        }
+        j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0l(arg1: u128) -> u128;
+        }
+        __j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1l(arg1: u128) -> u128;
+        }
+        j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1l(arg1: u128) -> u128;
+        }
+        __j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0l(arg1: u128) -> u128;
+        }
+        y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0l(arg1: u128) -> u128;
+        }
+        __y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1l(arg1: u128) -> u128;
+        }
+        y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1l(arg1: u128) -> u128;
+        }
+        __y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfl(arg1: u128) -> u128;
+        }
+        erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfl(arg1: u128) -> u128;
+        }
+        __erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcl(arg1: u128) -> u128;
+        }
+        erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcl(arg1: u128) -> u128;
+        }
+        __erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal(arg1: u128) -> u128;
+        }
+        lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal(arg1: u128) -> u128;
+        }
+        __lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammal(arg1: u128) -> u128;
+        }
+        tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammal(arg1: u128) -> u128;
+        }
+        __tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammal(arg1: u128) -> u128;
+        }
+        gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammal(arg1: u128) -> u128;
+        }
+        __gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintl(__x: u128) -> u128;
+        }
+        rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintl(__x: u128) -> u128;
+        }
+        __rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        __nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        __nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderl(__x: u128, __y: u128) -> u128;
+        }
+        remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderl(__x: u128, __y: u128) -> u128;
+        }
+        __remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        __scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        __ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        __scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintl(__x: u128) -> u128;
+        }
+        nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintl(__x: u128) -> u128;
+        }
+        __nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundl(__x: u128) -> u128;
+        }
+        roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundl(__x: u128) -> u128;
+        }
+        __roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncl(__x: u128) -> u128;
+        }
+        truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncl(__x: u128) -> u128;
+        }
+        __truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquol(arg___x: u128, arg___y: u128, arg___quo: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquol(
+    arg___x: u128,
+    arg___y: u128,
+    arg___quo: *mut ::std::os::raw::c_int,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdiml(__x: u128, __y: u128) -> u128;
+        }
+        fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdiml(__x: u128, __y: u128) -> u128;
+        }
+        __fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        __fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminl(__x: u128, __y: u128) -> u128;
+        }
+        fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminl(__x: u128, __y: u128) -> u128;
+        }
+        __fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        __fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbl(__x: u128, __n: u128) -> u128;
+        }
+        scalbl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbl(__x: u128, __n: u128) -> u128;
+        }
+        __scalbl(arg___x, arg___n)
     })
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-impl Default for exception {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
+pub const FP_NAN: _bindgen_ty_8 = 0;
+pub const FP_INFINITE: _bindgen_ty_8 = 1;
+pub const FP_ZERO: _bindgen_ty_8 = 2;
+pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
+pub const FP_NORMAL: _bindgen_ty_8 = 4;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[track_caller]
+pub unsafe fn strlcat(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlcat(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
         }
-    }
+        strlcat(arg_dst, arg_src, arg_siz)
+    })
+}
+#[track_caller]
+pub unsafe fn strlcpy(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlcpy(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strlcpy(arg_dst, arg_src, arg_siz)
+    })
 }
 #[track_caller]
 pub unsafe fn pg_qsort(
@@ -13744,17 +14698,16 @@ pub unsafe fn wait_result_is_any_signal(
         wait_result_is_any_signal(arg_exit_status, arg_include_command_not_found)
     })
 }
-pub type jmp_buf = [::std::os::raw::c_int; 48usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 49usize];
-#[track_caller]
-pub unsafe fn longjmperror() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn longjmperror();
-        }
-        longjmperror()
-    })
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
 }
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[track_caller]
 pub unsafe fn errstart(
     arg_elevel: ::std::os::raw::c_int,
@@ -17812,7 +18765,7 @@ pub unsafe fn ItemPointerCompare(arg_arg1: ItemPointer, arg_arg2: ItemPointer) -
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct pg_atomic_flag {
-    pub value: ::std::os::raw::c_int,
+    pub value: ::std::os::raw::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19342,390 +20295,147 @@ pub unsafe fn HeapTupleGetUpdateXid(arg_tuple: HeapTupleHeader) -> TransactionId
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
-#[track_caller]
-pub unsafe fn open(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        open(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn openat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn openat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        openat(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn creat(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: mode_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn creat(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: mode_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        creat(arg_arg1, arg_arg2)
-    })
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
 #[track_caller]
 pub unsafe fn fcntl(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fcntl(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        fcntl(arg_arg1, arg_arg2)
+        fcntl(arg___fd, arg___cmd)
     })
 }
 #[track_caller]
-pub unsafe fn openx_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: filesec_t,
+pub unsafe fn open(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openx_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: filesec_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        openx_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn open_dprotected_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open_dprotected_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn open(
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        open_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        open(arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_dprotected_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: ::std::os::raw::c_int,
+pub unsafe fn openat(
+    arg___fd: ::std::os::raw::c_int,
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_dprotected_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-                arg5: ::std::os::raw::c_int,
+            pub fn openat(
+                __fd: ::std::os::raw::c_int,
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        openat_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        openat(arg___fd, arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_authenticated_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
+pub unsafe fn creat(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___mode: mode_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_authenticated_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn creat(
+                __file: *const ::std::os::raw::c_char,
+                __mode: mode_t,
             ) -> ::std::os::raw::c_int;
         }
-        openat_authenticated_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        creat(arg___file, arg___mode)
     })
 }
 #[track_caller]
-pub unsafe fn flock(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn lockf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flock(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+            pub fn lockf(
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        flock(arg_arg1, arg_arg2)
+        lockf(arg___fd, arg___cmd, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_init() -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_init() -> filesec_t;
-        }
-        filesec_init()
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_dup(arg_arg1: filesec_t) -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-        }
-        filesec_dup(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_free(arg_arg1: filesec_t) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_free(arg1: filesec_t);
-        }
-        filesec_free(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_get_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_void,
+pub unsafe fn posix_fadvise(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
+    arg___advise: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_get_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_void,
+            pub fn posix_fadvise(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
+                __advise: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_get_property(arg_arg1, arg_arg2, arg_arg3)
+        posix_fadvise(arg___fd, arg___offset, arg___len, arg___advise)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_query_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_int,
+pub unsafe fn posix_fallocate(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_query_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_int,
+            pub fn posix_fallocate(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_query_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_set_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *const ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_set_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_set_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_unset_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_unset_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_unset_property(arg_arg1, arg_arg2)
+        posix_fallocate(arg___fd, arg___offset, arg___len)
     })
 }
 pub type XLogRecPtr = uint64;
@@ -20975,6 +21685,7 @@ pub struct SubPlan {
     pub args: *mut List,
     pub startup_cost: Cost,
     pub per_call_cost: Cost,
+    pub subLinkId: ::std::os::raw::c_int,
 }
 impl Default for SubPlan {
     fn default() -> Self {
@@ -22854,7 +23565,7 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
@@ -22865,26 +23576,11 @@ impl Default for tm {
         }
     }
 }
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[track_caller]
-pub unsafe fn asctime(arg_arg1: *const tm) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
-        }
-        asctime(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[track_caller]
 pub unsafe fn clock() -> clock_t {
@@ -22896,103 +23592,167 @@ pub unsafe fn clock() -> clock_t {
     })
 }
 #[track_caller]
-pub unsafe fn ctime(arg_arg1: *const time_t) -> *mut ::std::os::raw::c_char {
+pub unsafe fn time(arg___timer: *mut time_t) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+            pub fn time(__timer: *mut time_t) -> time_t;
         }
-        ctime(arg_arg1)
+        time(arg___timer)
     })
 }
 #[track_caller]
-pub unsafe fn difftime(arg_arg1: time_t, arg_arg2: time_t) -> f64 {
+pub unsafe fn difftime(arg___time1: time_t, arg___time0: time_t) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+            pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
         }
-        difftime(arg_arg1, arg_arg2)
+        difftime(arg___time1, arg___time0)
     })
 }
 #[track_caller]
-pub unsafe fn getdate(arg_arg1: *const ::std::os::raw::c_char) -> *mut tm {
+pub unsafe fn mktime(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+            pub fn mktime(__tp: *mut tm) -> time_t;
         }
-        getdate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gmtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gmtime(arg1: *const time_t) -> *mut tm;
-        }
-        gmtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime(arg1: *const time_t) -> *mut tm;
-        }
-        localtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mktime(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mktime(arg1: *mut tm) -> time_t;
-        }
-        mktime(arg_arg1)
+        mktime(arg___tp)
     })
 }
 #[track_caller]
 pub unsafe fn strftime(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const tm,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
 ) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strftime(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const tm,
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
             ) -> usize;
         }
-        strftime(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        strftime(arg___s, arg___maxsize, arg___format, arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn strptime(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut tm,
+pub unsafe fn strftime_l(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
+    arg___loc: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strftime_l(
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
+                __loc: locale_t,
+            ) -> usize;
+        }
+        strftime_l(arg___s, arg___maxsize, arg___format, arg___tp, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime(__timer: *const time_t) -> *mut tm;
+        }
+        gmtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime(__timer: *const time_t) -> *mut tm;
+        }
+        localtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        gmtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        localtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime(arg___tp: *const tm) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+        }
+        asctime(arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn ctime(arg___timer: *const time_t) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+        }
+        ctime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime_r(
+    arg___tp: *const tm,
+    arg___buf: *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strptime(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut tm,
+            pub fn asctime_r(
+                __tp: *const tm,
+                __buf: *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strptime(arg_arg1, arg_arg2, arg_arg3)
+        asctime_r(arg___tp, arg___buf)
     })
 }
 #[track_caller]
-pub unsafe fn time(arg_arg1: *mut time_t) -> time_t {
+pub unsafe fn ctime_r(
+    arg___timer: *const time_t,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn time(arg1: *mut time_t) -> time_t;
+            pub fn ctime_r(
+                __timer: *const time_t,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        time(arg_arg1)
+        ctime_r(arg___timer, arg___buf)
     })
+}
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[track_caller]
 pub unsafe fn tzset() {
@@ -23003,123 +23763,54 @@ pub unsafe fn tzset() {
         tzset()
     })
 }
+extern "C" {
+    pub static mut daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut timezone: ::std::os::raw::c_long;
+}
 #[track_caller]
-pub unsafe fn asctime_r(
-    arg_arg1: *const tm,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timegm(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asctime_r(
-                arg1: *const tm,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timegm(__tp: *mut tm) -> time_t;
         }
-        asctime_r(arg_arg1, arg_arg2)
+        timegm(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn ctime_r(
-    arg_arg1: *const time_t,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timelocal(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime_r(
-                arg1: *const time_t,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timelocal(__tp: *mut tm) -> time_t;
         }
-        ctime_r(arg_arg1, arg_arg2)
+        timelocal(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn gmtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
+pub unsafe fn dysize(arg___year: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+            pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        gmtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
-        }
-        localtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn posix2time(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix2time(arg1: time_t) -> time_t;
-        }
-        posix2time(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tzsetwall() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tzsetwall();
-        }
-        tzsetwall()
-    })
-}
-#[track_caller]
-pub unsafe fn time2posix(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn time2posix(arg1: time_t) -> time_t;
-        }
-        time2posix(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timelocal(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timelocal(arg1: *mut tm) -> time_t;
-        }
-        timelocal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timegm(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timegm(arg1: *mut tm) -> time_t;
-        }
-        timegm(arg_arg1)
+        dysize(arg___year)
     })
 }
 #[track_caller]
 pub unsafe fn nanosleep(
-    arg___rqtp: *const timespec,
-    arg___rmtp: *mut timespec,
+    arg___requested_time: *const timespec,
+    arg___remaining: *mut timespec,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn nanosleep(
-                __rqtp: *const timespec,
-                __rmtp: *mut timespec,
+                __requested_time: *const timespec,
+                __remaining: *mut timespec,
             ) -> ::std::os::raw::c_int;
         }
-        nanosleep(arg___rqtp, arg___rmtp)
+        nanosleep(arg___requested_time, arg___remaining)
     })
 }
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn clock_getres(
     arg___clock_id: clockid_t,
@@ -23151,15 +23842,6 @@ pub unsafe fn clock_gettime(
     })
 }
 #[track_caller]
-pub unsafe fn clock_gettime_nsec_np(arg___clock_id: clockid_t) -> __uint64_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-        }
-        clock_gettime_nsec_np(arg___clock_id)
-    })
-}
-#[track_caller]
 pub unsafe fn clock_settime(
     arg___clock_id: clockid_t,
     arg___tp: *const timespec,
@@ -23175,18 +23857,121 @@ pub unsafe fn clock_settime(
     })
 }
 #[track_caller]
+pub unsafe fn clock_nanosleep(
+    arg___clock_id: clockid_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___req: *const timespec,
+    arg___rem: *mut timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_nanosleep(
+                __clock_id: clockid_t,
+                __flags: ::std::os::raw::c_int,
+                __req: *const timespec,
+                __rem: *mut timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_nanosleep(arg___clock_id, arg___flags, arg___req, arg___rem)
+    })
+}
+#[track_caller]
+pub unsafe fn clock_getcpuclockid(
+    arg___pid: pid_t,
+    arg___clock_id: *mut clockid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_getcpuclockid(
+                __pid: pid_t,
+                __clock_id: *mut clockid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_getcpuclockid(arg___pid, arg___clock_id)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_create(
+    arg___clock_id: clockid_t,
+    arg___evp: *mut sigevent,
+    arg___timerid: *mut timer_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_create(
+                __clock_id: clockid_t,
+                __evp: *mut sigevent,
+                __timerid: *mut timer_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_create(arg___clock_id, arg___evp, arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_delete(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_delete(arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_settime(
+    arg___timerid: timer_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___value: *const itimerspec,
+    arg___ovalue: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_settime(
+                __timerid: timer_t,
+                __flags: ::std::os::raw::c_int,
+                __value: *const itimerspec,
+                __ovalue: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_settime(arg___timerid, arg___flags, arg___value, arg___ovalue)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_gettime(
+    arg___timerid: timer_t,
+    arg___value: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_gettime(
+                __timerid: timer_t,
+                __value: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_gettime(arg___timerid, arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_getoverrun(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_getoverrun(arg___timerid)
+    })
+}
+#[track_caller]
 pub unsafe fn timespec_get(
-    arg_ts: *mut timespec,
-    arg_base: ::std::os::raw::c_int,
+    arg___ts: *mut timespec,
+    arg___base: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn timespec_get(
-                ts: *mut timespec,
-                base: ::std::os::raw::c_int,
+                __ts: *mut timespec,
+                __base: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        timespec_get(arg_ts, arg_base)
+        timespec_get(arg___ts, arg___base)
     })
 }
 pub type instr_time = timespec;
@@ -24935,12 +25720,11 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
@@ -24951,146 +25735,119 @@ impl Default for dirent {
         }
     }
 }
+pub const DT_UNKNOWN: _bindgen_ty_9 = 0;
+pub const DT_FIFO: _bindgen_ty_9 = 1;
+pub const DT_CHR: _bindgen_ty_9 = 2;
+pub const DT_DIR: _bindgen_ty_9 = 4;
+pub const DT_BLK: _bindgen_ty_9 = 6;
+pub const DT_REG: _bindgen_ty_9 = 8;
+pub const DT_LNK: _bindgen_ty_9 = 10;
+pub const DT_SOCK: _bindgen_ty_9 = 12;
+pub const DT_WHT: _bindgen_ty_9 = 14;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type DIR = __dirstream;
 #[track_caller]
-pub unsafe fn closedir(arg_arg1: *mut DIR) -> ::std::os::raw::c_int {
+pub unsafe fn closedir(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+            pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        closedir(arg_arg1)
+        closedir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn opendir(arg_arg1: *const ::std::os::raw::c_char) -> *mut DIR {
+pub unsafe fn opendir(arg___name: *const ::std::os::raw::c_char) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+            pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
         }
-        opendir(arg_arg1)
+        opendir(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn readdir(arg_arg1: *mut DIR) -> *mut dirent {
+pub unsafe fn fdopendir(arg___fd: ::std::os::raw::c_int) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+            pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
         }
-        readdir(arg_arg1)
+        fdopendir(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn readdir(arg___dirp: *mut DIR) -> *mut dirent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+        }
+        readdir(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn readdir_r(
-    arg_arg1: *mut DIR,
-    arg_arg2: *mut dirent,
-    arg_arg3: *mut *mut dirent,
+    arg___dirp: *mut DIR,
+    arg___entry: *mut dirent,
+    arg___result: *mut *mut dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn readdir_r(
-                arg1: *mut DIR,
-                arg2: *mut dirent,
-                arg3: *mut *mut dirent,
+                __dirp: *mut DIR,
+                __entry: *mut dirent,
+                __result: *mut *mut dirent,
             ) -> ::std::os::raw::c_int;
         }
-        readdir_r(arg_arg1, arg_arg2, arg_arg3)
+        readdir_r(arg___dirp, arg___entry, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn rewinddir(arg_arg1: *mut DIR) {
+pub unsafe fn rewinddir(arg___dirp: *mut DIR) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rewinddir(arg1: *mut DIR);
+            pub fn rewinddir(__dirp: *mut DIR);
         }
-        rewinddir(arg_arg1)
+        rewinddir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn seekdir(arg_arg1: *mut DIR, arg_arg2: ::std::os::raw::c_long) {
+pub unsafe fn seekdir(arg___dirp: *mut DIR, arg___pos: ::std::os::raw::c_long) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+            pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
         }
-        seekdir(arg_arg1, arg_arg2)
+        seekdir(arg___dirp, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn telldir(arg_arg1: *mut DIR) -> ::std::os::raw::c_long {
+pub unsafe fn telldir(arg___dirp: *mut DIR) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+            pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
         }
-        telldir(arg_arg1)
+        telldir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn fdopendir(arg_arg1: ::std::os::raw::c_int) -> *mut DIR {
+pub unsafe fn dirfd(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+            pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        fdopendir(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn alphasort(
-    arg_arg1: *mut *const dirent,
-    arg_arg2: *mut *const dirent,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alphasort(
-                arg1: *mut *const dirent,
-                arg2: *mut *const dirent,
-            ) -> ::std::os::raw::c_int;
-        }
-        alphasort(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn dirfd(arg_dirp: *mut DIR) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-        }
-        dirfd(arg_dirp)
+        dirfd(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn scandir(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: ::std::option::Option<
+    arg___dir: *const ::std::os::raw::c_char,
+    arg___namelist: *mut *mut *mut dirent,
+    arg___selector: ::std::option::Option<
         unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
     >,
-    arg_arg4: ::std::option::Option<
+    arg___cmp: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut *const dirent,
             arg2: *mut *const dirent,
@@ -25100,12 +25857,12 @@ pub unsafe fn scandir(
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn scandir(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: ::std::option::Option<
+                __dir: *const ::std::os::raw::c_char,
+                __namelist: *mut *mut *mut dirent,
+                __selector: ::std::option::Option<
                     unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
                 >,
-                arg4: ::std::option::Option<
+                __cmp: ::std::option::Option<
                     unsafe extern "C" fn(
                         arg1: *mut *const dirent,
                         arg2: *mut *const dirent,
@@ -25113,61 +25870,41 @@ pub unsafe fn scandir(
                 >,
             ) -> ::std::os::raw::c_int;
         }
-        scandir(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        scandir(arg___dir, arg___namelist, arg___selector, arg___cmp)
     })
 }
 #[track_caller]
-pub unsafe fn scandir_b(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: *mut ::std::os::raw::c_void,
+pub unsafe fn alphasort(
+    arg___e1: *mut *const dirent,
+    arg___e2: *mut *const dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scandir_b(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: *mut ::std::os::raw::c_void,
+            pub fn alphasort(
+                __e1: *mut *const dirent,
+                __e2: *mut *const dirent,
             ) -> ::std::os::raw::c_int;
         }
-        scandir_b(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        alphasort(arg___e1, arg___e2)
     })
 }
 #[track_caller]
 pub unsafe fn getdirentries(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___nbytes: usize,
+    arg___basep: *mut __off_t,
+) -> __ssize_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
             pub fn getdirentries(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __nbytes: usize,
+                __basep: *mut __off_t,
+            ) -> __ssize_t;
         }
-        getdirentries(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __opendir2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut DIR {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __opendir2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut DIR;
-        }
-        __opendir2(arg_arg1, arg_arg2)
+        getdirentries(arg___fd, arg___buf, arg___nbytes, arg___basep)
     })
 }
 pub type File = ::std::os::raw::c_int;
@@ -25863,7 +26600,7 @@ pub unsafe fn data_sync_elevel(arg_elevel: ::std::os::raw::c_int) -> ::std::os::
         data_sync_elevel(arg_elevel)
     })
 }
-pub type slock_t = ::std::os::raw::c_int;
+pub type slock_t = ::std::os::raw::c_uchar;
 extern "C" {
     pub static mut dummy_spinlock: slock_t;
 }
@@ -37278,356 +38015,943 @@ pub unsafe fn extract_variadic_args(
         )
     })
 }
-extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
 }
-extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+impl Default for sigval {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const SI_ASYNCNL: _bindgen_ty_10 = -60;
+pub const SI_DETHREAD: _bindgen_ty_10 = -7;
+pub const SI_TKILL: _bindgen_ty_10 = -6;
+pub const SI_SIGIO: _bindgen_ty_10 = -5;
+pub const SI_ASYNCIO: _bindgen_ty_10 = -4;
+pub const SI_MESGQ: _bindgen_ty_10 = -3;
+pub const SI_TIMER: _bindgen_ty_10 = -2;
+pub const SI_QUEUE: _bindgen_ty_10 = -1;
+pub const SI_USER: _bindgen_ty_10 = 0;
+pub const SI_KERNEL: _bindgen_ty_10 = 128;
+pub type _bindgen_ty_10 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: _bindgen_ty_11 = 1;
+pub const ILL_ILLOPN: _bindgen_ty_11 = 2;
+pub const ILL_ILLADR: _bindgen_ty_11 = 3;
+pub const ILL_ILLTRP: _bindgen_ty_11 = 4;
+pub const ILL_PRVOPC: _bindgen_ty_11 = 5;
+pub const ILL_PRVREG: _bindgen_ty_11 = 6;
+pub const ILL_COPROC: _bindgen_ty_11 = 7;
+pub const ILL_BADSTK: _bindgen_ty_11 = 8;
+pub const ILL_BADIADDR: _bindgen_ty_11 = 9;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: _bindgen_ty_12 = 1;
+pub const FPE_INTOVF: _bindgen_ty_12 = 2;
+pub const FPE_FLTDIV: _bindgen_ty_12 = 3;
+pub const FPE_FLTOVF: _bindgen_ty_12 = 4;
+pub const FPE_FLTUND: _bindgen_ty_12 = 5;
+pub const FPE_FLTRES: _bindgen_ty_12 = 6;
+pub const FPE_FLTINV: _bindgen_ty_12 = 7;
+pub const FPE_FLTSUB: _bindgen_ty_12 = 8;
+pub const FPE_FLTUNK: _bindgen_ty_12 = 14;
+pub const FPE_CONDTRAP: _bindgen_ty_12 = 15;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: _bindgen_ty_13 = 1;
+pub const SEGV_ACCERR: _bindgen_ty_13 = 2;
+pub const SEGV_BNDERR: _bindgen_ty_13 = 3;
+pub const SEGV_PKUERR: _bindgen_ty_13 = 4;
+pub const SEGV_ACCADI: _bindgen_ty_13 = 5;
+pub const SEGV_ADIDERR: _bindgen_ty_13 = 6;
+pub const SEGV_ADIPERR: _bindgen_ty_13 = 7;
+pub const SEGV_MTEAERR: _bindgen_ty_13 = 8;
+pub const SEGV_MTESERR: _bindgen_ty_13 = 9;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: _bindgen_ty_14 = 1;
+pub const BUS_ADRERR: _bindgen_ty_14 = 2;
+pub const BUS_OBJERR: _bindgen_ty_14 = 3;
+pub const BUS_MCEERR_AR: _bindgen_ty_14 = 4;
+pub const BUS_MCEERR_AO: _bindgen_ty_14 = 5;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: _bindgen_ty_15 = 1;
+pub const CLD_KILLED: _bindgen_ty_15 = 2;
+pub const CLD_DUMPED: _bindgen_ty_15 = 3;
+pub const CLD_TRAPPED: _bindgen_ty_15 = 4;
+pub const CLD_STOPPED: _bindgen_ty_15 = 5;
+pub const CLD_CONTINUED: _bindgen_ty_15 = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub const POLL_IN: _bindgen_ty_16 = 1;
+pub const POLL_OUT: _bindgen_ty_16 = 2;
+pub const POLL_MSG: _bindgen_ty_16 = 3;
+pub const POLL_ERR: _bindgen_ty_16 = 4;
+pub const POLL_PRI: _bindgen_ty_16 = 5;
+pub const POLL_HUP: _bindgen_ty_16 = 6;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: _bindgen_ty_17 = 0;
+pub const SIGEV_NONE: _bindgen_ty_17 = 1;
+pub const SIGEV_THREAD: _bindgen_ty_17 = 2;
+pub const SIGEV_THREAD_ID: _bindgen_ty_17 = 4;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[track_caller]
-pub unsafe fn raise(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __sysv_signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __sysv_signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        raise(arg_arg1)
+        __sysv_signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn bsd_signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bsd_signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        bsd_signal(arg_arg1, arg_arg2)
+        signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn kill(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn kill(arg___pid: __pid_t, arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        kill(arg_arg1, arg_arg2)
+        kill(arg___pid, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn killpg(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        killpg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pthread_kill(
-    arg_arg1: pthread_t,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn killpg(
+    arg___pgrp: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_kill(
-                arg1: pthread_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_kill(arg_arg1, arg_arg2)
+        killpg(arg___pgrp, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn pthread_sigmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
-) -> ::std::os::raw::c_int {
+pub unsafe fn raise(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_sigmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
-            ) -> ::std::os::raw::c_int;
+            pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_sigmask(arg_arg1, arg_arg2, arg_arg3)
+        raise(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn sigaction(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigaction,
-    arg_arg3: *mut sigaction,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ssignal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigaction(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigaction,
-                arg3: *mut sigaction,
-            ) -> ::std::os::raw::c_int;
+            pub fn ssignal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        sigaction(arg_arg1, arg_arg2, arg_arg3)
+        ssignal(arg___sig, arg___handler)
+    })
+}
+#[track_caller]
+pub unsafe fn gsignal(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        gsignal(arg___sig)
+    })
+}
+#[track_caller]
+pub unsafe fn psignal(arg___sig: ::std::os::raw::c_int, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
+        }
+        psignal(arg___sig, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn psiginfo(arg___pinfo: *const siginfo_t, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
+        }
+        psiginfo(arg___pinfo, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn sigblock(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigblock(arg___mask)
+    })
+}
+#[track_caller]
+pub unsafe fn sigsetmask(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigsetmask(arg___mask)
+    })
+}
+pub type sig_t = __sighandler_t;
+#[track_caller]
+pub unsafe fn sigemptyset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigemptyset(arg___set)
+    })
+}
+#[track_caller]
+pub unsafe fn sigfillset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigfillset(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigaddset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigaddset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigaddset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigaltstack(
-    arg_arg1: *const stack_t,
-    arg_arg2: *mut stack_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
-        }
-        sigaltstack(arg_arg1, arg_arg2)
+        sigaddset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigdelset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigdelset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigdelset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigemptyset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigemptyset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigfillset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigfillset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sighold(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sighold(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigignore(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigignore(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn siginterrupt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn siginterrupt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        siginterrupt(arg_arg1, arg_arg2)
+        sigdelset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigismember(
-    arg_arg1: *const sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigismember(
-                arg1: *const sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigismember(arg_arg1, arg_arg2)
+        sigismember(arg___set, arg___signo)
     })
 }
-#[track_caller]
-pub unsafe fn sigpause(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigpause(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
 }
-#[track_caller]
-pub unsafe fn sigpending(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        sigpending(arg_arg1)
-    })
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[track_caller]
 pub unsafe fn sigprocmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
+    arg___how: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___oset: *mut sigset_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigprocmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
+                __how: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __oset: *mut sigset_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigprocmask(arg_arg1, arg_arg2, arg_arg3)
+        sigprocmask(arg___how, arg___set, arg___oset)
     })
 }
 #[track_caller]
-pub unsafe fn sigrelse(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn sigsuspend(arg___set: *const sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
         }
-        sigrelse(arg_arg1)
+        sigsuspend(arg___set)
     })
 }
 #[track_caller]
-pub unsafe fn sigset(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn sigaction(
+    arg___sig: ::std::os::raw::c_int,
+    arg___act: *const sigaction,
+    arg___oact: *mut sigaction,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigset(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn sigaction(
+                __sig: ::std::os::raw::c_int,
+                __act: *const sigaction,
+                __oact: *mut sigaction,
+            ) -> ::std::os::raw::c_int;
         }
-        sigset(arg_arg1, arg_arg2)
+        sigaction(arg___sig, arg___act, arg___oact)
     })
 }
 #[track_caller]
-pub unsafe fn sigsuspend(arg_arg1: *const sigset_t) -> ::std::os::raw::c_int {
+pub unsafe fn sigpending(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+            pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
         }
-        sigsuspend(arg_arg1)
+        sigpending(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigwait(
-    arg_arg1: *const sigset_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___sig: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigwait(
-                arg1: *const sigset_t,
-                arg2: *mut ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __sig: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigwait(arg_arg1, arg_arg2)
+        sigwait(arg___set, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn psignal(arg_arg1: ::std::os::raw::c_uint, arg_arg2: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
-        }
-        psignal(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigblock(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigblock(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigsetmask(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigsetmask(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigvec(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sigvec,
-    arg_arg3: *mut sigvec,
+pub unsafe fn sigwaitinfo(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigvec(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sigvec,
-                arg3: *mut sigvec,
+            pub fn sigwaitinfo(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigvec(arg_arg1, arg_arg2, arg_arg3)
+        sigwaitinfo(arg___set, arg___info)
+    })
+}
+#[track_caller]
+pub unsafe fn sigtimedwait(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
+    arg___timeout: *const timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigtimedwait(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
+                __timeout: *const timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigtimedwait(arg___set, arg___info, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn sigqueue(
+    arg___pid: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
+    arg___val: sigval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigqueue(
+                __pid: __pid_t,
+                __sig: ::std::os::raw::c_int,
+                __val: sigval,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigqueue(arg___pid, arg___sig, arg___val)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn siginterrupt(
+    arg___sig: ::std::os::raw::c_int,
+    arg___interrupt: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn siginterrupt(
+                __sig: ::std::os::raw::c_int,
+                __interrupt: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        siginterrupt(arg___sig, arg___interrupt)
+    })
+}
+pub const SS_ONSTACK: _bindgen_ty_18 = 1;
+pub const SS_DISABLE: _bindgen_ty_18 = 2;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[track_caller]
+pub unsafe fn sigaltstack(
+    arg___ss: *const stack_t,
+    arg___oss: *mut stack_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+        }
+        sigaltstack(arg___ss, arg___oss)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn pthread_sigmask(
+    arg___how: ::std::os::raw::c_int,
+    arg___newmask: *const __sigset_t,
+    arg___oldmask: *mut __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_sigmask(
+                __how: ::std::os::raw::c_int,
+                __newmask: *const __sigset_t,
+                __oldmask: *mut __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_sigmask(arg___how, arg___newmask, arg___oldmask)
+    })
+}
+#[track_caller]
+pub unsafe fn pthread_kill(
+    arg___threadid: pthread_t,
+    arg___signo: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_kill(
+                __threadid: pthread_t,
+                __signo: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_kill(arg___threadid, arg___signo)
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmin() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmin()
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmax() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmax()
     })
 }
 pub type pg_time_t = int64;
@@ -38639,9 +39963,8 @@ pub unsafe fn CancelBackup() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -38736,20 +40059,46 @@ pub const RmgrIds_RM_NEXT_ID: RmgrIds = 22;
 pub type RmgrIds = ::std::os::raw::c_uint;
 pub type pg_crc32c = uint32;
 #[track_caller]
-pub unsafe fn pg_comp_crc32c_armv8(
+pub unsafe fn pg_comp_crc32c_sb8(
     arg_crc: pg_crc32c,
     arg_data: *const ::std::os::raw::c_void,
     arg_len: usize,
 ) -> pg_crc32c {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pg_comp_crc32c_armv8(
+            pub fn pg_comp_crc32c_sb8(
                 crc: pg_crc32c,
                 data: *const ::std::os::raw::c_void,
                 len: usize,
             ) -> pg_crc32c;
         }
-        pg_comp_crc32c_armv8(arg_crc, arg_data, arg_len)
+        pg_comp_crc32c_sb8(arg_crc, arg_data, arg_len)
+    })
+}
+extern "C" {
+    pub static mut pg_comp_crc32c: ::std::option::Option<
+        unsafe extern "C" fn(
+            crc: pg_crc32c,
+            data: *const ::std::os::raw::c_void,
+            len: usize,
+        ) -> pg_crc32c,
+    >;
+}
+#[track_caller]
+pub unsafe fn pg_comp_crc32c_sse42(
+    arg_crc: pg_crc32c,
+    arg_data: *const ::std::os::raw::c_void,
+    arg_len: usize,
+) -> pg_crc32c {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pg_comp_crc32c_sse42(
+                crc: pg_crc32c,
+                data: *const ::std::os::raw::c_void,
+                len: usize,
+            ) -> pg_crc32c;
+        }
+        pg_comp_crc32c_sse42(arg_crc, arg_data, arg_len)
     })
 }
 pub const ForkNumber_InvalidForkNumber: ForkNumber = -1;
@@ -101688,8 +103037,29 @@ pub unsafe fn make_empty_range(arg_typcache: *mut TypeCacheEntry) -> *mut RangeT
         make_empty_range(arg_typcache)
     })
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+impl Default for __va_list_tag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct JitContext {
@@ -101755,2370 +103125,2765 @@ pub struct SMgrRelationData {
 pub struct RowSecurityDesc {
     pub _address: u8,
 }
+impl pg_sys::seal::Sealed for A_ArrayExpr {}
 impl pg_sys::PgNode for A_ArrayExpr {}
 impl std::fmt::Display for A_ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Const {}
 impl pg_sys::PgNode for A_Const {}
 impl std::fmt::Display for A_Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Expr {}
 impl pg_sys::PgNode for A_Expr {}
 impl std::fmt::Display for A_Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indices {}
 impl pg_sys::PgNode for A_Indices {}
 impl std::fmt::Display for A_Indices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indirection {}
 impl pg_sys::PgNode for A_Indirection {}
 impl std::fmt::Display for A_Indirection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Star {}
 impl pg_sys::PgNode for A_Star {}
 impl std::fmt::Display for A_Star {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AccessPriv {}
 impl pg_sys::PgNode for AccessPriv {}
 impl std::fmt::Display for AccessPriv {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Agg {}
 impl pg_sys::PgNode for Agg {}
 impl std::fmt::Display for Agg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggPath {}
 impl pg_sys::PgNode for AggPath {}
 impl std::fmt::Display for AggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggState {}
 impl pg_sys::PgNode for AggState {}
 impl std::fmt::Display for AggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Aggref {}
 impl pg_sys::PgNode for Aggref {}
 impl std::fmt::Display for Aggref {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggrefExprState {}
 impl pg_sys::PgNode for AggrefExprState {}
 impl std::fmt::Display for AggrefExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Alias {}
 impl pg_sys::PgNode for Alias {}
 impl std::fmt::Display for Alias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterCollationStmt {}
 impl pg_sys::PgNode for AlterCollationStmt {}
 impl std::fmt::Display for AlterCollationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseSetStmt {}
 impl pg_sys::PgNode for AlterDatabaseSetStmt {}
 impl std::fmt::Display for AlterDatabaseSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseStmt {}
 impl pg_sys::PgNode for AlterDatabaseStmt {}
 impl std::fmt::Display for AlterDatabaseStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDefaultPrivilegesStmt {}
 impl pg_sys::PgNode for AlterDefaultPrivilegesStmt {}
 impl std::fmt::Display for AlterDefaultPrivilegesStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDomainStmt {}
 impl pg_sys::PgNode for AlterDomainStmt {}
 impl std::fmt::Display for AlterDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEnumStmt {}
 impl pg_sys::PgNode for AlterEnumStmt {}
 impl std::fmt::Display for AlterEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEventTrigStmt {}
 impl pg_sys::PgNode for AlterEventTrigStmt {}
 impl std::fmt::Display for AlterEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionContentsStmt {}
 impl pg_sys::PgNode for AlterExtensionContentsStmt {}
 impl std::fmt::Display for AlterExtensionContentsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionStmt {}
 impl pg_sys::PgNode for AlterExtensionStmt {}
 impl std::fmt::Display for AlterExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFdwStmt {}
 impl pg_sys::PgNode for AlterFdwStmt {}
 impl std::fmt::Display for AlterFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterForeignServerStmt {}
 impl pg_sys::PgNode for AlterForeignServerStmt {}
 impl std::fmt::Display for AlterForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFunctionStmt {}
 impl pg_sys::PgNode for AlterFunctionStmt {}
 impl std::fmt::Display for AlterFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectDependsStmt {}
 impl pg_sys::PgNode for AlterObjectDependsStmt {}
 impl std::fmt::Display for AlterObjectDependsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectSchemaStmt {}
 impl pg_sys::PgNode for AlterObjectSchemaStmt {}
 impl std::fmt::Display for AlterObjectSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOpFamilyStmt {}
 impl pg_sys::PgNode for AlterOpFamilyStmt {}
 impl std::fmt::Display for AlterOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOperatorStmt {}
 impl pg_sys::PgNode for AlterOperatorStmt {}
 impl std::fmt::Display for AlterOperatorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOwnerStmt {}
 impl pg_sys::PgNode for AlterOwnerStmt {}
 impl std::fmt::Display for AlterOwnerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPolicyStmt {}
 impl pg_sys::PgNode for AlterPolicyStmt {}
 impl std::fmt::Display for AlterPolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPublicationStmt {}
 impl pg_sys::PgNode for AlterPublicationStmt {}
 impl std::fmt::Display for AlterPublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleSetStmt {}
 impl pg_sys::PgNode for AlterRoleSetStmt {}
 impl std::fmt::Display for AlterRoleSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleStmt {}
 impl pg_sys::PgNode for AlterRoleStmt {}
 impl std::fmt::Display for AlterRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSeqStmt {}
 impl pg_sys::PgNode for AlterSeqStmt {}
 impl std::fmt::Display for AlterSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSubscriptionStmt {}
 impl pg_sys::PgNode for AlterSubscriptionStmt {}
 impl std::fmt::Display for AlterSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSystemStmt {}
 impl pg_sys::PgNode for AlterSystemStmt {}
 impl std::fmt::Display for AlterSystemStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSConfigurationStmt {}
 impl pg_sys::PgNode for AlterTSConfigurationStmt {}
 impl std::fmt::Display for AlterTSConfigurationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSDictionaryStmt {}
 impl pg_sys::PgNode for AlterTSDictionaryStmt {}
 impl std::fmt::Display for AlterTSDictionaryStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableCmd {}
 impl pg_sys::PgNode for AlterTableCmd {}
 impl std::fmt::Display for AlterTableCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableMoveAllStmt {}
 impl pg_sys::PgNode for AlterTableMoveAllStmt {}
 impl std::fmt::Display for AlterTableMoveAllStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableSpaceOptionsStmt {}
 impl pg_sys::PgNode for AlterTableSpaceOptionsStmt {}
 impl std::fmt::Display for AlterTableSpaceOptionsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableStmt {}
 impl pg_sys::PgNode for AlterTableStmt {}
 impl std::fmt::Display for AlterTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterUserMappingStmt {}
 impl pg_sys::PgNode for AlterUserMappingStmt {}
 impl std::fmt::Display for AlterUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlan {}
 impl pg_sys::PgNode for AlternativeSubPlan {}
 impl std::fmt::Display for AlternativeSubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlanState {}
 impl pg_sys::PgNode for AlternativeSubPlanState {}
 impl std::fmt::Display for AlternativeSubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Append {}
 impl pg_sys::PgNode for Append {}
 impl std::fmt::Display for Append {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendPath {}
 impl pg_sys::PgNode for AppendPath {}
 impl std::fmt::Display for AppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendRelInfo {}
 impl pg_sys::PgNode for AppendRelInfo {}
 impl std::fmt::Display for AppendRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendState {}
 impl pg_sys::PgNode for AppendState {}
 impl std::fmt::Display for AppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayCoerceExpr {}
 impl pg_sys::PgNode for ArrayCoerceExpr {}
 impl std::fmt::Display for ArrayCoerceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayExpr {}
 impl pg_sys::PgNode for ArrayExpr {}
 impl std::fmt::Display for ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayRef {}
 impl pg_sys::PgNode for ArrayRef {}
 impl std::fmt::Display for ArrayRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BaseBackupCmd {}
 impl pg_sys::PgNode for BaseBackupCmd {}
 impl std::fmt::Display for BaseBackupCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAnd {}
 impl pg_sys::PgNode for BitmapAnd {}
 impl std::fmt::Display for BitmapAnd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndPath {}
 impl pg_sys::PgNode for BitmapAndPath {}
 impl std::fmt::Display for BitmapAndPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndState {}
 impl pg_sys::PgNode for BitmapAndState {}
 impl std::fmt::Display for BitmapAndState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapPath {}
 impl pg_sys::PgNode for BitmapHeapPath {}
 impl std::fmt::Display for BitmapHeapPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScan {}
 impl pg_sys::PgNode for BitmapHeapScan {}
 impl std::fmt::Display for BitmapHeapScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScanState {}
 impl pg_sys::PgNode for BitmapHeapScanState {}
 impl std::fmt::Display for BitmapHeapScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScan {}
 impl pg_sys::PgNode for BitmapIndexScan {}
 impl std::fmt::Display for BitmapIndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScanState {}
 impl pg_sys::PgNode for BitmapIndexScanState {}
 impl std::fmt::Display for BitmapIndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOr {}
 impl pg_sys::PgNode for BitmapOr {}
 impl std::fmt::Display for BitmapOr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrPath {}
 impl pg_sys::PgNode for BitmapOrPath {}
 impl std::fmt::Display for BitmapOrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrState {}
 impl pg_sys::PgNode for BitmapOrState {}
 impl std::fmt::Display for BitmapOrState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BoolExpr {}
 impl pg_sys::PgNode for BoolExpr {}
 impl std::fmt::Display for BoolExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BooleanTest {}
 impl pg_sys::PgNode for BooleanTest {}
 impl std::fmt::Display for BooleanTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallContext {}
 impl pg_sys::PgNode for CallContext {}
 impl std::fmt::Display for CallContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallStmt {}
 impl pg_sys::PgNode for CallStmt {}
 impl std::fmt::Display for CallStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseExpr {}
 impl pg_sys::PgNode for CaseExpr {}
 impl std::fmt::Display for CaseExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseTestExpr {}
 impl pg_sys::PgNode for CaseTestExpr {}
 impl std::fmt::Display for CaseTestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseWhen {}
 impl pg_sys::PgNode for CaseWhen {}
 impl std::fmt::Display for CaseWhen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CheckPointStmt {}
 impl pg_sys::PgNode for CheckPointStmt {}
 impl std::fmt::Display for CheckPointStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClosePortalStmt {}
 impl pg_sys::PgNode for ClosePortalStmt {}
 impl std::fmt::Display for ClosePortalStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClusterStmt {}
 impl pg_sys::PgNode for ClusterStmt {}
 impl std::fmt::Display for ClusterStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoalesceExpr {}
 impl pg_sys::PgNode for CoalesceExpr {}
 impl std::fmt::Display for CoalesceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomain {}
 impl pg_sys::PgNode for CoerceToDomain {}
 impl std::fmt::Display for CoerceToDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomainValue {}
 impl pg_sys::PgNode for CoerceToDomainValue {}
 impl std::fmt::Display for CoerceToDomainValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceViaIO {}
 impl pg_sys::PgNode for CoerceViaIO {}
 impl std::fmt::Display for CoerceViaIO {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateClause {}
 impl pg_sys::PgNode for CollateClause {}
 impl std::fmt::Display for CollateClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateExpr {}
 impl pg_sys::PgNode for CollateExpr {}
 impl std::fmt::Display for CollateExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnDef {}
 impl pg_sys::PgNode for ColumnDef {}
 impl std::fmt::Display for ColumnDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnRef {}
 impl pg_sys::PgNode for ColumnRef {}
 impl std::fmt::Display for ColumnRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommentStmt {}
 impl pg_sys::PgNode for CommentStmt {}
 impl std::fmt::Display for CommentStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommonTableExpr {}
 impl pg_sys::PgNode for CommonTableExpr {}
 impl std::fmt::Display for CommonTableExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CompositeTypeStmt {}
 impl pg_sys::PgNode for CompositeTypeStmt {}
 impl std::fmt::Display for CompositeTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Const {}
 impl pg_sys::PgNode for Const {}
 impl std::fmt::Display for Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Constraint {}
 impl pg_sys::PgNode for Constraint {}
 impl std::fmt::Display for Constraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConstraintsSetStmt {}
 impl pg_sys::PgNode for ConstraintsSetStmt {}
 impl std::fmt::Display for ConstraintsSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConvertRowtypeExpr {}
 impl pg_sys::PgNode for ConvertRowtypeExpr {}
 impl std::fmt::Display for ConvertRowtypeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CopyStmt {}
 impl pg_sys::PgNode for CopyStmt {}
 impl std::fmt::Display for CopyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateAmStmt {}
 impl pg_sys::PgNode for CreateAmStmt {}
 impl std::fmt::Display for CreateAmStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateCastStmt {}
 impl pg_sys::PgNode for CreateCastStmt {}
 impl std::fmt::Display for CreateCastStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateConversionStmt {}
 impl pg_sys::PgNode for CreateConversionStmt {}
 impl std::fmt::Display for CreateConversionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateDomainStmt {}
 impl pg_sys::PgNode for CreateDomainStmt {}
 impl std::fmt::Display for CreateDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEnumStmt {}
 impl pg_sys::PgNode for CreateEnumStmt {}
 impl std::fmt::Display for CreateEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEventTrigStmt {}
 impl pg_sys::PgNode for CreateEventTrigStmt {}
 impl std::fmt::Display for CreateEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateExtensionStmt {}
 impl pg_sys::PgNode for CreateExtensionStmt {}
 impl std::fmt::Display for CreateExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFdwStmt {}
 impl pg_sys::PgNode for CreateFdwStmt {}
 impl std::fmt::Display for CreateFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignServerStmt {}
 impl pg_sys::PgNode for CreateForeignServerStmt {}
 impl std::fmt::Display for CreateForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignTableStmt {}
 impl pg_sys::PgNode for CreateForeignTableStmt {}
 impl std::fmt::Display for CreateForeignTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFunctionStmt {}
 impl pg_sys::PgNode for CreateFunctionStmt {}
 impl std::fmt::Display for CreateFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassItem {}
 impl pg_sys::PgNode for CreateOpClassItem {}
 impl std::fmt::Display for CreateOpClassItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassStmt {}
 impl pg_sys::PgNode for CreateOpClassStmt {}
 impl std::fmt::Display for CreateOpClassStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpFamilyStmt {}
 impl pg_sys::PgNode for CreateOpFamilyStmt {}
 impl std::fmt::Display for CreateOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePLangStmt {}
 impl pg_sys::PgNode for CreatePLangStmt {}
 impl std::fmt::Display for CreatePLangStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePolicyStmt {}
 impl pg_sys::PgNode for CreatePolicyStmt {}
 impl std::fmt::Display for CreatePolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePublicationStmt {}
 impl pg_sys::PgNode for CreatePublicationStmt {}
 impl std::fmt::Display for CreatePublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRangeStmt {}
 impl pg_sys::PgNode for CreateRangeStmt {}
 impl std::fmt::Display for CreateRangeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateReplicationSlotCmd {}
 impl pg_sys::PgNode for CreateReplicationSlotCmd {}
 impl std::fmt::Display for CreateReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRoleStmt {}
 impl pg_sys::PgNode for CreateRoleStmt {}
 impl std::fmt::Display for CreateRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSchemaStmt {}
 impl pg_sys::PgNode for CreateSchemaStmt {}
 impl std::fmt::Display for CreateSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSeqStmt {}
 impl pg_sys::PgNode for CreateSeqStmt {}
 impl std::fmt::Display for CreateSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStatsStmt {}
 impl pg_sys::PgNode for CreateStatsStmt {}
 impl std::fmt::Display for CreateStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStmt {}
 impl pg_sys::PgNode for CreateStmt {}
 impl std::fmt::Display for CreateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSubscriptionStmt {}
 impl pg_sys::PgNode for CreateSubscriptionStmt {}
 impl std::fmt::Display for CreateSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableAsStmt {}
 impl pg_sys::PgNode for CreateTableAsStmt {}
 impl std::fmt::Display for CreateTableAsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableSpaceStmt {}
 impl pg_sys::PgNode for CreateTableSpaceStmt {}
 impl std::fmt::Display for CreateTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTransformStmt {}
 impl pg_sys::PgNode for CreateTransformStmt {}
 impl std::fmt::Display for CreateTransformStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTrigStmt {}
 impl pg_sys::PgNode for CreateTrigStmt {}
 impl std::fmt::Display for CreateTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateUserMappingStmt {}
 impl pg_sys::PgNode for CreateUserMappingStmt {}
 impl std::fmt::Display for CreateUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatedbStmt {}
 impl pg_sys::PgNode for CreatedbStmt {}
 impl std::fmt::Display for CreatedbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScan {}
 impl pg_sys::PgNode for CteScan {}
 impl std::fmt::Display for CteScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScanState {}
 impl pg_sys::PgNode for CteScanState {}
 impl std::fmt::Display for CteScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CurrentOfExpr {}
 impl pg_sys::PgNode for CurrentOfExpr {}
 impl std::fmt::Display for CurrentOfExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomPath {}
 impl pg_sys::PgNode for CustomPath {}
 impl std::fmt::Display for CustomPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScan {}
 impl pg_sys::PgNode for CustomScan {}
 impl std::fmt::Display for CustomScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScanState {}
 impl pg_sys::PgNode for CustomScanState {}
 impl std::fmt::Display for CustomScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeallocateStmt {}
 impl pg_sys::PgNode for DeallocateStmt {}
 impl std::fmt::Display for DeallocateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeclareCursorStmt {}
 impl pg_sys::PgNode for DeclareCursorStmt {}
 impl std::fmt::Display for DeclareCursorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefElem {}
 impl pg_sys::PgNode for DefElem {}
 impl std::fmt::Display for DefElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefineStmt {}
 impl pg_sys::PgNode for DefineStmt {}
 impl std::fmt::Display for DefineStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeleteStmt {}
 impl pg_sys::PgNode for DeleteStmt {}
 impl std::fmt::Display for DeleteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DiscardStmt {}
 impl pg_sys::PgNode for DiscardStmt {}
 impl std::fmt::Display for DiscardStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DoStmt {}
 impl pg_sys::PgNode for DoStmt {}
 impl std::fmt::Display for DoStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DomainConstraintState {}
 impl pg_sys::PgNode for DomainConstraintState {}
 impl std::fmt::Display for DomainConstraintState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropOwnedStmt {}
 impl pg_sys::PgNode for DropOwnedStmt {}
 impl std::fmt::Display for DropOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropReplicationSlotCmd {}
 impl pg_sys::PgNode for DropReplicationSlotCmd {}
 impl std::fmt::Display for DropReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropRoleStmt {}
 impl pg_sys::PgNode for DropRoleStmt {}
 impl std::fmt::Display for DropRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropStmt {}
 impl pg_sys::PgNode for DropStmt {}
 impl std::fmt::Display for DropStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropSubscriptionStmt {}
 impl pg_sys::PgNode for DropSubscriptionStmt {}
 impl std::fmt::Display for DropSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropTableSpaceStmt {}
 impl pg_sys::PgNode for DropTableSpaceStmt {}
 impl std::fmt::Display for DropTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropUserMappingStmt {}
 impl pg_sys::PgNode for DropUserMappingStmt {}
 impl std::fmt::Display for DropUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropdbStmt {}
 impl pg_sys::PgNode for DropdbStmt {}
 impl std::fmt::Display for DropdbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EState {}
 impl pg_sys::PgNode for EState {}
 impl std::fmt::Display for EState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceClass {}
 impl pg_sys::PgNode for EquivalenceClass {}
 impl std::fmt::Display for EquivalenceClass {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceMember {}
 impl pg_sys::PgNode for EquivalenceMember {}
 impl std::fmt::Display for EquivalenceMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EventTriggerData {}
 impl pg_sys::PgNode for EventTriggerData {}
 impl std::fmt::Display for EventTriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExecuteStmt {}
 impl pg_sys::PgNode for ExecuteStmt {}
 impl std::fmt::Display for ExecuteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExplainStmt {}
 impl pg_sys::PgNode for ExplainStmt {}
 impl std::fmt::Display for ExplainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Expr {}
 impl pg_sys::PgNode for Expr {}
 impl std::fmt::Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprContext {}
 impl pg_sys::PgNode for ExprContext {}
 impl std::fmt::Display for ExprContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprState {}
 impl pg_sys::PgNode for ExprState {}
 impl std::fmt::Display for ExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExtensibleNode {}
 impl pg_sys::PgNode for ExtensibleNode {}
 impl std::fmt::Display for ExtensibleNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FdwRoutine {}
 impl pg_sys::PgNode for FdwRoutine {}
 impl std::fmt::Display for FdwRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FetchStmt {}
 impl pg_sys::PgNode for FetchStmt {}
 impl std::fmt::Display for FetchStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldSelect {}
 impl pg_sys::PgNode for FieldSelect {}
 impl std::fmt::Display for FieldSelect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldStore {}
 impl pg_sys::PgNode for FieldStore {}
 impl std::fmt::Display for FieldStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyCacheInfo {}
 impl pg_sys::PgNode for ForeignKeyCacheInfo {}
 impl std::fmt::Display for ForeignKeyCacheInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyOptInfo {}
 impl pg_sys::PgNode for ForeignKeyOptInfo {}
 impl std::fmt::Display for ForeignKeyOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignPath {}
 impl pg_sys::PgNode for ForeignPath {}
 impl std::fmt::Display for ForeignPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScan {}
 impl pg_sys::PgNode for ForeignScan {}
 impl std::fmt::Display for ForeignScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScanState {}
 impl pg_sys::PgNode for ForeignScanState {}
 impl std::fmt::Display for ForeignScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FromExpr {}
 impl pg_sys::PgNode for FromExpr {}
 impl std::fmt::Display for FromExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncCall {}
 impl pg_sys::PgNode for FuncCall {}
 impl std::fmt::Display for FuncCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncExpr {}
 impl pg_sys::PgNode for FuncExpr {}
 impl std::fmt::Display for FuncExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionParameter {}
 impl pg_sys::PgNode for FunctionParameter {}
 impl std::fmt::Display for FunctionParameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScan {}
 impl pg_sys::PgNode for FunctionScan {}
 impl std::fmt::Display for FunctionScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScanState {}
 impl pg_sys::PgNode for FunctionScanState {}
 impl std::fmt::Display for FunctionScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Gather {}
 impl pg_sys::PgNode for Gather {}
 impl std::fmt::Display for Gather {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMerge {}
 impl pg_sys::PgNode for GatherMerge {}
 impl std::fmt::Display for GatherMerge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergePath {}
 impl pg_sys::PgNode for GatherMergePath {}
 impl std::fmt::Display for GatherMergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergeState {}
 impl pg_sys::PgNode for GatherMergeState {}
 impl std::fmt::Display for GatherMergeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherPath {}
 impl pg_sys::PgNode for GatherPath {}
 impl std::fmt::Display for GatherPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherState {}
 impl pg_sys::PgNode for GatherState {}
 impl std::fmt::Display for GatherState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantRoleStmt {}
 impl pg_sys::PgNode for GrantRoleStmt {}
 impl std::fmt::Display for GrantRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantStmt {}
 impl pg_sys::PgNode for GrantStmt {}
 impl std::fmt::Display for GrantStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Group {}
 impl pg_sys::PgNode for Group {}
 impl std::fmt::Display for Group {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupPath {}
 impl pg_sys::PgNode for GroupPath {}
 impl std::fmt::Display for GroupPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupState {}
 impl pg_sys::PgNode for GroupState {}
 impl std::fmt::Display for GroupState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingFunc {}
 impl pg_sys::PgNode for GroupingFunc {}
 impl std::fmt::Display for GroupingFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSet {}
 impl pg_sys::PgNode for GroupingSet {}
 impl std::fmt::Display for GroupingSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetData {}
 impl pg_sys::PgNode for GroupingSetData {}
 impl std::fmt::Display for GroupingSetData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetsPath {}
 impl pg_sys::PgNode for GroupingSetsPath {}
 impl std::fmt::Display for GroupingSetsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Hash {}
 impl pg_sys::PgNode for Hash {}
 impl std::fmt::Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoin {}
 impl pg_sys::PgNode for HashJoin {}
 impl std::fmt::Display for HashJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoinState {}
 impl pg_sys::PgNode for HashJoinState {}
 impl std::fmt::Display for HashJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashPath {}
 impl pg_sys::PgNode for HashPath {}
 impl std::fmt::Display for HashPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashState {}
 impl pg_sys::PgNode for HashState {}
 impl std::fmt::Display for HashState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IdentifySystemCmd {}
 impl pg_sys::PgNode for IdentifySystemCmd {}
 impl std::fmt::Display for IdentifySystemCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ImportForeignSchemaStmt {}
 impl pg_sys::PgNode for ImportForeignSchemaStmt {}
 impl std::fmt::Display for ImportForeignSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexAmRoutine {}
 impl pg_sys::PgNode for IndexAmRoutine {}
 impl std::fmt::Display for IndexAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexElem {}
 impl pg_sys::PgNode for IndexElem {}
 impl std::fmt::Display for IndexElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexInfo {}
 impl pg_sys::PgNode for IndexInfo {}
 impl std::fmt::Display for IndexInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScan {}
 impl pg_sys::PgNode for IndexOnlyScan {}
 impl std::fmt::Display for IndexOnlyScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScanState {}
 impl pg_sys::PgNode for IndexOnlyScanState {}
 impl std::fmt::Display for IndexOnlyScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOptInfo {}
 impl pg_sys::PgNode for IndexOptInfo {}
 impl std::fmt::Display for IndexOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexPath {}
 impl pg_sys::PgNode for IndexPath {}
 impl std::fmt::Display for IndexPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScan {}
 impl pg_sys::PgNode for IndexScan {}
 impl std::fmt::Display for IndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScanState {}
 impl pg_sys::PgNode for IndexScanState {}
 impl std::fmt::Display for IndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexStmt {}
 impl pg_sys::PgNode for IndexStmt {}
 impl std::fmt::Display for IndexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferClause {}
 impl pg_sys::PgNode for InferClause {}
 impl std::fmt::Display for InferClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferenceElem {}
 impl pg_sys::PgNode for InferenceElem {}
 impl std::fmt::Display for InferenceElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InlineCodeBlock {}
 impl pg_sys::PgNode for InlineCodeBlock {}
 impl std::fmt::Display for InlineCodeBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InsertStmt {}
 impl pg_sys::PgNode for InsertStmt {}
 impl std::fmt::Display for InsertStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IntoClause {}
 impl pg_sys::PgNode for IntoClause {}
 impl std::fmt::Display for IntoClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Join {}
 impl pg_sys::PgNode for Join {}
 impl std::fmt::Display for Join {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinExpr {}
 impl pg_sys::PgNode for JoinExpr {}
 impl std::fmt::Display for JoinExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinPath {}
 impl pg_sys::PgNode for JoinPath {}
 impl std::fmt::Display for JoinPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinState {}
 impl pg_sys::PgNode for JoinState {}
 impl std::fmt::Display for JoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JunkFilter {}
 impl pg_sys::PgNode for JunkFilter {}
 impl std::fmt::Display for JunkFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Limit {}
 impl pg_sys::PgNode for Limit {}
 impl std::fmt::Display for Limit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitPath {}
 impl pg_sys::PgNode for LimitPath {}
 impl std::fmt::Display for LimitPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitState {}
 impl pg_sys::PgNode for LimitState {}
 impl std::fmt::Display for LimitState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for List {}
 impl pg_sys::PgNode for List {}
 impl std::fmt::Display for List {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ListenStmt {}
 impl pg_sys::PgNode for ListenStmt {}
 impl std::fmt::Display for ListenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LoadStmt {}
 impl pg_sys::PgNode for LoadStmt {}
 impl std::fmt::Display for LoadStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRows {}
 impl pg_sys::PgNode for LockRows {}
 impl std::fmt::Display for LockRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsPath {}
 impl pg_sys::PgNode for LockRowsPath {}
 impl std::fmt::Display for LockRowsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsState {}
 impl pg_sys::PgNode for LockRowsState {}
 impl std::fmt::Display for LockRowsState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockStmt {}
 impl pg_sys::PgNode for LockStmt {}
 impl std::fmt::Display for LockStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockingClause {}
 impl pg_sys::PgNode for LockingClause {}
 impl std::fmt::Display for LockingClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Material {}
 impl pg_sys::PgNode for Material {}
 impl std::fmt::Display for Material {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialPath {}
 impl pg_sys::PgNode for MaterialPath {}
 impl std::fmt::Display for MaterialPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialState {}
 impl pg_sys::PgNode for MaterialState {}
 impl std::fmt::Display for MaterialState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoryContextData {}
 impl pg_sys::PgNode for MemoryContextData {}
 impl std::fmt::Display for MemoryContextData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppend {}
 impl pg_sys::PgNode for MergeAppend {}
 impl std::fmt::Display for MergeAppend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendPath {}
 impl pg_sys::PgNode for MergeAppendPath {}
 impl std::fmt::Display for MergeAppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendState {}
 impl pg_sys::PgNode for MergeAppendState {}
 impl std::fmt::Display for MergeAppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoin {}
 impl pg_sys::PgNode for MergeJoin {}
 impl std::fmt::Display for MergeJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoinState {}
 impl pg_sys::PgNode for MergeJoinState {}
 impl std::fmt::Display for MergeJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergePath {}
 impl pg_sys::PgNode for MergePath {}
 impl std::fmt::Display for MergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggInfo {}
 impl pg_sys::PgNode for MinMaxAggInfo {}
 impl std::fmt::Display for MinMaxAggInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggPath {}
 impl pg_sys::PgNode for MinMaxAggPath {}
 impl std::fmt::Display for MinMaxAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxExpr {}
 impl pg_sys::PgNode for MinMaxExpr {}
 impl std::fmt::Display for MinMaxExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTable {}
 impl pg_sys::PgNode for ModifyTable {}
 impl std::fmt::Display for ModifyTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTablePath {}
 impl pg_sys::PgNode for ModifyTablePath {}
 impl std::fmt::Display for ModifyTablePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTableState {}
 impl pg_sys::PgNode for ModifyTableState {}
 impl std::fmt::Display for ModifyTableState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MultiAssignRef {}
 impl pg_sys::PgNode for MultiAssignRef {}
 impl std::fmt::Display for MultiAssignRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedArgExpr {}
 impl pg_sys::PgNode for NamedArgExpr {}
 impl std::fmt::Display for NamedArgExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScan {}
 impl pg_sys::PgNode for NamedTuplestoreScan {}
 impl std::fmt::Display for NamedTuplestoreScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScanState {}
 impl pg_sys::PgNode for NamedTuplestoreScanState {}
 impl std::fmt::Display for NamedTuplestoreScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoop {}
 impl pg_sys::PgNode for NestLoop {}
 impl std::fmt::Display for NestLoop {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopParam {}
 impl pg_sys::PgNode for NestLoopParam {}
 impl std::fmt::Display for NestLoopParam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopState {}
 impl pg_sys::PgNode for NestLoopState {}
 impl std::fmt::Display for NestLoopState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NextValueExpr {}
 impl pg_sys::PgNode for NextValueExpr {}
 impl std::fmt::Display for NextValueExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Node {}
 impl pg_sys::PgNode for Node {}
 impl std::fmt::Display for Node {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NotifyStmt {}
 impl pg_sys::PgNode for NotifyStmt {}
 impl std::fmt::Display for NotifyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NullTest {}
 impl pg_sys::PgNode for NullTest {}
 impl std::fmt::Display for NullTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ObjectWithArgs {}
 impl pg_sys::PgNode for ObjectWithArgs {}
 impl std::fmt::Display for ObjectWithArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictClause {}
 impl pg_sys::PgNode for OnConflictClause {}
 impl std::fmt::Display for OnConflictClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictExpr {}
 impl pg_sys::PgNode for OnConflictExpr {}
 impl std::fmt::Display for OnConflictExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictSetState {}
 impl pg_sys::PgNode for OnConflictSetState {}
 impl std::fmt::Display for OnConflictSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OpExpr {}
 impl pg_sys::PgNode for OpExpr {}
 impl std::fmt::Display for OpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Param {}
 impl pg_sys::PgNode for Param {}
 impl std::fmt::Display for Param {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamPathInfo {}
 impl pg_sys::PgNode for ParamPathInfo {}
 impl std::fmt::Display for ParamPathInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamRef {}
 impl pg_sys::PgNode for ParamRef {}
 impl std::fmt::Display for ParamRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionBoundSpec {}
 impl pg_sys::PgNode for PartitionBoundSpec {}
 impl std::fmt::Display for PartitionBoundSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionCmd {}
 impl pg_sys::PgNode for PartitionCmd {}
 impl std::fmt::Display for PartitionCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionElem {}
 impl pg_sys::PgNode for PartitionElem {}
 impl std::fmt::Display for PartitionElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneInfo {}
 impl pg_sys::PgNode for PartitionPruneInfo {}
 impl std::fmt::Display for PartitionPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStep {}
 impl pg_sys::PgNode for PartitionPruneStep {}
 impl std::fmt::Display for PartitionPruneStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepCombine {}
 impl pg_sys::PgNode for PartitionPruneStepCombine {}
 impl std::fmt::Display for PartitionPruneStepCombine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepOp {}
 impl pg_sys::PgNode for PartitionPruneStepOp {}
 impl std::fmt::Display for PartitionPruneStepOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionRangeDatum {}
 impl pg_sys::PgNode for PartitionRangeDatum {}
 impl std::fmt::Display for PartitionRangeDatum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionSpec {}
 impl pg_sys::PgNode for PartitionSpec {}
 impl std::fmt::Display for PartitionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionedRelPruneInfo {}
 impl pg_sys::PgNode for PartitionedRelPruneInfo {}
 impl std::fmt::Display for PartitionedRelPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Path {}
 impl pg_sys::PgNode for Path {}
 impl std::fmt::Display for Path {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathKey {}
 impl pg_sys::PgNode for PathKey {}
 impl std::fmt::Display for PathKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathTarget {}
 impl pg_sys::PgNode for PathTarget {}
 impl std::fmt::Display for PathTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderInfo {}
 impl pg_sys::PgNode for PlaceHolderInfo {}
 impl std::fmt::Display for PlaceHolderInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderVar {}
 impl pg_sys::PgNode for PlaceHolderVar {}
 impl std::fmt::Display for PlaceHolderVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Plan {}
 impl pg_sys::PgNode for Plan {}
 impl std::fmt::Display for Plan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanInvalItem {}
 impl pg_sys::PgNode for PlanInvalItem {}
 impl std::fmt::Display for PlanInvalItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanRowMark {}
 impl pg_sys::PgNode for PlanRowMark {}
 impl std::fmt::Display for PlanRowMark {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanState {}
 impl pg_sys::PgNode for PlanState {}
 impl std::fmt::Display for PlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannedStmt {}
 impl pg_sys::PgNode for PlannedStmt {}
 impl std::fmt::Display for PlannedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerGlobal {}
 impl pg_sys::PgNode for PlannerGlobal {}
 impl std::fmt::Display for PlannerGlobal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerInfo {}
 impl pg_sys::PgNode for PlannerInfo {}
 impl std::fmt::Display for PlannerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerParamItem {}
 impl pg_sys::PgNode for PlannerParamItem {}
 impl std::fmt::Display for PlannerParamItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PrepareStmt {}
 impl pg_sys::PgNode for PrepareStmt {}
 impl std::fmt::Display for PrepareStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSet {}
 impl pg_sys::PgNode for ProjectSet {}
 impl std::fmt::Display for ProjectSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetPath {}
 impl pg_sys::PgNode for ProjectSetPath {}
 impl std::fmt::Display for ProjectSetPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetState {}
 impl pg_sys::PgNode for ProjectSetState {}
 impl std::fmt::Display for ProjectSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionInfo {}
 impl pg_sys::PgNode for ProjectionInfo {}
 impl std::fmt::Display for ProjectionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionPath {}
 impl pg_sys::PgNode for ProjectionPath {}
 impl std::fmt::Display for ProjectionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Query {}
 impl pg_sys::PgNode for Query {}
 impl std::fmt::Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeFunction {}
 impl pg_sys::PgNode for RangeFunction {}
 impl std::fmt::Display for RangeFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeSubselect {}
 impl pg_sys::PgNode for RangeSubselect {}
 impl std::fmt::Display for RangeSubselect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFunc {}
 impl pg_sys::PgNode for RangeTableFunc {}
 impl std::fmt::Display for RangeTableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFuncCol {}
 impl pg_sys::PgNode for RangeTableFuncCol {}
 impl std::fmt::Display for RangeTableFuncCol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableSample {}
 impl pg_sys::PgNode for RangeTableSample {}
 impl std::fmt::Display for RangeTableSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblEntry {}
 impl pg_sys::PgNode for RangeTblEntry {}
 impl std::fmt::Display for RangeTblEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblFunction {}
 impl pg_sys::PgNode for RangeTblFunction {}
 impl std::fmt::Display for RangeTblFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblRef {}
 impl pg_sys::PgNode for RangeTblRef {}
 impl std::fmt::Display for RangeTblRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeVar {}
 impl pg_sys::PgNode for RangeVar {}
 impl std::fmt::Display for RangeVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RawStmt {}
 impl pg_sys::PgNode for RawStmt {}
 impl std::fmt::Display for RawStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReassignOwnedStmt {}
 impl pg_sys::PgNode for ReassignOwnedStmt {}
 impl std::fmt::Display for ReassignOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnion {}
 impl pg_sys::PgNode for RecursiveUnion {}
 impl std::fmt::Display for RecursiveUnion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionPath {}
 impl pg_sys::PgNode for RecursiveUnionPath {}
 impl std::fmt::Display for RecursiveUnionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionState {}
 impl pg_sys::PgNode for RecursiveUnionState {}
 impl std::fmt::Display for RecursiveUnionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RefreshMatViewStmt {}
 impl pg_sys::PgNode for RefreshMatViewStmt {}
 impl std::fmt::Display for RefreshMatViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReindexStmt {}
 impl pg_sys::PgNode for ReindexStmt {}
 impl std::fmt::Display for ReindexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelOptInfo {}
 impl pg_sys::PgNode for RelOptInfo {}
 impl std::fmt::Display for RelOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelabelType {}
 impl pg_sys::PgNode for RelabelType {}
 impl std::fmt::Display for RelabelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RenameStmt {}
 impl pg_sys::PgNode for RenameStmt {}
 impl std::fmt::Display for RenameStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReplicaIdentityStmt {}
 impl pg_sys::PgNode for ReplicaIdentityStmt {}
 impl std::fmt::Display for ReplicaIdentityStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResTarget {}
 impl pg_sys::PgNode for ResTarget {}
 impl std::fmt::Display for ResTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RestrictInfo {}
 impl pg_sys::PgNode for RestrictInfo {}
 impl std::fmt::Display for RestrictInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Result {}
 impl pg_sys::PgNode for Result {}
 impl std::fmt::Display for Result {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultPath {}
 impl pg_sys::PgNode for ResultPath {}
 impl std::fmt::Display for ResultPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultRelInfo {}
 impl pg_sys::PgNode for ResultRelInfo {}
 impl std::fmt::Display for ResultRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultState {}
 impl pg_sys::PgNode for ResultState {}
 impl std::fmt::Display for ResultState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReturnSetInfo {}
 impl pg_sys::PgNode for ReturnSetInfo {}
 impl std::fmt::Display for ReturnSetInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RoleSpec {}
 impl pg_sys::PgNode for RoleSpec {}
 impl std::fmt::Display for RoleSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RollupData {}
 impl pg_sys::PgNode for RollupData {}
 impl std::fmt::Display for RollupData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowCompareExpr {}
 impl pg_sys::PgNode for RowCompareExpr {}
 impl std::fmt::Display for RowCompareExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowExpr {}
 impl pg_sys::PgNode for RowExpr {}
 impl std::fmt::Display for RowExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowMarkClause {}
 impl pg_sys::PgNode for RowMarkClause {}
 impl std::fmt::Display for RowMarkClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RuleStmt {}
 impl pg_sys::PgNode for RuleStmt {}
 impl std::fmt::Display for RuleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLCmd {}
 impl pg_sys::PgNode for SQLCmd {}
 impl std::fmt::Display for SQLCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLValueFunction {}
 impl pg_sys::PgNode for SQLValueFunction {}
 impl std::fmt::Display for SQLValueFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScan {}
 impl pg_sys::PgNode for SampleScan {}
 impl std::fmt::Display for SampleScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScanState {}
 impl pg_sys::PgNode for SampleScanState {}
 impl std::fmt::Display for SampleScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScalarArrayOpExpr {}
 impl pg_sys::PgNode for ScalarArrayOpExpr {}
 impl std::fmt::Display for ScalarArrayOpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Scan {}
 impl pg_sys::PgNode for Scan {}
 impl std::fmt::Display for Scan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScanState {}
 impl pg_sys::PgNode for ScanState {}
 impl std::fmt::Display for ScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SecLabelStmt {}
 impl pg_sys::PgNode for SecLabelStmt {}
 impl std::fmt::Display for SecLabelStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SelectStmt {}
 impl pg_sys::PgNode for SelectStmt {}
 impl std::fmt::Display for SelectStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SeqScanState {}
 impl pg_sys::PgNode for SeqScanState {}
 impl std::fmt::Display for SeqScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetExprState {}
 impl pg_sys::PgNode for SetExprState {}
 impl std::fmt::Display for SetExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOp {}
 impl pg_sys::PgNode for SetOp {}
 impl std::fmt::Display for SetOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpPath {}
 impl pg_sys::PgNode for SetOpPath {}
 impl std::fmt::Display for SetOpPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpState {}
 impl pg_sys::PgNode for SetOpState {}
 impl std::fmt::Display for SetOpState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOperationStmt {}
 impl pg_sys::PgNode for SetOperationStmt {}
 impl std::fmt::Display for SetOperationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetToDefault {}
 impl pg_sys::PgNode for SetToDefault {}
 impl std::fmt::Display for SetToDefault {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Sort {}
 impl pg_sys::PgNode for Sort {}
 impl std::fmt::Display for Sort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortBy {}
 impl pg_sys::PgNode for SortBy {}
 impl std::fmt::Display for SortBy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortGroupClause {}
 impl pg_sys::PgNode for SortGroupClause {}
 impl std::fmt::Display for SortGroupClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortPath {}
 impl pg_sys::PgNode for SortPath {}
 impl std::fmt::Display for SortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortState {}
 impl pg_sys::PgNode for SortState {}
 impl std::fmt::Display for SortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SpecialJoinInfo {}
 impl pg_sys::PgNode for SpecialJoinInfo {}
 impl std::fmt::Display for SpecialJoinInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StartReplicationCmd {}
 impl pg_sys::PgNode for StartReplicationCmd {}
 impl std::fmt::Display for StartReplicationCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StatisticExtInfo {}
 impl pg_sys::PgNode for StatisticExtInfo {}
 impl std::fmt::Display for StatisticExtInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubLink {}
 impl pg_sys::PgNode for SubLink {}
 impl std::fmt::Display for SubLink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlan {}
 impl pg_sys::PgNode for SubPlan {}
 impl std::fmt::Display for SubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlanState {}
 impl pg_sys::PgNode for SubPlanState {}
 impl std::fmt::Display for SubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScan {}
 impl pg_sys::PgNode for SubqueryScan {}
 impl std::fmt::Display for SubqueryScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanPath {}
 impl pg_sys::PgNode for SubqueryScanPath {}
 impl std::fmt::Display for SubqueryScanPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanState {}
 impl pg_sys::PgNode for SubqueryScanState {}
 impl std::fmt::Display for SubqueryScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFunc {}
 impl pg_sys::PgNode for TableFunc {}
 impl std::fmt::Display for TableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScan {}
 impl pg_sys::PgNode for TableFuncScan {}
 impl std::fmt::Display for TableFuncScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScanState {}
 impl pg_sys::PgNode for TableFuncScanState {}
 impl std::fmt::Display for TableFuncScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableLikeClause {}
 impl pg_sys::PgNode for TableLikeClause {}
 impl std::fmt::Display for TableLikeClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableSampleClause {}
 impl pg_sys::PgNode for TableSampleClause {}
 impl std::fmt::Display for TableSampleClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TargetEntry {}
 impl pg_sys::PgNode for TargetEntry {}
 impl std::fmt::Display for TargetEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidPath {}
 impl pg_sys::PgNode for TidPath {}
 impl std::fmt::Display for TidPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScan {}
 impl pg_sys::PgNode for TidScan {}
 impl std::fmt::Display for TidScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScanState {}
 impl pg_sys::PgNode for TidScanState {}
 impl std::fmt::Display for TidScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TimeLineHistoryCmd {}
 impl pg_sys::PgNode for TimeLineHistoryCmd {}
 impl std::fmt::Display for TimeLineHistoryCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TransactionStmt {}
 impl pg_sys::PgNode for TransactionStmt {}
 impl std::fmt::Display for TransactionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerData {}
 impl pg_sys::PgNode for TriggerData {}
 impl std::fmt::Display for TriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerTransition {}
 impl pg_sys::PgNode for TriggerTransition {}
 impl std::fmt::Display for TriggerTransition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TruncateStmt {}
 impl pg_sys::PgNode for TruncateStmt {}
 impl std::fmt::Display for TruncateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TupleTableSlot {}
 impl pg_sys::PgNode for TupleTableSlot {}
 impl std::fmt::Display for TupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeCast {}
 impl pg_sys::PgNode for TypeCast {}
 impl std::fmt::Display for TypeCast {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeName {}
 impl pg_sys::PgNode for TypeName {}
 impl std::fmt::Display for TypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Unique {}
 impl pg_sys::PgNode for Unique {}
 impl std::fmt::Display for Unique {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniquePath {}
 impl pg_sys::PgNode for UniquePath {}
 impl std::fmt::Display for UniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniqueState {}
 impl pg_sys::PgNode for UniqueState {}
 impl std::fmt::Display for UniqueState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UnlistenStmt {}
 impl pg_sys::PgNode for UnlistenStmt {}
 impl std::fmt::Display for UnlistenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpdateStmt {}
 impl pg_sys::PgNode for UpdateStmt {}
 impl std::fmt::Display for UpdateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpperUniquePath {}
 impl pg_sys::PgNode for UpperUniquePath {}
 impl std::fmt::Display for UpperUniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumRelation {}
 impl pg_sys::PgNode for VacuumRelation {}
 impl std::fmt::Display for VacuumRelation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumStmt {}
 impl pg_sys::PgNode for VacuumStmt {}
 impl std::fmt::Display for VacuumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Value {}
 impl pg_sys::PgNode for Value {}
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScan {}
 impl pg_sys::PgNode for ValuesScan {}
 impl std::fmt::Display for ValuesScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScanState {}
 impl pg_sys::PgNode for ValuesScanState {}
 impl std::fmt::Display for ValuesScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Var {}
 impl pg_sys::PgNode for Var {}
 impl std::fmt::Display for Var {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableSetStmt {}
 impl pg_sys::PgNode for VariableSetStmt {}
 impl std::fmt::Display for VariableSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableShowStmt {}
 impl pg_sys::PgNode for VariableShowStmt {}
 impl std::fmt::Display for VariableShowStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ViewStmt {}
 impl pg_sys::PgNode for ViewStmt {}
 impl std::fmt::Display for ViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAgg {}
 impl pg_sys::PgNode for WindowAgg {}
 impl std::fmt::Display for WindowAgg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggPath {}
 impl pg_sys::PgNode for WindowAggPath {}
 impl std::fmt::Display for WindowAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggState {}
 impl pg_sys::PgNode for WindowAggState {}
 impl std::fmt::Display for WindowAggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowClause {}
 impl pg_sys::PgNode for WindowClause {}
 impl std::fmt::Display for WindowClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowDef {}
 impl pg_sys::PgNode for WindowDef {}
 impl std::fmt::Display for WindowDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFunc {}
 impl pg_sys::PgNode for WindowFunc {}
 impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFuncExprState {}
 impl pg_sys::PgNode for WindowFuncExprState {}
 impl std::fmt::Display for WindowFuncExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithCheckOption {}
 impl pg_sys::PgNode for WithCheckOption {}
 impl std::fmt::Display for WithCheckOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithClause {}
 impl pg_sys::PgNode for WithClause {}
 impl std::fmt::Display for WithClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScan {}
 impl pg_sys::PgNode for WorkTableScan {}
 impl std::fmt::Display for WorkTableScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScanState {}
 impl pg_sys::PgNode for WorkTableScanState {}
 impl std::fmt::Display for WorkTableScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlExpr {}
 impl pg_sys::PgNode for XmlExpr {}
 impl std::fmt::Display for XmlExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlSerialize {}
 impl pg_sys::PgNode for XmlSerialize {}
 impl std::fmt::Display for XmlSerialize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -167,26 +167,25 @@ pub const BLCKSZ: u32 = 8192;
 pub const DEF_PGPORT: u32 = 28812;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28812\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_CBRT: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
-pub const HAVE_COPYFILE: u32 = 1;
-pub const HAVE_COPYFILE_H: u32 = 1;
 pub const HAVE_CRYPT: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_CRYPT_H: u32 = 1;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -196,11 +195,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -210,7 +209,6 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTPTR_T: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
 pub const HAVE_ISINF: u32 = 1;
@@ -221,7 +219,6 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
 pub const HAVE_LONG_LONG_INT: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMMOVE: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
@@ -229,9 +226,11 @@ pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
+pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
@@ -242,6 +241,7 @@ pub const HAVE_RINT: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETENV: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
@@ -250,11 +250,10 @@ pub const HAVE_SRANDOM: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
+pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -262,29 +261,27 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
+pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TM_ZONE: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
 pub const HAVE_TZNAME: u32 = 1;
 pub const HAVE_UINTPTR_T: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNIX_SOCKETS: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
@@ -294,8 +291,8 @@ pub const HAVE_UTIME: u32 = 1;
 pub const HAVE_UTIMES: u32 = 1;
 pub const HAVE_UTIME_H: u32 = 1;
 pub const HAVE_WCHAR_H: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
+pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP16: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP32: u32 = 1;
@@ -308,22 +305,23 @@ pub const HAVE__BUILTIN_OP_OVERFLOW: u32 = 1;
 pub const HAVE__BUILTIN_POPCOUNT: u32 = 1;
 pub const HAVE__BUILTIN_TYPES_COMPATIBLE_P: u32 = 1;
 pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
+pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &[u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 12.12\0";
+pub const PACKAGE_STRING: &[u8; 17usize] = b"PostgreSQL 12.13\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1usize] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6usize] = b"12.12\0";
+pub const PACKAGE_VERSION: &[u8; 6usize] = b"12.13\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"12\0";
-pub const PG_VERSION: &[u8; 6usize] = b"12.12\0";
-pub const PG_VERSION_NUM: u32 = 120012;
-pub const PG_VERSION_STR : & [u8 ; 113usize] = b"PostgreSQL 12.12 on arm-apple-darwin22.1.0, compiled by Apple clang version 14.0.0 (clang-1400.0.29.202), 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6usize] = b"12.13\0";
+pub const PG_VERSION_NUM: u32 = 120013;
+pub const PG_VERSION_STR: &[u8; 78usize] =
+    b"PostgreSQL 12.13 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -331,15 +329,13 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
-pub const USE_ARMV8_CRC32C: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
+pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -354,566 +350,214 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &[u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &[u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_13_0: u32 = 130000;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 130000;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 36;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
+pub const P_tmpdir: &[u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -924,7 +568,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -948,92 +592,151 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const USE_STDBOOL: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4usize] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4usize] = b"%lu\0";
@@ -1059,376 +762,366 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &[u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &[u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &[u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_PRIMARY_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const SO_RESOLVER_SIGNATURE: u32 = 4401;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MCTP: u32 = 45;
+pub const PF_MAX: u32 = 46;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MCTP: u32 = 45;
+pub const AF_MAX: u32 = 46;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_NETNS_COOKIE: u32 = 71;
+pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_RECVERR_RFC4884: u32 = 26;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_RECVERR_RFC4884: u32 = 31;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1440,285 +1133,68 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &[u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_ULA_USETEMPADDR: u32 = 51;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &[u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &[u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &[u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &[u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &[u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &[u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &[u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &[u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &[u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &[u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &[u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &[u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &[u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &[u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &[u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &[u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &[u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 12.12\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29usize] = b"postgres (PostgreSQL) 12.13\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1732,13 +1208,9 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 48;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
+pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1823,162 +1295,136 @@ pub const MaxTransactionIdAttributeNumber: i32 = -4;
 pub const MaxCommandIdAttributeNumber: i32 = -5;
 pub const TableOidAttributeNumber: i32 = -6;
 pub const FirstLowInvalidHeapAttributeNumber: i32 = -7;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const O_EXEC: u32 = 1073741824;
-pub const O_SEARCH: u32 = 1074790400;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const AT_SYMLINK_NOFOLLOW_ANY: u32 = 2048;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const O_DP_AUTHENTICATE: u32 = 4;
-pub const AUTH_OPEN_NOAUTHFD: i32 = -1;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const F_SETLEASE: u32 = 106;
-pub const F_GETLEASE: u32 = 107;
-pub const F_TRANSFEREXTENTS: u32 = 110;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_ALLOCATEPERSIST: u32 = 8;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstBootstrapObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -2042,7 +1488,24 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const PARAM_FLAG_CONST: u32 = 1;
 pub const BTLessStrategyNumber: u32 = 1;
 pub const BTLessEqualStrategyNumber: u32 = 2;
@@ -2101,25 +1564,66 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
+pub const _POSIX_ARG_MAX: u32 = 4096;
+pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
+pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
+pub const _POSIX_MAX_CANON: u32 = 255;
+pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_NAME_MAX: u32 = 14;
+pub const _POSIX_NGROUPS_MAX: u32 = 8;
+pub const _POSIX_OPEN_MAX: u32 = 20;
+pub const _POSIX_PATH_MAX: u32 = 256;
+pub const _POSIX_PIPE_BUF: u32 = 512;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
+pub const _POSIX_RTSIG_MAX: u32 = 8;
+pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
+pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
+pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
+pub const _POSIX_SYMLINK_MAX: u32 = 255;
+pub const _POSIX_SYMLOOP_MAX: u32 = 8;
+pub const _POSIX_TIMER_MAX: u32 = 32;
+pub const _POSIX_TTY_NAME_MAX: u32 = 9;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const DSM_IMPL_POSIX: u32 = 1;
@@ -2163,121 +1667,27 @@ pub const INDEX_SIZE_MASK: u32 = 8191;
 pub const INDEX_AM_RESERVED_BIT: u32 = 8192;
 pub const INDEX_VAR_MASK: u32 = 16384;
 pub const INDEX_NULL_MASK: u32 = 32768;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
-pub const _POSIX_ARG_MAX: u32 = 4096;
-pub const _POSIX_CHILD_MAX: u32 = 25;
-pub const _POSIX_LINK_MAX: u32 = 8;
-pub const _POSIX_MAX_CANON: u32 = 255;
-pub const _POSIX_MAX_INPUT: u32 = 255;
-pub const _POSIX_NAME_MAX: u32 = 14;
-pub const _POSIX_NGROUPS_MAX: u32 = 8;
-pub const _POSIX_OPEN_MAX: u32 = 20;
-pub const _POSIX_PATH_MAX: u32 = 256;
-pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
 pub const _POSIX2_BC_BASE_MAX: u32 = 99;
 pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
 pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
 pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
+pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
 pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
 pub const _POSIX2_LINE_MAX: u32 = 2048;
 pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
-pub const _POSIX_RTSIG_MAX: u32 = 8;
-pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
-pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
-pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
-pub const _POSIX_SYMLINK_MAX: u32 = 255;
-pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
-pub const _POSIX_TTY_NAME_MAX: u32 = 9;
 pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
-pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const SIZEOF_DSA_POINTER: u32 = 8;
 pub const DSA_POINTER_FORMAT: &[u8; 7usize] = b"%016lx\0";
 pub const DSA_ALLOC_HUGE: u32 = 1;
@@ -2361,7 +1771,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const REINDEXOPT_REPORT_PROGRESS: u32 = 2;
 pub const MaxAllocHugeSize: u32 = 0;
@@ -2380,6 +1789,85 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2398,13 +1886,7 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2591,7 +2073,6 @@ pub const F_HAS_GARBAGE: u32 = 16;
 pub const GIST_PAGE_ID: u32 = 65409;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const EA_MAGIC: u32 = 689375833;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3794,22 +3275,95 @@ pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
@@ -3820,45 +3374,13 @@ impl Default for __mbstate_t {
         }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
 }
-impl Default for __darwin_pthread_handler_rec {
+impl Default for _G_fpos_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3867,13 +3389,14 @@ impl Default for __darwin_pthread_handler_rec {
         }
     }
 }
+pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
 }
-impl Default for _opaque_pthread_attr_t {
+impl Default for _G_fpos64_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3882,241 +3405,59 @@ impl Default for _opaque_pthread_attr_t {
         }
     }
 }
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[track_caller]
-pub unsafe fn renameat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameat(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn renamex_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renamex_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renamex_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn renameatx_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameatx_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameatx_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -4125,327 +3466,24 @@ impl Default for __sFILE {
         }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
-}
-extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stdout: *mut FILE;
+}
+extern "C" {
+    pub static mut stderr: *mut FILE;
 }
 #[track_caller]
-pub unsafe fn clearerr(arg_arg1: *mut FILE) {
+pub unsafe fn remove(arg___filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn clearerr(arg1: *mut FILE);
+            pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        clearerr(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn feof(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        feof(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ferror(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        ferror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fflush(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fflush(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fgetc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetpos(arg_arg1: *mut FILE, arg_arg2: *mut fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-        }
-        fgetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fgets(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut FILE,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgets(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut FILE,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fgets(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fopen(
-    arg___filename: *const ::std::os::raw::c_char,
-    arg___mode: *const ::std::os::raw::c_char,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fopen(
-                __filename: *const ::std::os::raw::c_char,
-                __mode: *const ::std::os::raw::c_char,
-            ) -> *mut FILE;
-        }
-        fopen(arg___filename, arg___mode)
-    })
-}
-#[track_caller]
-pub unsafe fn fprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fputc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputs(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputs(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut FILE,
-            ) -> ::std::os::raw::c_int;
-        }
-        fputs(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fread(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fread(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fread(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn freopen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut FILE,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freopen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut FILE,
-            ) -> *mut FILE;
-        }
-        freopen(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fscanf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fseek(
-    arg_arg1: *mut FILE,
-    arg_arg2: ::std::os::raw::c_long,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fseek(
-                arg1: *mut FILE,
-                arg2: ::std::os::raw::c_long,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        fseek(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fsetpos(arg_arg1: *mut FILE, arg_arg2: *const fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-        }
-        fsetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn ftell(arg_arg1: *mut FILE) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-        }
-        ftell(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fwrite(
-    arg___ptr: *const ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fwrite(
-                __ptr: *const ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fwrite(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn getc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        getc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getchar() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getchar() -> ::std::os::raw::c_int;
-        }
-        getchar()
-    })
-}
-#[track_caller]
-pub unsafe fn perror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn perror(arg1: *const ::std::os::raw::c_char);
-        }
-        perror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn printf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        printf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn putc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        putc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn putchar(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        putchar(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn puts(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        puts(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn remove(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        remove(arg_arg1)
+        remove(arg___filename)
     })
 }
 #[track_caller]
@@ -4464,81 +3502,31 @@ pub unsafe fn rename(
     })
 }
 #[track_caller]
-pub unsafe fn rewind(arg_arg1: *mut FILE) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rewind(arg1: *mut FILE);
-        }
-        rewind(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn scanf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        scanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuf(arg_arg1: *mut FILE, arg_arg2: *mut ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-        }
-        setbuf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setvbuf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
+pub unsafe fn renameat(
+    arg___oldfd: ::std::os::raw::c_int,
+    arg___old: *const ::std::os::raw::c_char,
+    arg___newfd: ::std::os::raw::c_int,
+    arg___new: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setvbuf(
-                arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
+            pub fn renameat(
+                __oldfd: ::std::os::raw::c_int,
+                __old: *const ::std::os::raw::c_char,
+                __newfd: ::std::os::raw::c_int,
+                __new: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        setvbuf(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        renameat(arg___oldfd, arg___old, arg___newfd, arg___new)
     })
 }
 #[track_caller]
-pub unsafe fn sprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        sprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sscanf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sscanf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        sscanf(arg_arg1, arg_arg2)
+        fclose(arg___stream)
     })
 }
 #[track_caller]
@@ -4551,195 +3539,540 @@ pub unsafe fn tmpfile() -> *mut FILE {
     })
 }
 #[track_caller]
-pub unsafe fn ungetc(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ungetc(arg_arg1, arg_arg2)
+        fflush(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vfprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vfprintf(arg_arg1, arg_arg2, arg_arg3)
+        fflush_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vprintf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vprintf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+            ) -> *mut FILE;
         }
-        vprintf(arg_arg1, arg_arg2)
+        fopen(arg___filename, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn vsprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn freopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn freopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> *mut FILE;
         }
-        vsprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ctermid(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        ctermid(arg_arg1)
+        freopen(arg___filename, arg___modes, arg___stream)
     })
 }
 #[track_caller]
 pub unsafe fn fdopen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
+    arg___fd: ::std::os::raw::c_int,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fdopen(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
+                __fd: ::std::os::raw::c_int,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fdopen(arg_arg1, arg_arg2)
+        fdopen(arg___fd, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn fileno(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fileno(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn pclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        pclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn popen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
+pub unsafe fn fmemopen(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___len: usize,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn popen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
+            pub fn fmemopen(
+                __s: *mut ::std::os::raw::c_void,
+                __len: usize,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        popen(arg_arg1, arg_arg2)
+        fmemopen(arg___s, arg___len, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn __srget(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn open_memstream(
+    arg___bufloc: *mut *mut ::std::os::raw::c_char,
+    arg___sizeloc: *mut usize,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn open_memstream(
+                __bufloc: *mut *mut ::std::os::raw::c_char,
+                __sizeloc: *mut usize,
+            ) -> *mut FILE;
         }
-        __srget(arg_arg1)
+        open_memstream(arg___bufloc, arg___sizeloc)
     })
 }
 #[track_caller]
-pub unsafe fn __svfscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
+pub unsafe fn setbuf(arg___stream: *mut FILE, arg___buf: *mut ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+        }
+        setbuf(arg___stream, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setvbuf(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___modes: ::std::os::raw::c_int,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __svfscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
+            pub fn setvbuf(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __modes: ::std::os::raw::c_int,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        __svfscanf(arg_arg1, arg_arg2, arg_arg3)
+        setvbuf(arg___stream, arg___buf, arg___modes, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn __swbuf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+pub unsafe fn setbuffer(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___size: usize,
+) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuffer(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __size: usize,
+            );
+        }
+        setbuffer(arg___stream, arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn setlinebuf(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlinebuf(__stream: *mut FILE);
+        }
+        setlinebuf(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fprintf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fprintf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        __swbuf(arg_arg1, arg_arg2)
+        fprintf(arg___stream, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn flockfile(arg_arg1: *mut FILE) {
+pub unsafe fn printf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flockfile(arg1: *mut FILE);
+            pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
         }
-        flockfile(arg_arg1)
+        printf(arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn ftrylockfile(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn sprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn sprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        ftrylockfile(arg_arg1)
+        sprintf(arg___s, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn funlockfile(arg_arg1: *mut FILE) {
+pub unsafe fn vfprintf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn funlockfile(arg1: *mut FILE);
+            pub fn vfprintf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        funlockfile(arg_arg1)
+        vfprintf(arg___s, arg___format, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn getc_unlocked(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn vprintf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn vprintf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        getc_unlocked(arg_arg1)
+        vprintf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsprintf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn snprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn snprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        snprintf(arg___s, arg___maxlen, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vsnprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsnprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsnprintf(arg___s, arg___maxlen, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vdprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vdprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vdprintf(arg___fd, arg___fmt, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn dprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        dprintf(arg___fd, arg___fmt)
+    })
+}
+#[track_caller]
+pub unsafe fn fscanf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fscanf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf(arg___s, arg___format)
+    })
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[track_caller]
+pub unsafe fn fscanf1(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_fscanf"]
+            pub fn fscanf1(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf1(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf1(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_scanf"]
+            pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf1(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_sscanf"]
+            pub fn sscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf1(arg___s, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vfscanf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vscanf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf1(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vfscanf"]
+            pub fn vfscanf1(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf1(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vscanf"]
+            pub fn vscanf1(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf1(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vsscanf"]
+            pub fn vsscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getchar() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getchar() -> ::std::os::raw::c_int;
+        }
+        getchar()
+    })
+}
+#[track_caller]
+pub unsafe fn getc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc_unlocked(arg___stream)
     })
 }
 #[track_caller]
@@ -4752,1508 +4085,537 @@ pub unsafe fn getchar_unlocked() -> ::std::os::raw::c_int {
     })
 }
 #[track_caller]
+pub unsafe fn fgetc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fputc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putchar(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        putchar(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc_unlocked(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc_unlocked(
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputc_unlocked(arg___c, arg___stream)
+    })
+}
+#[track_caller]
 pub unsafe fn putc_unlocked(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn putc_unlocked(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut FILE,
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
             ) -> ::std::os::raw::c_int;
         }
-        putc_unlocked(arg_arg1, arg_arg2)
+        putc_unlocked(arg___c, arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putchar_unlocked(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn putchar_unlocked(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        putchar_unlocked(arg_arg1)
+        putchar_unlocked(arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn getw(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn getw(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getw(arg_arg1)
+        getw(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putw(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn putw(
+    arg___w: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        putw(arg_arg1, arg_arg2)
+        putw(arg___w, arg___stream)
     })
 }
-pub type off_t = __darwin_off_t;
+#[track_caller]
+pub unsafe fn fgets(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgets(
+                __s: *mut ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fgets(arg___s, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn __getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        __getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getline(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getline(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getline(arg___lineptr, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputs(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputs(
+                __s: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputs(arg___s, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn puts(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        puts(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn ungetc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+                -> ::std::os::raw::c_int;
+        }
+        ungetc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fread(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fread(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___s: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __s: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fwrite(arg___ptr, arg___size, arg___n, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn fread_unlocked(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread_unlocked(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fread_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite_unlocked(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite_unlocked(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fwrite_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fseek(
+    arg___stream: *mut FILE,
+    arg___off: ::std::os::raw::c_long,
+    arg___whence: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fseek(
+                __stream: *mut FILE,
+                __off: ::std::os::raw::c_long,
+                __whence: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        fseek(arg___stream, arg___off, arg___whence)
+    })
+}
+#[track_caller]
+pub unsafe fn ftell(arg___stream: *mut FILE) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+        }
+        ftell(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn rewind(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rewind(__stream: *mut FILE);
+        }
+        rewind(arg___stream)
+    })
+}
 #[track_caller]
 pub unsafe fn fseeko(
     arg___stream: *mut FILE,
-    arg___offset: off_t,
+    arg___off: __off_t,
     arg___whence: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fseeko(
                 __stream: *mut FILE,
-                __offset: off_t,
+                __off: __off_t,
                 __whence: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        fseeko(arg___stream, arg___offset, arg___whence)
+        fseeko(arg___stream, arg___off, arg___whence)
     })
 }
 #[track_caller]
-pub unsafe fn ftello(arg___stream: *mut FILE) -> off_t {
+pub unsafe fn ftello(arg___stream: *mut FILE) -> __off_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftello(__stream: *mut FILE) -> off_t;
+            pub fn ftello(__stream: *mut FILE) -> __off_t;
         }
         ftello(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn snprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fgetpos(arg___stream: *mut FILE, arg___pos: *mut fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn snprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
         }
-        snprintf(arg___str, arg___size, arg___format)
+        fgetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vfscanf(
-    arg___stream: *mut FILE,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fsetpos(arg___stream: *mut FILE, arg___pos: *const fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfscanf(
-                __stream: *mut FILE,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
         }
-        vfscanf(arg___stream, arg___format, arg_arg1)
+        fsetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vscanf(
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vscanf(
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr(__stream: *mut FILE);
         }
-        vscanf(arg___format, arg_arg1)
+        clearerr(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsnprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsnprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsnprintf(arg___str, arg___size, arg___format, arg_arg1)
+        feof(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsscanf(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ferror(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsscanf(
-                __str: *const ::std::os::raw::c_char,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsscanf(arg___str, arg___format, arg_arg1)
+        ferror(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn dprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr_unlocked(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn dprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr_unlocked(__stream: *mut FILE);
         }
-        dprintf(arg_arg1, arg_arg2)
+        clearerr_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vdprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vdprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vdprintf(arg_arg1, arg_arg2, arg_arg3)
+        feof_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getdelim(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___delimiter: ::std::os::raw::c_int,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn ferror_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdelim(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __delimiter: ::std::os::raw::c_int,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getdelim(arg___linep, arg___linecapp, arg___delimiter, arg___stream)
+        ferror_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getline(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn perror(arg___s: *const ::std::os::raw::c_char) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getline(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn perror(__s: *const ::std::os::raw::c_char);
         }
-        getline(arg___linep, arg___linecapp, arg___stream)
+        perror(arg___s)
     })
 }
 #[track_caller]
-pub unsafe fn fmemopen(
-    arg___buf: *mut ::std::os::raw::c_void,
-    arg___size: usize,
-    arg___mode: *const ::std::os::raw::c_char,
+pub unsafe fn fileno(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fileno_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn pclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        pclose(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn popen(
+    arg___command: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmemopen(
-                __buf: *mut ::std::os::raw::c_void,
-                __size: usize,
-                __mode: *const ::std::os::raw::c_char,
+            pub fn popen(
+                __command: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fmemopen(arg___buf, arg___size, arg___mode)
+        popen(arg___command, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn open_memstream(
-    arg___bufp: *mut *mut ::std::os::raw::c_char,
-    arg___sizep: *mut usize,
-) -> *mut FILE {
+pub unsafe fn ctermid(arg___s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn open_memstream(
-                __bufp: *mut *mut ::std::os::raw::c_char,
-                __sizep: *mut usize,
-            ) -> *mut FILE;
+            pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
         }
-        open_memstream(arg___bufp, arg___sizep)
+        ctermid(arg___s)
     })
 }
-extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
-}
 #[track_caller]
-pub unsafe fn asprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn flockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn flockfile(__stream: *mut FILE);
         }
-        asprintf(arg_arg1, arg_arg2)
+        flockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn ctermid_r(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ftrylockfile(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ctermid_r(arg_arg1)
+        ftrylockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fgetln(arg_arg1: *mut FILE, arg_arg2: *mut usize) -> *mut ::std::os::raw::c_char {
+pub unsafe fn funlockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+            pub fn funlockfile(__stream: *mut FILE);
         }
-        fgetln(arg_arg1, arg_arg2)
+        funlockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fmtcheck(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *const ::std::os::raw::c_char {
+pub unsafe fn __uflow(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmtcheck(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *const ::std::os::raw::c_char;
+            pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
         }
-        fmtcheck(arg_arg1, arg_arg2)
+        __uflow(arg_arg1)
     })
 }
 #[track_caller]
-pub unsafe fn fpurge(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fpurge(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuffer(
+pub unsafe fn __overflow(
     arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) {
+    arg_arg2: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setbuffer(
+            pub fn __overflow(
                 arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            );
-        }
-        setbuffer(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setlinebuf(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        setlinebuf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn vasprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn vasprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        vasprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn funopen(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg3: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg4: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    arg_arg5: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn funopen(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *mut ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg3: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg4: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: fpos_t,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> fpos_t,
-                >,
-                arg5: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> *mut FILE;
-        }
-        funopen(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __sprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __sprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __snprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __snprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __snprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsnprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-    arg_arg6: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsnprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                arg6: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsnprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
-}
-impl Default for __darwin_arm_vfp_state {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
-        }
-        signal(arg_arg1, arg_arg2)
-    })
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_reserved: [u64; 14usize],
-}
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[track_caller]
-pub unsafe fn getpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-        }
-        getpriority(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getiopolicy_np(
-                arg1: ::std::os::raw::c_int,
                 arg2: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getiopolicy_np(arg_arg1, arg_arg2)
+        __overflow(arg_arg1, arg_arg2)
     })
 }
-#[track_caller]
-pub unsafe fn getrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getrusage(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rusage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrusage(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rusage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrusage(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpriority(
-                arg1: ::std::os::raw::c_int,
-                arg2: id_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setpriority(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setiopolicy_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setiopolicy_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        setrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn wait(arg_arg1: *mut ::std::os::raw::c_int) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-        }
-        wait(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn waitpid(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitpid(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> pid_t;
-        }
-        waitpid(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn waitid(
-    arg_arg1: idtype_t,
-    arg_arg2: id_t,
-    arg_arg3: *mut siginfo_t,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitid(
-                arg1: idtype_t,
-                arg2: id_t,
-                arg3: *mut siginfo_t,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        waitid(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn wait3(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait3(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut rusage,
-            ) -> pid_t;
-        }
-        wait3(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn wait4(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait4(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut rusage,
-            ) -> pid_t;
-        }
-        wait4(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn alloca(arg_arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-        }
-        alloca(arg_arg1)
-    })
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6272,8 +4634,1000 @@ pub struct lldiv_t {
     pub quot: ::std::os::raw::c_longlong,
     pub rem: ::std::os::raw::c_longlong,
 }
-extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+#[track_caller]
+pub unsafe fn __ctype_get_mb_cur_max() -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ctype_get_mb_cur_max() -> usize;
+        }
+        __ctype_get_mb_cur_max()
+    })
+}
+#[track_caller]
+pub unsafe fn atof(arg___nptr: *const ::std::os::raw::c_char) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+        }
+        atof(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoi(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        atoi(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atol(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        atol(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoll(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+        }
+        atoll(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtod(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtod(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f64;
+        }
+        strtod(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtof(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtof(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f32;
+        }
+        strtof(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtold(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtold(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> u128;
+        }
+        strtold(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtol(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtol(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_long;
+        }
+        strtol(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoul(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoul(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strtoul(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtouq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtouq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtouq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoll(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoll(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoll(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoull(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoull(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtoull(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn l64a(arg___n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+        }
+        l64a(arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn a64l(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        a64l(arg___s)
+    })
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[track_caller]
+pub unsafe fn select(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *mut timeval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn select(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *mut timeval,
+            ) -> ::std::os::raw::c_int;
+        }
+        select(arg___nfds, arg___readfds, arg___writefds, arg___exceptfds, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn pselect(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *const timespec,
+    arg___sigmask: *const __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pselect(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *const timespec,
+                __sigmask: *const __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pselect(
+            arg___nfds,
+            arg___readfds,
+            arg___writefds,
+            arg___exceptfds,
+            arg___timeout,
+            arg___sigmask,
+        )
+    })
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __atomic_wide_counter {
+    pub __value64: ::std::os::raw::c_ulonglong,
+    pub __value32: __atomic_wide_counter__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __atomic_wide_counter__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __atomic_wide_counter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __wseq: __atomic_wide_counter,
+    pub __g1_start: __atomic_wide_counter,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random() -> ::std::os::raw::c_long;
+        }
+        random()
+    })
+}
+#[track_caller]
+pub unsafe fn srandom(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom(__seed: ::std::os::raw::c_uint);
+        }
+        srandom(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        initstate(arg___seed, arg___statebuf, arg___statelen)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate(arg___statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate(__statebuf: *mut ::std::os::raw::c_char)
+                -> *mut ::std::os::raw::c_char;
+        }
+        setstate(arg___statebuf)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random_r(
+    arg___buf: *mut random_data,
+    arg___result: *mut i32,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+        }
+        random_r(arg___buf, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srandom_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom_r(
+                __seed: ::std::os::raw::c_uint,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srandom_r(arg___seed, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate_r(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        initstate_r(arg___seed, arg___statebuf, arg___statelen, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate_r(
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate_r(
+                __statebuf: *mut ::std::os::raw::c_char,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        setstate_r(arg___statebuf, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn rand() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand() -> ::std::os::raw::c_int;
+        }
+        rand()
+    })
+}
+#[track_caller]
+pub unsafe fn srand(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand(__seed: ::std::os::raw::c_uint);
+        }
+        srand(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn rand_r(arg___seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+        }
+        rand_r(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn drand48() -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48() -> f64;
+        }
+        drand48()
+    })
+}
+#[track_caller]
+pub unsafe fn erand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+        }
+        erand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48() -> ::std::os::raw::c_long;
+        }
+        lrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        nrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48() -> ::std::os::raw::c_long;
+        }
+        mrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        jrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48(arg___seedval: ::std::os::raw::c_long) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48(__seedval: ::std::os::raw::c_long);
+        }
+        srand48(arg___seedval)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+) -> *mut ::std::os::raw::c_ushort {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+            ) -> *mut ::std::os::raw::c_ushort;
+        }
+        seed48(arg___seed16v)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48(arg___param: *mut ::std::os::raw::c_ushort) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+        }
+        lcong48(arg___param)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[track_caller]
+pub unsafe fn drand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        drand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn erand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        erand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        lrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        nrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        mrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        jrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48_r(
+    arg___seedval: ::std::os::raw::c_long,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48_r(
+                __seedval: ::std::os::raw::c_long,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srand48_r(arg___seedval, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48_r(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48_r(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        seed48_r(arg___seed16v, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48_r(
+    arg___param: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48_r(
+                __param: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        lcong48_r(arg___param, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random() -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random() -> __uint32_t;
+        }
+        arc4random()
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___size: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+        }
+        arc4random_buf(arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_uniform(arg___upper_bound: __uint32_t) -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+        }
+        arc4random_uniform(arg___upper_bound)
+    })
 }
 #[track_caller]
 pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
@@ -6286,26 +5640,17 @@ pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw
 }
 #[track_caller]
 pub unsafe fn calloc(
-    arg___count: ::std::os::raw::c_ulong,
+    arg___nmemb: ::std::os::raw::c_ulong,
     arg___size: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn calloc(
-                __count: ::std::os::raw::c_ulong,
+                __nmemb: ::std::os::raw::c_ulong,
                 __size: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        calloc(arg___count, arg___size)
-    })
-}
-#[track_caller]
-pub unsafe fn free(arg_arg1: *mut ::std::os::raw::c_void) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn free(arg1: *mut ::std::os::raw::c_void);
-        }
-        free(arg_arg1)
+        calloc(arg___nmemb, arg___size)
     })
 }
 #[track_caller]
@@ -6324,27 +5669,47 @@ pub unsafe fn realloc(
     })
 }
 #[track_caller]
-pub unsafe fn valloc(arg_arg1: usize) -> *mut ::std::os::raw::c_void {
+pub unsafe fn free(arg___ptr: *mut ::std::os::raw::c_void) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+            pub fn free(__ptr: *mut ::std::os::raw::c_void);
         }
-        valloc(arg_arg1)
+        free(arg___ptr)
     })
 }
 #[track_caller]
-pub unsafe fn aligned_alloc(
-    arg___alignment: ::std::os::raw::c_ulong,
-    arg___size: ::std::os::raw::c_ulong,
+pub unsafe fn reallocarray(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn aligned_alloc(
-                __alignment: ::std::os::raw::c_ulong,
-                __size: ::std::os::raw::c_ulong,
+            pub fn reallocarray(
+                __ptr: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
             ) -> *mut ::std::os::raw::c_void;
         }
-        aligned_alloc(arg___alignment, arg___size)
+        reallocarray(arg___ptr, arg___nmemb, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn alloca(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+        }
+        alloca(arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn valloc(arg___size: usize) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+        }
+        valloc(arg___size)
     })
 }
 #[track_caller]
@@ -6365,6 +5730,21 @@ pub unsafe fn posix_memalign(
     })
 }
 #[track_caller]
+pub unsafe fn aligned_alloc(
+    arg___alignment: ::std::os::raw::c_ulong,
+    arg___size: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn aligned_alloc(
+                __alignment: ::std::os::raw::c_ulong,
+                __size: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        aligned_alloc(arg___alignment, arg___size)
+    })
+}
+#[track_caller]
 pub unsafe fn abort() {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -6374,161 +5754,500 @@ pub unsafe fn abort() {
     })
 }
 #[track_caller]
-pub unsafe fn abs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        abs(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn atexit(
-    arg_arg1: ::std::option::Option<unsafe extern "C" fn()>,
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn atexit(
-                arg1: ::std::option::Option<unsafe extern "C" fn()>,
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
             ) -> ::std::os::raw::c_int;
         }
-        atexit(arg_arg1)
+        atexit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atof(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
+pub unsafe fn at_quick_exit(
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+            pub fn at_quick_exit(
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
+            ) -> ::std::os::raw::c_int;
         }
-        atof(arg_arg1)
+        at_quick_exit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atoi(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+pub unsafe fn on_exit(
+    arg___func: ::std::option::Option<
+        unsafe extern "C" fn(__status: ::std::os::raw::c_int, __arg: *mut ::std::os::raw::c_void),
+    >,
+    arg___arg: *mut ::std::os::raw::c_void,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+            pub fn on_exit(
+                __func: ::std::option::Option<
+                    unsafe extern "C" fn(
+                        __status: ::std::os::raw::c_int,
+                        __arg: *mut ::std::os::raw::c_void,
+                    ),
+                >,
+                __arg: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int;
         }
-        atoi(arg_arg1)
+        on_exit(arg___func, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn atol(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn exit(__status: ::std::os::raw::c_int);
         }
-        atol(arg_arg1)
+        exit(arg___status)
     })
 }
 #[track_caller]
-pub unsafe fn atoll(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+pub unsafe fn quick_exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+            pub fn quick_exit(__status: ::std::os::raw::c_int);
         }
-        atoll(arg_arg1)
+        quick_exit(arg___status)
     })
 }
+#[track_caller]
+pub unsafe fn _Exit(arg___status: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _Exit(__status: ::std::os::raw::c_int);
+        }
+        _Exit(arg___status)
+    })
+}
+#[track_caller]
+pub unsafe fn getenv(arg___name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        getenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn putenv(arg___string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        putenv(arg___string)
+    })
+}
+#[track_caller]
+pub unsafe fn setenv(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___value: *const ::std::os::raw::c_char,
+    arg___replace: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setenv(
+                __name: *const ::std::os::raw::c_char,
+                __value: *const ::std::os::raw::c_char,
+                __replace: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        setenv(arg___name, arg___value, arg___replace)
+    })
+}
+#[track_caller]
+pub unsafe fn unsetenv(arg___name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        unsetenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn clearenv() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clearenv() -> ::std::os::raw::c_int;
+        }
+        clearenv()
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemp(arg___template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        mkstemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemps(
+    arg___template: *mut ::std::os::raw::c_char,
+    arg___suffixlen: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemps(
+                __template: *mut ::std::os::raw::c_char,
+                __suffixlen: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        mkstemps(arg___template, arg___suffixlen)
+    })
+}
+#[track_caller]
+pub unsafe fn mkdtemp(arg___template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        mkdtemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn system(arg___command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        system(arg___command)
+    })
+}
+#[track_caller]
+pub unsafe fn realpath(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resolved: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn realpath(
+                __name: *const ::std::os::raw::c_char,
+                __resolved: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        realpath(arg___name, arg___resolved)
+    })
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[track_caller]
 pub unsafe fn bsearch(
     arg___key: *const ::std::os::raw::c_void,
     arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bsearch(
                 __key: *const ::std::os::raw::c_void,
                 __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
             ) -> *mut ::std::os::raw::c_void;
         }
-        bsearch(arg___key, arg___base, arg___nel, arg___width, arg___compar)
+        bsearch(arg___key, arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn div(arg_arg1: ::std::os::raw::c_int, arg_arg2: ::std::os::raw::c_int) -> div_t {
+pub unsafe fn qsort(
+    arg___base: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+            pub fn qsort(
+                __base: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
+            );
         }
-        div(arg_arg1, arg_arg2)
+        qsort(arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn abs(arg___x: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exit(arg1: ::std::os::raw::c_int);
+            pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        exit(arg_arg1)
+        abs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn getenv(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn labs(arg___x: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
         }
-        getenv(arg_arg1)
+        labs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn labs(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
+pub unsafe fn llabs(arg___x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+            pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
         }
-        labs(arg_arg1)
+        llabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ldiv(arg_arg1: ::std::os::raw::c_long, arg_arg2: ::std::os::raw::c_long) -> ldiv_t {
+pub unsafe fn div(arg___numer: ::std::os::raw::c_int, arg___denom: ::std::os::raw::c_int) -> div_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+            pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
         }
-        ldiv(arg_arg1, arg_arg2)
+        div(arg___numer, arg___denom)
     })
 }
 #[track_caller]
-pub unsafe fn llabs(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
+pub unsafe fn ldiv(
+    arg___numer: ::std::os::raw::c_long,
+    arg___denom: ::std::os::raw::c_long,
+) -> ldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+            pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long)
+                -> ldiv_t;
         }
-        llabs(arg_arg1)
+        ldiv(arg___numer, arg___denom)
     })
 }
 #[track_caller]
 pub unsafe fn lldiv(
-    arg_arg1: ::std::os::raw::c_longlong,
-    arg_arg2: ::std::os::raw::c_longlong,
+    arg___numer: ::std::os::raw::c_longlong,
+    arg___denom: ::std::os::raw::c_longlong,
 ) -> lldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn lldiv(
-                arg1: ::std::os::raw::c_longlong,
-                arg2: ::std::os::raw::c_longlong,
+                __numer: ::std::os::raw::c_longlong,
+                __denom: ::std::os::raw::c_longlong,
             ) -> lldiv_t;
         }
-        lldiv(arg_arg1, arg_arg2)
+        lldiv(arg___numer, arg___denom)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        ecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn gcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        gcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qfcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qgcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qgcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qgcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        ecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        fcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qfcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
     })
 }
 #[track_caller]
@@ -6544,1295 +6263,180 @@ pub unsafe fn mblen(
     })
 }
 #[track_caller]
-pub unsafe fn mbstowcs(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mbstowcs(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> usize;
-        }
-        mbstowcs(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
 pub unsafe fn mbtowc(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
+    arg___pwc: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn mbtowc(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
+                __pwc: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        mbtowc(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn rand() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand() -> ::std::os::raw::c_int;
-        }
-        rand()
-    })
-}
-#[track_caller]
-pub unsafe fn srand(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand(arg1: ::std::os::raw::c_uint);
-        }
-        srand(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn strtod(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtod(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtof(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtof(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f32;
-        }
-        strtof(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtol(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtol(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_long;
-        }
-        strtol(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtold(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtold(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtold(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoll(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoll(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoll(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoul(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoul(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strtoul(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoull(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoull(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtoull(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn system(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        system(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn wcstombs(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const wchar_t,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wcstombs(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const wchar_t,
-                arg3: usize,
-            ) -> usize;
-        }
-        wcstombs(arg_arg1, arg_arg2, arg_arg3)
+        mbtowc(arg___pwc, arg___s, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn wctomb(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: wchar_t,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___wchar: wchar_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn wctomb(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: wchar_t,
+                __s: *mut ::std::os::raw::c_char,
+                __wchar: wchar_t,
             ) -> ::std::os::raw::c_int;
         }
-        wctomb(arg_arg1, arg_arg2)
+        wctomb(arg___s, arg___wchar)
     })
 }
 #[track_caller]
-pub unsafe fn _Exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn mbstowcs(
+    arg___pwcs: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn _Exit(arg1: ::std::os::raw::c_int);
+            pub fn mbstowcs(
+                __pwcs: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> usize;
         }
-        _Exit(arg_arg1)
+        mbstowcs(arg___pwcs, arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn a64l(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn wcstombs(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___pwcs: *const wchar_t,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn wcstombs(
+                __s: *mut ::std::os::raw::c_char,
+                __pwcs: *const wchar_t,
+                __n: usize,
+            ) -> usize;
         }
-        a64l(arg_arg1)
+        wcstombs(arg___s, arg___pwcs, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn drand48() -> f64 {
+pub unsafe fn rpmatch(arg___response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn drand48() -> f64;
+            pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        drand48()
-    })
-}
-#[track_caller]
-pub unsafe fn ecvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ecvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        ecvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn erand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-        }
-        erand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fcvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        gcvt(arg_arg1, arg_arg2, arg_arg3)
+        rpmatch(arg___response)
     })
 }
 #[track_caller]
 pub unsafe fn getsubopt(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+    arg___optionp: *mut *mut ::std::os::raw::c_char,
+    arg___tokens: *const *mut ::std::os::raw::c_char,
+    arg___valuep: *mut *mut ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn getsubopt(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+                __optionp: *mut *mut ::std::os::raw::c_char,
+                __tokens: *const *mut ::std::os::raw::c_char,
+                __valuep: *mut *mut ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        getsubopt(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn grantpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        grantpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn initstate(
-    arg_arg1: ::std::os::raw::c_uint,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn initstate(
-                arg1: ::std::os::raw::c_uint,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        initstate(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn jrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        jrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn l64a(arg_arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-        }
-        l64a(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lcong48(arg_arg1: *mut ::std::os::raw::c_ushort) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-        }
-        lcong48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrand48() -> ::std::os::raw::c_long;
-        }
-        lrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn mkstemp(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        mkstemp(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mrand48() -> ::std::os::raw::c_long;
-        }
-        mrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn nrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        nrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn posix_openpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        posix_openpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname(arg_arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        ptsname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname_r(
-    arg_fildes: ::std::os::raw::c_int,
-    arg_buffer: *mut ::std::os::raw::c_char,
-    arg_buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname_r(
-                fildes: ::std::os::raw::c_int,
-                buffer: *mut ::std::os::raw::c_char,
-                buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        ptsname_r(arg_fildes, arg_buffer, arg_buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn putenv(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        putenv(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn random() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn random() -> ::std::os::raw::c_long;
-        }
-        random()
-    })
-}
-#[track_caller]
-pub unsafe fn rand_r(arg_arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-        }
-        rand_r(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn realpath(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-            pub fn realpath(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        realpath(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn seed48(arg_arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-        }
-        seed48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setenv(
-    arg___name: *const ::std::os::raw::c_char,
-    arg___value: *const ::std::os::raw::c_char,
-    arg___overwrite: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setenv(
-                __name: *const ::std::os::raw::c_char,
-                __value: *const ::std::os::raw::c_char,
-                __overwrite: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setenv(arg___name, arg___value, arg___overwrite)
-    })
-}
-#[track_caller]
-pub unsafe fn setkey(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setkey(arg1: *const ::std::os::raw::c_char);
-        }
-        setkey(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setstate(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        setstate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srand48(arg_arg1: ::std::os::raw::c_long) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand48(arg1: ::std::os::raw::c_long);
-        }
-        srand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srandom(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandom(arg1: ::std::os::raw::c_uint);
-        }
-        srandom(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unlockpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        unlockpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unsetenv(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        unsetenv(arg_arg1)
-    })
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[track_caller]
-pub unsafe fn arc4random() -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random() -> u32;
-        }
-        arc4random()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_addrandom(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: ::std::os::raw::c_int,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_addrandom(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: ::std::os::raw::c_int,
-            );
-        }
-        arc4random_addrandom(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___nbytes: usize) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-        }
-        arc4random_buf(arg___buf, arg___nbytes)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_stir() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_stir();
-        }
-        arc4random_stir()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_uniform(arg___upper_bound: u32) -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-        }
-        arc4random_uniform(arg___upper_bound)
-    })
-}
-#[track_caller]
-pub unsafe fn atexit_b(arg_arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-        }
-        atexit_b(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn bsearch_b(
-    arg___key: *const ::std::os::raw::c_void,
-    arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bsearch_b(
-                __key: *const ::std::os::raw::c_void,
-                __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        bsearch_b(arg___key, arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetcap(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetcap(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        cgetcap(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetclose() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetclose() -> ::std::os::raw::c_int;
-        }
-        cgetclose()
-    })
-}
-#[track_caller]
-pub unsafe fn cgetent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetent(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetfirst(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetfirst(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetfirst(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetmatch(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetmatch(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetmatch(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnext(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnext(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnext(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnum(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnum(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnum(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetset(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        cgetset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetstr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetstr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetstr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetustr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetustr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetustr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn daemon(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn daemon(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        daemon(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname(arg_arg1: dev_t, arg_arg2: mode_t) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-        }
-        devname(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname_r(
-    arg_arg1: dev_t,
-    arg_arg2: mode_t,
-    arg_buf: *mut ::std::os::raw::c_char,
-    arg_len: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname_r(
-                arg1: dev_t,
-                arg2: mode_t,
-                buf: *mut ::std::os::raw::c_char,
-                len: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        devname_r(arg_arg1, arg_arg2, arg_buf, arg_len)
-    })
-}
-#[track_caller]
-pub unsafe fn getbsize(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_long,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getbsize(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_long,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        getbsize(arg_arg1, arg_arg2)
+        getsubopt(arg___optionp, arg___tokens, arg___valuep)
     })
 }
 #[track_caller]
 pub unsafe fn getloadavg(
-    arg_arg1: *mut f64,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___loadavg: *mut f64,
+    arg___nelem: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int)
-                -> ::std::os::raw::c_int;
-        }
-        getloadavg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getprogname() -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprogname() -> *const ::std::os::raw::c_char;
-        }
-        getprogname()
-    })
-}
-#[track_caller]
-pub unsafe fn setprogname(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-        }
-        setprogname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn heapsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+            pub fn getloadavg(
+                __loadavg: *mut f64,
+                __nelem: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        heapsort(arg___base, arg___nel, arg___width, arg___compar)
+        getloadavg(arg___loadavg, arg___nelem)
     })
 }
 #[track_caller]
-pub unsafe fn heapsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        heapsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        psort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        qsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn radixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn radixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        radixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn rpmatch(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        rpmatch(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sradixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sradixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        sradixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn sranddev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sranddev();
-        }
-        sranddev()
-    })
-}
-#[track_caller]
-pub unsafe fn srandomdev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandomdev();
-        }
-        srandomdev()
-    })
-}
-#[track_caller]
-pub unsafe fn reallocf(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: usize,
+pub unsafe fn memcpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn reallocf(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: usize,
+            pub fn memcpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        reallocf(arg___ptr, arg___size)
+        memcpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtonum(
-    arg___numstr: *const ::std::os::raw::c_char,
-    arg___minval: ::std::os::raw::c_longlong,
-    arg___maxval: ::std::os::raw::c_longlong,
-    arg___errstrp: *mut *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_longlong {
+pub unsafe fn memmove(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strtonum(
-                __numstr: *const ::std::os::raw::c_char,
-                __minval: ::std::os::raw::c_longlong,
-                __maxval: ::std::os::raw::c_longlong,
-                __errstrp: *mut *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_longlong;
+            pub fn memmove(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
         }
-        strtonum(arg___numstr, arg___minval, arg___maxval, arg___errstrp)
+        memmove(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtoq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoq(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtouq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtouq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtouq(arg___str, arg___endptr, arg___base)
-    })
-}
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[track_caller]
-pub unsafe fn memchr(
-    arg___s: *const ::std::os::raw::c_void,
+pub unsafe fn memccpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
     arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memchr(
-                __s: *const ::std::os::raw::c_void,
+            pub fn memccpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
                 __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memchr(arg___s, arg___c, arg___n)
+        memccpy(arg___dest, arg___src, arg___c, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memset(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn memset(
+                __s: *mut ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        memset(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
@@ -7853,84 +6457,101 @@ pub unsafe fn memcmp(
     })
 }
 #[track_caller]
-pub unsafe fn memcpy(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
+pub unsafe fn __memcmpeq(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __memcmpeq(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        __memcmpeq(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memchr(
+    arg___s: *const ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memcpy(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
+            pub fn memchr(
+                __s: *const ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memcpy(arg___dst, arg___src, arg___n)
+        memchr(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn memmove(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memmove(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memmove(arg___dst, arg___src, arg___len)
+        strcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn memset(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset(
-                __b: *mut ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset(arg___b, arg___c, arg___len)
+        strncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn strcat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strcat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcat(arg___s1, arg___s2)
+        strcat(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn strchr(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___c: ::std::os::raw::c_int,
+pub unsafe fn strncat(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strchr(
-                __s: *const ::std::os::raw::c_char,
-                __c: ::std::os::raw::c_int,
+            pub fn strncat(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strchr(arg___s, arg___c)
+        strncat(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
@@ -7946,86 +6567,6 @@ pub unsafe fn strcmp(
             ) -> ::std::os::raw::c_int;
         }
         strcmp(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcoll(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcoll(
-                __s1: *const ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        strcoll(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strcpy(arg___dst, arg___src)
-    })
-}
-#[track_caller]
-pub unsafe fn strcspn(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcspn(
-                __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strcspn(arg___s, arg___charset)
-    })
-}
-#[track_caller]
-pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strerror(arg___errnum)
-    })
-}
-#[track_caller]
-pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-        }
-        strlen(arg___s)
-    })
-}
-#[track_caller]
-pub unsafe fn strncat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strncat(arg___s1, arg___s2, arg___n)
     })
 }
 #[track_caller]
@@ -8046,35 +6587,130 @@ pub unsafe fn strncmp(
     })
 }
 #[track_caller]
-pub unsafe fn strncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
+pub unsafe fn strcoll(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm(
+    arg___dest: *mut ::std::os::raw::c_char,
     arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strxfrm(arg___dest, arg___src, arg___n)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[track_caller]
+pub unsafe fn strcoll_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __l: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll_l(arg___s1, arg___s2, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm_l(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___l: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm_l(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+                __l: locale_t,
+            ) -> usize;
+        }
+        strxfrm_l(arg___dest, arg___src, arg___n, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strdup(arg___s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        strdup(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strndup(
+    arg___string: *const ::std::os::raw::c_char,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
+            pub fn strndup(
+                __string: *const ::std::os::raw::c_char,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strncpy(arg___dst, arg___src, arg___n)
+        strndup(arg___string, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strpbrk(
+pub unsafe fn strchr(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strpbrk(
+            pub fn strchr(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strpbrk(arg___s, arg___charset)
+        strchr(arg___s, arg___c)
     })
 }
 #[track_caller]
@@ -8093,358 +6729,349 @@ pub unsafe fn strrchr(
     })
 }
 #[track_caller]
+pub unsafe fn strcspn(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___reject: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcspn(
+                __s: *const ::std::os::raw::c_char,
+                __reject: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strcspn(arg___s, arg___reject)
+    })
+}
+#[track_caller]
 pub unsafe fn strspn(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strspn(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_ulong;
         }
-        strspn(arg___s, arg___charset)
+        strspn(arg___s, arg___accept)
+    })
+}
+#[track_caller]
+pub unsafe fn strpbrk(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strpbrk(
+                __s: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        strpbrk(arg___s, arg___accept)
     })
 }
 #[track_caller]
 pub unsafe fn strstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+    arg___haystack: *const ::std::os::raw::c_char,
+    arg___needle: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+                __haystack: *const ::std::os::raw::c_char,
+                __needle: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strstr(arg___big, arg___little)
+        strstr(arg___haystack, arg___needle)
     })
 }
 #[track_caller]
 pub unsafe fn strtok(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok(arg___str, arg___sep)
+        strtok(arg___s, arg___delim)
     })
 }
 #[track_caller]
-pub unsafe fn strxfrm(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn __strtok_r(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strxfrm(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn __strtok_r(
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strxfrm(arg___s1, arg___s2, arg___n)
+        __strtok_r(arg___s, arg___delim, arg___save_ptr)
     })
 }
 #[track_caller]
 pub unsafe fn strtok_r(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
-    arg___lasts: *mut *mut ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok_r(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
-                __lasts: *mut *mut ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok_r(arg___str, arg___sep, arg___lasts)
+        strtok_r(arg___s, arg___delim, arg___save_ptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+        }
+        strlen(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strnlen(arg___string: *const ::std::os::raw::c_char, arg___maxlen: usize) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+        }
+        strnlen(arg___string, arg___maxlen)
+    })
+}
+#[track_caller]
+pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+        }
+        strerror(arg___errnum)
     })
 }
 #[track_caller]
 pub unsafe fn strerror_r(
     arg___errnum: ::std::os::raw::c_int,
-    arg___strerrbuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut ::std::os::raw::c_char,
     arg___buflen: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
+            #[link_name = "\u{1}__xpg_strerror_r"]
             pub fn strerror_r(
                 __errnum: ::std::os::raw::c_int,
-                __strerrbuf: *mut ::std::os::raw::c_char,
+                __buf: *mut ::std::os::raw::c_char,
                 __buflen: usize,
             ) -> ::std::os::raw::c_int;
         }
-        strerror_r(arg___errnum, arg___strerrbuf, arg___buflen)
+        strerror_r(arg___errnum, arg___buf, arg___buflen)
     })
 }
 #[track_caller]
-pub unsafe fn strdup(arg___s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn strerror_l(
+    arg___errnum: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn strerror_l(
+                __errnum: ::std::os::raw::c_int,
+                __l: locale_t,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strdup(arg___s1)
+        strerror_l(arg___errnum, arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn memccpy(
-    arg___dst: *mut ::std::os::raw::c_void,
+pub unsafe fn bcmp(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn bcmp(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        bcmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn bcopy(
     arg___src: *const ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memccpy(
-                __dst: *mut ::std::os::raw::c_void,
+            pub fn bcopy(
                 __src: *const ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+                __dest: *mut ::std::os::raw::c_void,
+                __n: usize,
+            );
         }
-        memccpy(arg___dst, arg___src, arg___c, arg___n)
+        bcopy(arg___src, arg___dest, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: ::std::os::raw::c_ulong) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn stpcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
         }
-        stpcpy(arg___dst, arg___src)
+        bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn stpncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        stpncpy(arg___dst, arg___src, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strndup(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strndup(
-                __s1: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strndup(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strnlen(arg___s1: *const ::std::os::raw::c_char, arg___n: usize) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
-        }
-        strnlen(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strsignal(arg___sig)
-    })
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[track_caller]
-pub unsafe fn memset_s(
-    arg___s: *mut ::std::os::raw::c_void,
-    arg___smax: rsize_t,
+pub unsafe fn index(
+    arg___s: *const ::std::os::raw::c_char,
     arg___c: ::std::os::raw::c_int,
-    arg___n: rsize_t,
-) -> errno_t {
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset_s(
-                __s: *mut ::std::os::raw::c_void,
-                __smax: rsize_t,
+            pub fn index(
+                __s: *const ::std::os::raw::c_char,
                 __c: ::std::os::raw::c_int,
-                __n: rsize_t,
-            ) -> errno_t;
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset_s(arg___s, arg___smax, arg___c, arg___n)
+        index(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn memmem(
-    arg___big: *const ::std::os::raw::c_void,
-    arg___big_len: usize,
-    arg___little: *const ::std::os::raw::c_void,
-    arg___little_len: usize,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memmem(
-                __big: *const ::std::os::raw::c_void,
-                __big_len: usize,
-                __little: *const ::std::os::raw::c_void,
-                __little_len: usize,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        memmem(arg___big, arg___big_len, arg___little, arg___little_len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern4(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern4: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern4(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern4: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern4(arg___b, arg___pattern4, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern8(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern8: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern8(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern8: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern8(arg___b, arg___pattern8, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern16(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern16: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern16(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern16: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern16(arg___b, arg___pattern16, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strcasestr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+pub unsafe fn rindex(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasestr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+            pub fn rindex(
+                __s: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcasestr(arg___big, arg___little)
+        rindex(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn strnstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
-    arg___len: usize,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ffs(arg___i: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strnstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
-                __len: usize,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        strnstr(arg___big, arg___little, arg___len)
+        ffs(arg___i)
     })
 }
 #[track_caller]
-pub unsafe fn strlcat(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsl(arg___l: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcat(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
         }
-        strlcat(arg___dst, arg___source, arg___size)
+        ffsl(arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn strlcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsll(arg___ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
         }
-        strlcpy(arg___dst, arg___source, arg___size)
+        ffsll(arg___ll)
     })
 }
 #[track_caller]
-pub unsafe fn strmode(arg___mode: ::std::os::raw::c_int, arg___bp: *mut ::std::os::raw::c_char) {
+pub unsafe fn strcasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+            pub fn strcasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        strmode(arg___mode, arg___bp)
+        strcasecmp(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn strcasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcasecmp_l(arg___s1, arg___s2, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: usize,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp_l(arg___s1, arg___s2, arg___n, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn explicit_bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+        }
+        explicit_bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
@@ -8463,285 +7090,111 @@ pub unsafe fn strsep(
     })
 }
 #[track_caller]
-pub unsafe fn swab(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: isize,
-) {
+pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn swab(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: isize,
-            );
+            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
         }
-        swab(arg_arg1, arg_arg2, arg_arg3)
+        strsignal(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn timingsafe_bcmp(
-    arg___b1: *const ::std::os::raw::c_void,
-    arg___b2: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timingsafe_bcmp(
-                __b1: *const ::std::os::raw::c_void,
-                __b2: *const ::std::os::raw::c_void,
-                __len: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        timingsafe_bcmp(arg___b1, arg___b2, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal_r(
-    arg___sig: ::std::os::raw::c_int,
-    arg___strsignalbuf: *mut ::std::os::raw::c_char,
-    arg___buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal_r(
-                __sig: ::std::os::raw::c_int,
-                __strsignalbuf: *mut ::std::os::raw::c_char,
-                __buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        strsignal_r(arg___sig, arg___strsignalbuf, arg___buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn bcmp(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcmp(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        bcmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bcopy(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcopy(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-            );
-        }
-        bcopy(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bzero(arg_arg1: *mut ::std::os::raw::c_void, arg_arg2: ::std::os::raw::c_ulong) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-        }
-        bzero(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn index(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn __stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn index(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn __stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        index(arg_arg1, arg_arg2)
+        __stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn rindex(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rindex(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        rindex(arg_arg1, arg_arg2)
+        stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn ffs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        ffs(arg_arg1)
+        __stpncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strcasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
+            pub fn stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strcasecmp(arg_arg1, arg_arg2)
+        stpncpy(arg___dest, arg___src, arg___n)
     })
 }
-#[track_caller]
-pub unsafe fn strncasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        strncasecmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        ffsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        ffsll(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fls(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        fls(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        flsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        flsll(arg_arg1)
-    })
-}
-pub type max_align_t = f64;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[track_caller]
-pub unsafe fn __darwin_check_fd_set_overflow(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn __errno_location() -> *mut ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __darwin_check_fd_set_overflow(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn __errno_location() -> *mut ::std::os::raw::c_int;
         }
-        __darwin_check_fd_set_overflow(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[track_caller]
-pub unsafe fn __error() -> *mut ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __error() -> *mut ::std::os::raw::c_int;
-        }
-        __error()
+        __errno_location()
     })
 }
 #[repr(C)]
@@ -8766,8 +7219,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -8782,6 +7235,21 @@ impl Default for lconv {
     }
 }
 #[track_caller]
+pub unsafe fn setlocale(
+    arg___category: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlocale(
+                __category: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        setlocale(arg___category, arg___locale)
+    })
+}
+#[track_caller]
 pub unsafe fn localeconv() -> *mut lconv {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -8791,18 +7259,47 @@ pub unsafe fn localeconv() -> *mut lconv {
     })
 }
 #[track_caller]
-pub unsafe fn setlocale(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn newlocale(
+    arg___category_mask: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+    arg___base: locale_t,
+) -> locale_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setlocale(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn newlocale(
+                __category_mask: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+                __base: locale_t,
+            ) -> locale_t;
         }
-        setlocale(arg_arg1, arg_arg2)
+        newlocale(arg___category_mask, arg___locale, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn duplocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn duplocale(__dataset: locale_t) -> locale_t;
+        }
+        duplocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn freelocale(arg___dataset: locale_t) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freelocale(__dataset: locale_t);
+        }
+        freelocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn uselocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn uselocale(__dataset: locale_t) -> locale_t;
+        }
+        uselocale(arg___dataset)
     })
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
@@ -8936,163 +7433,401 @@ impl Default for PGAlignedXLogBlock {
         }
     }
 }
+pub const _ISupper: _bindgen_ty_1 = 256;
+pub const _ISlower: _bindgen_ty_1 = 512;
+pub const _ISalpha: _bindgen_ty_1 = 1024;
+pub const _ISdigit: _bindgen_ty_1 = 2048;
+pub const _ISxdigit: _bindgen_ty_1 = 4096;
+pub const _ISspace: _bindgen_ty_1 = 8192;
+pub const _ISprint: _bindgen_ty_1 = 16384;
+pub const _ISgraph: _bindgen_ty_1 = 32768;
+pub const _ISblank: _bindgen_ty_1 = 1;
+pub const _IScntrl: _bindgen_ty_1 = 2;
+pub const _ISpunct: _bindgen_ty_1 = 4;
+pub const _ISalnum: _bindgen_ty_1 = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn fdatasync(arg_fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
         }
-        fdatasync(arg_fildes)
-    })
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
-}
-extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
-}
-#[track_caller]
-pub unsafe fn ___runetype(arg_arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
-        }
-        ___runetype(arg_arg1)
+        __ctype_b_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_tolower_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
         }
-        ___tolower(arg_arg1)
+        __ctype_tolower_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_toupper_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
         }
-        ___toupper(arg_arg1)
+        __ctype_toupper_loc()
     })
 }
 #[track_caller]
-pub unsafe fn __maskrune(
-    arg_arg1: __darwin_ct_rune_t,
-    arg_arg2: ::std::os::raw::c_ulong,
+pub unsafe fn isalnum(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalnum(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalpha(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalpha(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn iscntrl(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        iscntrl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn islower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        islower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isgraph(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isprint(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        ispunct(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isspace(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isxdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        tolower(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toupper(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isblank(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn _toupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _toupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn _tolower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _tolower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalnum_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __maskrune(
-                arg1: __darwin_ct_rune_t,
-                arg2: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
+            pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __maskrune(arg_arg1, arg_arg2)
+        isalnum_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn isalpha_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __toupper(arg_arg1)
+        isalpha_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn iscntrl_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __tolower(arg_arg1)
+        iscntrl_l(arg_arg1, arg_arg2)
     })
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[track_caller]
+pub unsafe fn isdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn islower_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        islower_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isgraph_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isprint_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        ispunct_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isspace_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isupper_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t)
+                -> ::std::os::raw::c_int;
+        }
+        isxdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isblank_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn __toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __toupper_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        toupper_l(arg___c, arg___l)
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -9108,68 +7843,30 @@ impl Default for iovec {
         }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-pub type sockaddr_ref_t = *mut sockaddr;
-pub type sockaddr_ref_ref_t = *mut *mut sockaddr;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sockaddr_header {
-    pub sa_len: __uint8_t,
-    pub sa_family: sa_family_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
@@ -9180,17 +7877,37 @@ impl Default for sockaddr_storage {
         }
     }
 }
-pub type sockaddr_storage_ref_t = *mut sockaddr_storage;
-pub type sockaddr_storage_ref_ref_t = *mut *mut sockaddr_storage;
+pub const MSG_OOB: _bindgen_ty_2 = 1;
+pub const MSG_PEEK: _bindgen_ty_2 = 2;
+pub const MSG_DONTROUTE: _bindgen_ty_2 = 4;
+pub const MSG_CTRUNC: _bindgen_ty_2 = 8;
+pub const MSG_PROXY: _bindgen_ty_2 = 16;
+pub const MSG_TRUNC: _bindgen_ty_2 = 32;
+pub const MSG_DONTWAIT: _bindgen_ty_2 = 64;
+pub const MSG_EOR: _bindgen_ty_2 = 128;
+pub const MSG_WAITALL: _bindgen_ty_2 = 256;
+pub const MSG_FIN: _bindgen_ty_2 = 512;
+pub const MSG_SYN: _bindgen_ty_2 = 1024;
+pub const MSG_CONFIRM: _bindgen_ty_2 = 2048;
+pub const MSG_RST: _bindgen_ty_2 = 4096;
+pub const MSG_ERRQUEUE: _bindgen_ty_2 = 8192;
+pub const MSG_NOSIGNAL: _bindgen_ty_2 = 16384;
+pub const MSG_MORE: _bindgen_ty_2 = 32768;
+pub const MSG_WAITFORONE: _bindgen_ty_2 = 65536;
+pub const MSG_BATCH: _bindgen_ty_2 = 262144;
+pub const MSG_ZEROCOPY: _bindgen_ty_2 = 67108864;
+pub const MSG_FASTOPEN: _bindgen_ty_2 = 536870912;
+pub const MSG_CMSG_CLOEXEC: _bindgen_ty_2 = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -9203,438 +7920,423 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[track_caller]
+pub unsafe fn __cmsg_nxthdr(arg___mhdr: *mut msghdr, arg___cmsg: *mut cmsghdr) -> *mut cmsghdr {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+        }
+        __cmsg_nxthdr(arg___mhdr, arg___cmsg)
+    })
+}
+pub const SCM_RIGHTS: _bindgen_ty_3 = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn accept(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn accept(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        accept(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bind(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bind(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        bind(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn connect(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn connect(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        connect(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getpeername(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpeername(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getpeername(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockname(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockname(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockname(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_void,
-    arg_arg5: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_void,
-                arg5: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn listen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn listen(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        listen(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn recv(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recv(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recv(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn recvfrom(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *mut sockaddr,
-    arg_arg6: *mut socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvfrom(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *mut sockaddr,
-                arg6: *mut socklen_t,
-            ) -> isize;
-        }
-        recvfrom(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn recvmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recvmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn send(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn send(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        send(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn sendmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        sendmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn sendto(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *const sockaddr,
-    arg_arg6: socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendto(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const sockaddr,
-                arg6: socklen_t,
-            ) -> isize;
-        }
-        sendto(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_void,
-    arg_arg5: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_void,
-                arg5: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn shutdown(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn shutdown(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        shutdown(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sockatmark(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sockatmark(arg_arg1)
-    })
-}
+pub const SHUT_RD: _bindgen_ty_4 = 0;
+pub const SHUT_WR: _bindgen_ty_4 = 1;
+pub const SHUT_RDWR: _bindgen_ty_4 = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn socket(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socket(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socket(arg_arg1, arg_arg2, arg_arg3)
+        socket(arg___domain, arg___type, arg___protocol)
     })
 }
 #[track_caller]
 pub unsafe fn socketpair(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
+    arg___fds: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socketpair(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
+                __fds: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socketpair(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        socketpair(arg___domain, arg___type, arg___protocol, arg___fds)
     })
 }
 #[track_caller]
-pub unsafe fn sendfile(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: off_t,
-    arg_arg4: *mut off_t,
-    arg_arg5: *mut sf_hdtr,
-    arg_arg6: ::std::os::raw::c_int,
+pub unsafe fn bind(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sendfile(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: off_t,
-                arg4: *mut off_t,
-                arg5: *mut sf_hdtr,
-                arg6: ::std::os::raw::c_int,
+            pub fn bind(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        sendfile(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
+        bind(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn pfctlinput(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut sockaddr) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-        }
-        pfctlinput(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn connectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sa_endpoints_t,
-    arg_arg3: sae_associd_t,
-    arg_arg4: ::std::os::raw::c_uint,
-    arg_arg5: *const iovec,
-    arg_arg6: ::std::os::raw::c_uint,
-    arg_arg7: *mut usize,
-    arg_arg8: *mut sae_connid_t,
+pub unsafe fn getsockname(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn connectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sa_endpoints_t,
-                arg3: sae_associd_t,
-                arg4: ::std::os::raw::c_uint,
-                arg5: *const iovec,
-                arg6: ::std::os::raw::c_uint,
-                arg7: *mut usize,
-                arg8: *mut sae_connid_t,
+            pub fn getsockname(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        connectx(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7, arg_arg8)
+        getsockname(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn disconnectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: sae_associd_t,
-    arg_arg3: sae_connid_t,
+pub unsafe fn connect(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn disconnectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: sae_associd_t,
-                arg3: sae_connid_t,
+            pub fn connect(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        disconnectx(arg_arg1, arg_arg2, arg_arg3)
+        connect(arg___fd, arg___addr, arg___len)
     })
 }
+#[track_caller]
+pub unsafe fn getpeername(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeername(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeername(arg___fd, arg___addr, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn send(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn send(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        send(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recv(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recv(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recv(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn sendto(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___addr_len: socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendto(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __addr_len: socklen_t,
+            ) -> isize;
+        }
+        sendto(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn recvfrom(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvfrom(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> isize;
+        }
+        recvfrom(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn sendmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *const msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *const msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        sendmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recvmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *mut msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *mut msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recvmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn getsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *mut ::std::os::raw::c_void,
+    arg___optlen: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *mut ::std::os::raw::c_void,
+                __optlen: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn setsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *const ::std::os::raw::c_void,
+    arg___optlen: socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *const ::std::os::raw::c_void,
+                __optlen: socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        setsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn listen(
+    arg___fd: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn listen(
+                __fd: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        listen(arg___fd, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn accept(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn accept(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        accept(arg___fd, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn shutdown(
+    arg___fd: ::std::os::raw::c_int,
+    arg___how: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn shutdown(
+                __fd: ::std::os::raw::c_int,
+                __how: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        shutdown(arg___fd, arg___how)
+    })
+}
+#[track_caller]
+pub unsafe fn sockatmark(arg___fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sockatmark(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn isfdtype(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fdtype: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isfdtype(
+                __fd: ::std::os::raw::c_int,
+                __fdtype: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        isfdtype(arg___fd, arg___fdtype)
+    })
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9653,12 +8355,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -9666,175 +8362,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn setipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: u32,
-    arg_arg5: u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: u32,
-                arg5: u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        setipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn getipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: *mut u32,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: *mut u32,
-                arg5: *mut u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        getipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: u32,
-    arg_arg6: u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: u32,
-                arg6: u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: *mut u32,
-                arg6: *mut u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: _bindgen_ty_5 = 0;
+pub const IPPROTO_ICMP: _bindgen_ty_5 = 1;
+pub const IPPROTO_IGMP: _bindgen_ty_5 = 2;
+pub const IPPROTO_IPIP: _bindgen_ty_5 = 4;
+pub const IPPROTO_TCP: _bindgen_ty_5 = 6;
+pub const IPPROTO_EGP: _bindgen_ty_5 = 8;
+pub const IPPROTO_PUP: _bindgen_ty_5 = 12;
+pub const IPPROTO_UDP: _bindgen_ty_5 = 17;
+pub const IPPROTO_IDP: _bindgen_ty_5 = 22;
+pub const IPPROTO_TP: _bindgen_ty_5 = 29;
+pub const IPPROTO_DCCP: _bindgen_ty_5 = 33;
+pub const IPPROTO_IPV6: _bindgen_ty_5 = 41;
+pub const IPPROTO_RSVP: _bindgen_ty_5 = 46;
+pub const IPPROTO_GRE: _bindgen_ty_5 = 47;
+pub const IPPROTO_ESP: _bindgen_ty_5 = 50;
+pub const IPPROTO_AH: _bindgen_ty_5 = 51;
+pub const IPPROTO_MTP: _bindgen_ty_5 = 92;
+pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
+pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
+pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
+pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
+pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
+pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
+pub const IPPROTO_ETHERNET: _bindgen_ty_5 = 143;
+pub const IPPROTO_RAW: _bindgen_ty_5 = 255;
+pub const IPPROTO_MPTCP: _bindgen_ty_5 = 262;
+pub const IPPROTO_MAX: _bindgen_ty_5 = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: _bindgen_ty_6 = 0;
+pub const IPPROTO_ROUTING: _bindgen_ty_6 = 43;
+pub const IPPROTO_FRAGMENT: _bindgen_ty_6 = 44;
+pub const IPPROTO_ICMPV6: _bindgen_ty_6 = 58;
+pub const IPPROTO_NONE: _bindgen_ty_6 = 59;
+pub const IPPROTO_DSTOPTS: _bindgen_ty_6 = 60;
+pub const IPPROTO_MH: _bindgen_ty_6 = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: _bindgen_ty_7 = 7;
+pub const IPPORT_DISCARD: _bindgen_ty_7 = 9;
+pub const IPPORT_SYSTAT: _bindgen_ty_7 = 11;
+pub const IPPORT_DAYTIME: _bindgen_ty_7 = 13;
+pub const IPPORT_NETSTAT: _bindgen_ty_7 = 15;
+pub const IPPORT_FTP: _bindgen_ty_7 = 21;
+pub const IPPORT_TELNET: _bindgen_ty_7 = 23;
+pub const IPPORT_SMTP: _bindgen_ty_7 = 25;
+pub const IPPORT_TIMESERVER: _bindgen_ty_7 = 37;
+pub const IPPORT_NAMESERVER: _bindgen_ty_7 = 42;
+pub const IPPORT_WHOIS: _bindgen_ty_7 = 43;
+pub const IPPORT_MTP: _bindgen_ty_7 = 57;
+pub const IPPORT_TFTP: _bindgen_ty_7 = 69;
+pub const IPPORT_RJE: _bindgen_ty_7 = 77;
+pub const IPPORT_FINGER: _bindgen_ty_7 = 79;
+pub const IPPORT_TTYLINK: _bindgen_ty_7 = 87;
+pub const IPPORT_SUPDUP: _bindgen_ty_7 = 95;
+pub const IPPORT_EXECSERVER: _bindgen_ty_7 = 512;
+pub const IPPORT_LOGINSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_CMDSERVER: _bindgen_ty_7 = 514;
+pub const IPPORT_EFSSERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_BIFFUDP: _bindgen_ty_7 = 512;
+pub const IPPORT_WHOSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_ROUTESERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_RESERVED: _bindgen_ty_7 = 1024;
+pub const IPPORT_USERRESERVED: _bindgen_ty_7 = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -9854,16 +8462,28 @@ impl Default for in6_addr {
         }
     }
 }
-pub type in6_addr_t = in6_addr;
+extern "C" {
+    pub static in6addr_any: in6_addr;
+}
+extern "C" {
+    pub static in6addr_loopback: in6_addr;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
     pub sin6_family: sa_family_t,
     pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
+    pub sin6_flowinfo: u32,
     pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
+    pub sin6_scope_id: u32,
 }
 impl Default for sockaddr_in6 {
     fn default() -> Self {
@@ -9874,23 +8494,18 @@ impl Default for sockaddr_in6 {
         }
     }
 }
-extern "C" {
-    pub static in6addr_any: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
 }
-extern "C" {
-    pub static in6addr_loopback: in6_addr;
-}
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -9908,12 +8523,12 @@ impl Default for ipv6_mreq {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+#[derive(Debug, Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9923,12 +8538,40 @@ impl Default for in6_pktinfo {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+#[derive(Debug, Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9938,464 +8581,236 @@ impl Default for ip6_mtuinfo {
     }
 }
 #[track_caller]
-pub unsafe fn inet6_option_space(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn ntohl(arg___netlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn ntohl(__netlong: u32) -> u32;
         }
-        inet6_option_space(arg_arg1)
+        ntohl(arg___netlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *mut *mut cmsghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ntohs(arg___netshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut *mut cmsghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn ntohs(__netshort: u16) -> u16;
         }
-        inet6_option_init(arg_arg1, arg_arg2, arg_arg3)
+        ntohs(arg___netshort)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_append(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn htonl(arg___hostlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_append(
-                arg1: *mut cmsghdr,
-                arg2: *const __uint8_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn htonl(__hostlong: u32) -> u32;
         }
-        inet6_option_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        htonl(arg___hostlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_alloc(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut __uint8_t {
+pub unsafe fn htons(arg___hostshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_alloc(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut __uint8_t;
+            pub fn htons(__hostshort: u16) -> u16;
         }
-        inet6_option_alloc(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_next(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_next(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_next(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_find(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_find(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_find(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> usize;
-        }
-        inet6_rthdr_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut cmsghdr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut cmsghdr;
-        }
-        inet6_rthdr_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_add(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const in6_addr,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_add(
-                arg1: *mut cmsghdr,
-                arg2: *const in6_addr,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_add(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_lasthop(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_lasthop(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_lasthop(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_segments(arg_arg1: *const cmsghdr) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getaddr(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getaddr(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rthdr_getaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getflags(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getflags(
-                arg1: *const cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_getflags(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_append(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: socklen_t,
-    arg_arg6: __uint8_t,
-    arg_arg7: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_append(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: socklen_t,
-                arg6: __uint8_t,
-                arg7: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_finish(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_finish(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_finish(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_set_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_set_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_set_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_next(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_next(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_next(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_find(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_find(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_find(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_get_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_get_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_get_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> socklen_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> socklen_t;
-        }
-        inet6_rth_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        inet6_rth_init(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_add(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *const in6_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_add(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const in6_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_add(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_reverse(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_reverse(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_reverse(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_segments(arg_arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void)
-                -> ::std::os::raw::c_int;
-        }
-        inet6_rth_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_getaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_getaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rth_getaddr(arg_arg1, arg_arg2)
+        htons(arg___hostshort)
     })
 }
 #[track_caller]
 pub unsafe fn bindresvport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr_in,
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bindresvport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr_in,
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport(arg_arg1, arg_arg2)
+        bindresvport(arg___sockfd, arg___sock_in)
     })
 }
 #[track_caller]
-pub unsafe fn bindresvport_sa(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
+pub unsafe fn bindresvport6(
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in6,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bindresvport_sa(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
+            pub fn bindresvport6(
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in6,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport_sa(arg_arg1, arg_arg2)
+        bindresvport6(arg___sockfd, arg___sock_in)
     })
 }
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn setrpcent(arg___stayopen: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
+        }
+        setrpcent(arg___stayopen)
+    })
+}
+#[track_caller]
+pub unsafe fn endrpcent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endrpcent();
+        }
+        endrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname(arg___name: *const ::std::os::raw::c_char) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
+        }
+        getrpcbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber(arg___number: ::std::os::raw::c_int) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
+        }
+        getrpcbynumber(arg___number)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent() -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent() -> *mut rpcent;
+        }
+        getrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbyname_r(arg___name, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber_r(
+    arg___number: ::std::os::raw::c_int,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber_r(
+                __number: ::std::os::raw::c_int,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbynumber_r(arg___number, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent_r(
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent_r(
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcent_r(arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn __h_errno_location() -> *mut ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+        }
+        __h_errno_location()
+    })
+}
+#[track_caller]
+pub unsafe fn herror(arg___str: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn herror(__str: *const ::std::os::raw::c_char);
+        }
+        herror(arg___str)
+    })
+}
+#[track_caller]
+pub unsafe fn hstrerror(arg___err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        hstrerror(arg___err_num)
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10415,22 +8830,322 @@ impl Default for hostent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
+#[track_caller]
+pub unsafe fn sethostent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sethostent(__stay_open: ::std::os::raw::c_int);
         }
-    }
+        sethostent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endhostent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endhostent();
+        }
+        endhostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent() -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent() -> *mut hostent;
+        }
+        gethostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyaddr(arg___addr, arg___len, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname(arg___name: *const ::std::os::raw::c_char) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+        }
+        gethostbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyname2(arg___name, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent_r(
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent_r(
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr_r(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr_r(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyaddr_r(
+            arg___addr,
+            arg___len,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2_r(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname2_r(
+            arg___name,
+            arg___af,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn setnetent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+        }
+        setnetent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endnetent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endnetent();
+        }
+        endnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent() -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent() -> *mut netent;
+        }
+        getnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr(arg___net: u32, arg___type: ::std::os::raw::c_int) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+        }
+        getnetbyaddr(arg___net, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname(arg___name: *const ::std::os::raw::c_char) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+        }
+        getnetbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent_r(
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent_r(
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr_r(
+    arg___net: u32,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr_r(
+                __net: u32,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyaddr_r(
+            arg___net,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10449,6 +9164,142 @@ impl Default for servent {
         }
     }
 }
+#[track_caller]
+pub unsafe fn setservent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setservent(__stay_open: ::std::os::raw::c_int);
+        }
+        setservent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endservent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endservent();
+        }
+        endservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservent() -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent() -> *mut servent;
+        }
+        getservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyname(arg___name, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyport(arg___port, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservent_r(
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent_r(
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyname_r(
+            arg___name,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport_r(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport_r(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyport_r(
+            arg___port,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -10465,59 +9316,13 @@ impl Default for protoent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
 #[track_caller]
-pub unsafe fn endhostent() {
+pub unsafe fn setprotoent(arg___stay_open: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn endhostent();
+            pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
         }
-        endhostent()
-    })
-}
-#[track_caller]
-pub unsafe fn endnetent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endnetent();
-        }
-        endnetent()
+        setprotoent(arg___stay_open)
     })
 }
 #[track_caller]
@@ -10530,157 +9335,6 @@ pub unsafe fn endprotoent() {
     })
 }
 #[track_caller]
-pub unsafe fn endservent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endservent();
-        }
-        endservent()
-    })
-}
-#[track_caller]
-pub unsafe fn freeaddrinfo(arg_arg1: *mut addrinfo) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freeaddrinfo(arg1: *mut addrinfo);
-        }
-        freeaddrinfo(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gai_strerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        gai_strerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getaddrinfo(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const addrinfo,
-    arg_arg4: *mut *mut addrinfo,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getaddrinfo(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const addrinfo,
-                arg4: *mut *mut addrinfo,
-            ) -> ::std::os::raw::c_int;
-        }
-        getaddrinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyaddr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-        }
-        gethostbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostent() -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostent() -> *mut hostent;
-        }
-        gethostent()
-    })
-}
-#[track_caller]
-pub unsafe fn getnameinfo(
-    arg_arg1: *const sockaddr,
-    arg_arg2: socklen_t,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut ::std::os::raw::c_char,
-    arg_arg6: socklen_t,
-    arg_arg7: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnameinfo(
-                arg1: *const sockaddr,
-                arg2: socklen_t,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: socklen_t,
-                arg5: *mut ::std::os::raw::c_char,
-                arg6: socklen_t,
-                arg7: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        getnameinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyaddr(arg_arg1: u32, arg_arg2: ::std::os::raw::c_int) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-        }
-        getnetbyaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-        }
-        getnetbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetent() -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetent() -> *mut netent;
-        }
-        getnetent()
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-        }
-        getprotobyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobynumber(arg_arg1: ::std::os::raw::c_int) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-        }
-        getprotobynumber(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn getprotoent() -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -10690,239 +9344,91 @@ pub unsafe fn getprotoent() -> *mut protoent {
     })
 }
 #[track_caller]
-pub unsafe fn getservbyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobyname(arg___name: *const ::std::os::raw::c_char) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
         }
-        getservbyname(arg_arg1, arg_arg2)
+        getprotobyname(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn getservbyport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobynumber(arg___proto: ::std::os::raw::c_int) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
         }
-        getservbyport(arg_arg1, arg_arg2)
+        getprotobynumber(arg___proto)
     })
 }
 #[track_caller]
-pub unsafe fn getservent() -> *mut servent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getservent() -> *mut servent;
-        }
-        getservent()
-    })
-}
-#[track_caller]
-pub unsafe fn sethostent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sethostent(arg1: ::std::os::raw::c_int);
-        }
-        sethostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setnetent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setnetent(arg1: ::std::os::raw::c_int);
-        }
-        setnetent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setprotoent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprotoent(arg1: ::std::os::raw::c_int);
-        }
-        setprotoent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setservent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setservent(arg1: ::std::os::raw::c_int);
-        }
-        setservent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn freehostent(arg_arg1: *mut hostent) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freehostent(arg1: *mut hostent);
-        }
-        freehostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyname2(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyaddr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyname(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbyname(arg_name: *const ::std::os::raw::c_char) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-        }
-        getrpcbyname(arg_name)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbynumber(arg_number: ::std::os::raw::c_int) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-        }
-        getrpcbynumber(arg_number)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcent() -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcent() -> *mut rpcent;
-        }
-        getrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn setrpcent(arg_stayopen: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrpcent(stayopen: ::std::os::raw::c_int);
-        }
-        setrpcent(arg_stayopen)
-    })
-}
-#[track_caller]
-pub unsafe fn endrpcent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endrpcent();
-        }
-        endrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn herror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn herror(arg1: *const ::std::os::raw::c_char);
-        }
-        herror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hstrerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        hstrerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn innetgr(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const ::std::os::raw::c_char,
+pub unsafe fn getprotoent_r(
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn innetgr(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const ::std::os::raw::c_char,
+            pub fn getprotoent_r(
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        innetgr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        getprotoent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn getnetgrent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+pub unsafe fn getprotobyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getnetgrent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+            pub fn getprotobyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        getnetgrent(arg_arg1, arg_arg2, arg_arg3)
+        getprotobyname_r(arg___name, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getprotobynumber_r(
+    arg___proto: ::std::os::raw::c_int,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getprotobynumber_r(
+                __proto: ::std::os::raw::c_int,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getprotobynumber_r(arg___proto, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn setnetgrent(arg___netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        setnetgrent(arg___netgroup)
     })
 }
 #[track_caller]
@@ -10935,29 +9441,283 @@ pub unsafe fn endnetgrent() {
     })
 }
 #[track_caller]
-pub unsafe fn setnetgrent(arg_arg1: *const ::std::os::raw::c_char) {
+pub unsafe fn getnetgrent(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+            pub fn getnetgrent(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        setnetgrent(arg_arg1)
+        getnetgrent(arg___hostp, arg___userp, arg___domainp)
+    })
+}
+#[track_caller]
+pub unsafe fn innetgr(
+    arg___netgroup: *const ::std::os::raw::c_char,
+    arg___host: *const ::std::os::raw::c_char,
+    arg___user: *const ::std::os::raw::c_char,
+    arg___domain: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn innetgr(
+                __netgroup: *const ::std::os::raw::c_char,
+                __host: *const ::std::os::raw::c_char,
+                __user: *const ::std::os::raw::c_char,
+                __domain: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        innetgr(arg___netgroup, arg___host, arg___user, arg___domain)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetgrent_r(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetgrent_r(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetgrent_r(arg___hostp, arg___userp, arg___domainp, arg___buffer, arg___buflen)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd(arg___ahost, arg___rport, arg___locuser, arg___remuser, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd_af(
+            arg___ahost,
+            arg___rport,
+            arg___locuser,
+            arg___remuser,
+            arg___cmd,
+            arg___fd2p,
+            arg___af,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn rexec(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rexec_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec_af(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok(arg___rhost, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok_af(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok_af(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok_af(arg___rhost, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok(
+    arg___raddr: u32,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok(
+                __raddr: u32,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok(arg___raddr, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok_af(
+    arg___raddr: *const ::std::os::raw::c_void,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok_af(
+                __raddr: *const ::std::os::raw::c_void,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok_af(arg___raddr, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport(arg___alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        rresvport(arg___alport)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport_af(
+    arg___alport: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport_af(
+                __alport: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rresvport_af(arg___alport, arg___af)
     })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -10967,73 +9727,94 @@ impl Default for passwd {
     }
 }
 #[track_caller]
-pub unsafe fn getpwuid(arg_arg1: uid_t) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-        }
-        getpwuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwnam(arg_arg1: *const ::std::os::raw::c_char) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-        }
-        getpwnam(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuid_r(
-    arg_arg1: uid_t,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getaddrinfo(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___service: *const ::std::os::raw::c_char,
+    arg___req: *const addrinfo,
+    arg___pai: *mut *mut addrinfo,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuid_r(
-                arg1: uid_t,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getaddrinfo(
+                __name: *const ::std::os::raw::c_char,
+                __service: *const ::std::os::raw::c_char,
+                __req: *const addrinfo,
+                __pai: *mut *mut addrinfo,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getaddrinfo(arg___name, arg___service, arg___req, arg___pai)
     })
 }
 #[track_caller]
-pub unsafe fn getpwnam_r(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn freeaddrinfo(arg___ai: *mut addrinfo) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freeaddrinfo(__ai: *mut addrinfo);
+        }
+        freeaddrinfo(arg___ai)
+    })
+}
+#[track_caller]
+pub unsafe fn gai_strerror(arg___ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        gai_strerror(arg___ecode)
+    })
+}
+#[track_caller]
+pub unsafe fn getnameinfo(
+    arg___sa: *const sockaddr,
+    arg___salen: socklen_t,
+    arg___host: *mut ::std::os::raw::c_char,
+    arg___hostlen: socklen_t,
+    arg___serv: *mut ::std::os::raw::c_char,
+    arg___servlen: socklen_t,
+    arg___flags: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwnam_r(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getnameinfo(
+                __sa: *const sockaddr,
+                __salen: socklen_t,
+                __host: *mut ::std::os::raw::c_char,
+                __hostlen: socklen_t,
+                __serv: *mut ::std::os::raw::c_char,
+                __servlen: socklen_t,
+                __flags: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getpwnam_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getnameinfo(
+            arg___sa,
+            arg___salen,
+            arg___host,
+            arg___hostlen,
+            arg___serv,
+            arg___servlen,
+            arg___flags,
+        )
     })
 }
-#[track_caller]
-pub unsafe fn getpwent() -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwent() -> *mut passwd;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        getpwent()
-    })
+    }
 }
 #[track_caller]
 pub unsafe fn setpwent() {
@@ -11053,192 +9834,131 @@ pub unsafe fn endpwent() {
         endpwent()
     })
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
-extern "C" {
-    pub static UUID_NULL: uuid_t;
-}
 #[track_caller]
-pub unsafe fn uuid_clear(arg_uu: *mut ::std::os::raw::c_uchar) {
+pub unsafe fn getpwent() -> *mut passwd {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+            pub fn getpwent() -> *mut passwd;
         }
-        uuid_clear(arg_uu)
+        getpwent()
     })
 }
 #[track_caller]
-pub unsafe fn uuid_compare(
-    arg_uu1: *mut ::std::os::raw::c_uchar,
-    arg_uu2: *mut ::std::os::raw::c_uchar,
+pub unsafe fn fgetpwent(arg___stream: *mut FILE) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+        }
+        fgetpwent(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putpwent(arg___p: *const passwd, arg___f: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putpwent(arg___p, arg___f)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwuid(arg___uid: __uid_t) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+        }
+        getpwuid(arg___uid)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwnam(arg___name: *const ::std::os::raw::c_char) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+        }
+        getpwnam(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwent_r(
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_compare(
-                uu1: *mut ::std::os::raw::c_uchar,
-                uu2: *mut ::std::os::raw::c_uchar,
+            pub fn getpwent_r(
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_compare(arg_uu1, arg_uu2)
+        getpwent_r(arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_copy(
-    arg_dst: *mut ::std::os::raw::c_uchar,
-    arg_src: *mut ::std::os::raw::c_uchar,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_copy(arg_dst, arg_src)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_random(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_random(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_time(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_time(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_is_null(arg_uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-        }
-        uuid_is_null(arg_uu)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_parse(
-    arg_in_: *mut ::std::os::raw::c_char,
-    arg_uu: *mut ::std::os::raw::c_uchar,
+pub unsafe fn getpwuid_r(
+    arg___uid: __uid_t,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_parse(
-                in_: *mut ::std::os::raw::c_char,
-                uu: *mut ::std::os::raw::c_uchar,
+            pub fn getpwuid_r(
+                __uid: __uid_t,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_parse(arg_in_, arg_uu)
+        getpwuid_r(arg___uid, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_unparse(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-        }
-        uuid_unparse(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_lower(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_lower(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_lower(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_upper(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_upper(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_upper(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn setpassent(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        setpassent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn user_from_uid(
-    arg_arg1: uid_t,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn user_from_uid(
-                arg1: uid_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        user_from_uid(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid(arg_arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-        }
-        getpwuuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid_r(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getpwnam_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuuid_r(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getpwnam_r(
+                __name: *const ::std::os::raw::c_char,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getpwnam_r(arg___name, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetpwent_r(
+    arg___stream: *mut FILE,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent_r(
+                __stream: *mut FILE,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
+            ) -> ::std::os::raw::c_int;
+        }
+        fgetpwent_r(arg___stream, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -11928,1692 +10648,761 @@ pub unsafe fn pg_srand48(arg_seed: ::std::os::raw::c_long) {
         pg_srand48(arg_seed)
     })
 }
+#[track_caller]
+pub unsafe fn fls(arg_mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        fls(arg_mask)
+    })
+}
+#[track_caller]
+pub unsafe fn getpeereid(
+    arg_sock: ::std::os::raw::c_int,
+    arg_uid: *mut uid_t,
+    arg_gid: *mut gid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeereid(
+                sock: ::std::os::raw::c_int,
+                uid: *mut uid_t,
+                gid: *mut gid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeereid(arg_sock, arg_uid, arg_gid)
+    })
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[track_caller]
-pub unsafe fn __math_errhandling() -> ::std::os::raw::c_int {
+pub unsafe fn __fpclassify(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __math_errhandling() -> ::std::os::raw::c_int;
+            pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
         }
-        __math_errhandling()
+        __fpclassify(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __signbit(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyf(arg_arg1)
+        __signbit(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyd(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyd(arg_arg1)
+        __isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyl(arg_arg1)
+        __finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosf(arg1: f32) -> f32;
+            pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosf(arg_arg1)
+        __isnan(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acos(arg_arg1: f64) -> f64 {
+pub unsafe fn __iseqsig(arg___x: f64, arg___y: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acos(arg1: f64) -> f64;
+            pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
         }
-        acos(arg_arg1)
+        __iseqsig(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn acosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __issignaling(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosl(arg1: f64) -> f64;
+            pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosl(arg_arg1)
+        __issignaling(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn asinf(arg_arg1: f32) -> f32 {
+pub unsafe fn acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinf(arg1: f32) -> f32;
+            pub fn acos(__x: f64) -> f64;
         }
-        asinf(arg_arg1)
+        acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asin(arg_arg1: f64) -> f64 {
+pub unsafe fn __acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asin(arg1: f64) -> f64;
+            pub fn __acos(__x: f64) -> f64;
         }
-        asin(arg_arg1)
+        __acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinl(arg_arg1: f64) -> f64 {
+pub unsafe fn asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinl(arg1: f64) -> f64;
+            pub fn asin(__x: f64) -> f64;
         }
-        asinl(arg_arg1)
+        asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanf(arg1: f32) -> f32;
+            pub fn __asin(__x: f64) -> f64;
         }
-        atanf(arg_arg1)
+        __asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan(arg_arg1: f64) -> f64 {
+pub unsafe fn atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan(arg1: f64) -> f64;
+            pub fn atan(__x: f64) -> f64;
         }
-        atan(arg_arg1)
+        atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanl(arg1: f64) -> f64;
+            pub fn __atan(__x: f64) -> f64;
         }
-        atanl(arg_arg1)
+        __atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2f(arg_arg1: f32, arg_arg2: f32) -> f32 {
+pub unsafe fn atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+            pub fn atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2f(arg_arg1, arg_arg2)
+        atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2(arg1: f64, arg2: f64) -> f64;
+            pub fn __atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2(arg_arg1, arg_arg2)
+        __atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2l(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+            pub fn cos(__x: f64) -> f64;
         }
-        atan2l(arg_arg1, arg_arg2)
+        cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosf(arg1: f32) -> f32;
+            pub fn __cos(__x: f64) -> f64;
         }
-        cosf(arg_arg1)
+        __cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cos(arg_arg1: f64) -> f64 {
+pub unsafe fn sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cos(arg1: f64) -> f64;
+            pub fn sin(__x: f64) -> f64;
         }
-        cos(arg_arg1)
+        sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosl(arg1: f64) -> f64;
+            pub fn __sin(__x: f64) -> f64;
         }
-        cosl(arg_arg1)
+        __sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinf(arg_arg1: f32) -> f32 {
+pub unsafe fn tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinf(arg1: f32) -> f32;
+            pub fn tan(__x: f64) -> f64;
         }
-        sinf(arg_arg1)
+        tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sin(arg_arg1: f64) -> f64 {
+pub unsafe fn __tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sin(arg1: f64) -> f64;
+            pub fn __tan(__x: f64) -> f64;
         }
-        sin(arg_arg1)
+        __tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinl(arg_arg1: f64) -> f64 {
+pub unsafe fn cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinl(arg1: f64) -> f64;
+            pub fn cosh(__x: f64) -> f64;
         }
-        sinl(arg_arg1)
+        cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanf(arg1: f32) -> f32;
+            pub fn __cosh(__x: f64) -> f64;
         }
-        tanf(arg_arg1)
+        __cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tan(arg_arg1: f64) -> f64 {
+pub unsafe fn sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tan(arg1: f64) -> f64;
+            pub fn sinh(__x: f64) -> f64;
         }
-        tan(arg_arg1)
+        sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanl(arg1: f64) -> f64;
+            pub fn __sinh(__x: f64) -> f64;
         }
-        tanl(arg_arg1)
+        __sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshf(arg_arg1: f32) -> f32 {
+pub unsafe fn tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshf(arg1: f32) -> f32;
+            pub fn tanh(__x: f64) -> f64;
         }
-        acoshf(arg_arg1)
+        tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acosh(arg_arg1: f64) -> f64 {
+pub unsafe fn __tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosh(arg1: f64) -> f64;
+            pub fn __tanh(__x: f64) -> f64;
         }
-        acosh(arg_arg1)
+        __tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshl(arg_arg1: f64) -> f64 {
+pub unsafe fn acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshl(arg1: f64) -> f64;
+            pub fn acosh(__x: f64) -> f64;
         }
-        acoshl(arg_arg1)
+        acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn __acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhf(arg1: f32) -> f32;
+            pub fn __acosh(__x: f64) -> f64;
         }
-        asinhf(arg_arg1)
+        __acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinh(arg_arg1: f64) -> f64 {
+pub unsafe fn asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinh(arg1: f64) -> f64;
+            pub fn asinh(__x: f64) -> f64;
         }
-        asinh(arg_arg1)
+        asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhl(arg1: f64) -> f64;
+            pub fn __asinh(__x: f64) -> f64;
         }
-        asinhl(arg_arg1)
+        __asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhf(arg1: f32) -> f32;
+            pub fn atanh(__x: f64) -> f64;
         }
-        atanhf(arg_arg1)
+        atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanh(arg1: f64) -> f64;
+            pub fn __atanh(__x: f64) -> f64;
         }
-        atanh(arg_arg1)
+        __atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhl(arg1: f64) -> f64;
+            pub fn exp(__x: f64) -> f64;
         }
-        atanhl(arg_arg1)
+        exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn coshf(arg_arg1: f32) -> f32 {
+pub unsafe fn __exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshf(arg1: f32) -> f32;
+            pub fn __exp(__x: f64) -> f64;
         }
-        coshf(arg_arg1)
+        __exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosh(arg_arg1: f64) -> f64 {
+pub unsafe fn frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosh(arg1: f64) -> f64;
+            pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        cosh(arg_arg1)
+        frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn coshl(arg_arg1: f64) -> f64 {
+pub unsafe fn __frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshl(arg1: f64) -> f64;
+            pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        coshl(arg_arg1)
+        __frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhf(arg1: f32) -> f32;
+            pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinhf(arg_arg1)
+        ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinh(arg_arg1: f64) -> f64 {
+pub unsafe fn __ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinh(arg1: f64) -> f64;
+            pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinh(arg_arg1)
+        __ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhl(arg1: f64) -> f64;
+            pub fn __log(__x: f64) -> f64;
         }
-        sinhl(arg_arg1)
+        __log(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhf(arg1: f32) -> f32;
+            pub fn log10(__x: f64) -> f64;
         }
-        tanhf(arg_arg1)
+        log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanh(arg1: f64) -> f64;
+            pub fn __log10(__x: f64) -> f64;
         }
-        tanh(arg_arg1)
+        __log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhl(arg1: f64) -> f64;
+            pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        tanhl(arg_arg1)
+        modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn expf(arg_arg1: f32) -> f32 {
+pub unsafe fn __modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expf(arg1: f32) -> f32;
+            pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        expf(arg_arg1)
+        __modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn exp(arg_arg1: f64) -> f64 {
+pub unsafe fn expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp(arg1: f64) -> f64;
+            pub fn expm1(__x: f64) -> f64;
         }
-        exp(arg_arg1)
+        expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expl(arg_arg1: f64) -> f64 {
+pub unsafe fn __expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expl(arg1: f64) -> f64;
+            pub fn __expm1(__x: f64) -> f64;
         }
-        expl(arg_arg1)
+        __expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2f(arg_arg1: f32) -> f32 {
+pub unsafe fn log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2f(arg1: f32) -> f32;
+            pub fn log1p(__x: f64) -> f64;
         }
-        exp2f(arg_arg1)
+        log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2(arg_arg1: f64) -> f64 {
+pub unsafe fn __log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2(arg1: f64) -> f64;
+            pub fn __log1p(__x: f64) -> f64;
         }
-        exp2(arg_arg1)
+        __log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2l(arg_arg1: f64) -> f64 {
+pub unsafe fn logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2l(arg1: f64) -> f64;
+            pub fn logb(__x: f64) -> f64;
         }
-        exp2l(arg_arg1)
+        logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1f(arg_arg1: f32) -> f32 {
+pub unsafe fn __logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1f(arg1: f32) -> f32;
+            pub fn __logb(__x: f64) -> f64;
         }
-        expm1f(arg_arg1)
+        __logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1(arg_arg1: f64) -> f64 {
+pub unsafe fn exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1(arg1: f64) -> f64;
+            pub fn exp2(__x: f64) -> f64;
         }
-        expm1(arg_arg1)
+        exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1l(arg_arg1: f64) -> f64 {
+pub unsafe fn __exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1l(arg1: f64) -> f64;
+            pub fn __exp2(__x: f64) -> f64;
         }
-        expm1l(arg_arg1)
+        __exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logf(arg_arg1: f32) -> f32 {
+pub unsafe fn log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logf(arg1: f32) -> f32;
+            pub fn log2(__x: f64) -> f64;
         }
-        logf(arg_arg1)
+        log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logl(arg1: f64) -> f64;
+            pub fn __log2(__x: f64) -> f64;
         }
-        logl(arg_arg1)
+        __log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log10f(arg_arg1: f32) -> f32 {
+pub unsafe fn pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10f(arg1: f32) -> f32;
+            pub fn pow(__x: f64, __y: f64) -> f64;
         }
-        log10f(arg_arg1)
+        pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10(arg_arg1: f64) -> f64 {
+pub unsafe fn __pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10(arg1: f64) -> f64;
+            pub fn __pow(__x: f64, __y: f64) -> f64;
         }
-        log10(arg_arg1)
+        __pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10l(arg_arg1: f64) -> f64 {
+pub unsafe fn sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10l(arg1: f64) -> f64;
+            pub fn sqrt(__x: f64) -> f64;
         }
-        log10l(arg_arg1)
+        sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2f(arg_arg1: f32) -> f32 {
+pub unsafe fn __sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2f(arg1: f32) -> f32;
+            pub fn __sqrt(__x: f64) -> f64;
         }
-        log2f(arg_arg1)
+        __sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2(arg_arg1: f64) -> f64 {
+pub unsafe fn hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2(arg1: f64) -> f64;
+            pub fn hypot(__x: f64, __y: f64) -> f64;
         }
-        log2(arg_arg1)
+        hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log2l(arg_arg1: f64) -> f64 {
+pub unsafe fn __hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2l(arg1: f64) -> f64;
+            pub fn __hypot(__x: f64, __y: f64) -> f64;
         }
-        log2l(arg_arg1)
+        __hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log1pf(arg_arg1: f32) -> f32 {
+pub unsafe fn cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pf(arg1: f32) -> f32;
+            pub fn cbrt(__x: f64) -> f64;
         }
-        log1pf(arg_arg1)
+        cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1p(arg_arg1: f64) -> f64 {
+pub unsafe fn __cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1p(arg1: f64) -> f64;
+            pub fn __cbrt(__x: f64) -> f64;
         }
-        log1p(arg_arg1)
+        __cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1pl(arg_arg1: f64) -> f64 {
+pub unsafe fn ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pl(arg1: f64) -> f64;
+            pub fn ceil(__x: f64) -> f64;
         }
-        log1pl(arg_arg1)
+        ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbf(arg_arg1: f32) -> f32 {
+pub unsafe fn __ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbf(arg1: f32) -> f32;
+            pub fn __ceil(__x: f64) -> f64;
         }
-        logbf(arg_arg1)
+        __ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logb(arg_arg1: f64) -> f64 {
+pub unsafe fn fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logb(arg1: f64) -> f64;
+            pub fn fabs(__x: f64) -> f64;
         }
-        logb(arg_arg1)
+        fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbl(arg_arg1: f64) -> f64 {
+pub unsafe fn __fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbl(arg1: f64) -> f64;
+            pub fn __fabs(__x: f64) -> f64;
         }
-        logbl(arg_arg1)
+        __fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modff(arg_arg1: f32, arg_arg2: *mut f32) -> f32 {
+pub unsafe fn floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+            pub fn floor(__x: f64) -> f64;
         }
-        modff(arg_arg1, arg_arg2)
+        floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modf(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn __floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn __floor(__x: f64) -> f64;
         }
-        modf(arg_arg1, arg_arg2)
+        __floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modfl(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn fmod(__x: f64, __y: f64) -> f64;
         }
-        modfl(arg_arg1, arg_arg2)
+        fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn __fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn __fmod(__x: f64, __y: f64) -> f64;
         }
-        ldexpf(arg_arg1, arg_arg2)
+        __fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexp(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexp(arg_arg1, arg_arg2)
+        isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexpl(arg_arg1, arg_arg2)
+        finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn frexpf(arg_arg1: f32, arg_arg2: *mut ::std::os::raw::c_int) -> f32 {
+pub unsafe fn drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+            pub fn drem(__x: f64, __y: f64) -> f64;
         }
-        frexpf(arg_arg1, arg_arg2)
+        drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexp(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn __drem(__x: f64, __y: f64) -> f64;
         }
-        frexp(arg_arg1, arg_arg2)
+        __drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexpl(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn significand(__x: f64) -> f64;
         }
-        frexpl(arg_arg1, arg_arg2)
+        significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __significand(__x: f64) -> f64;
         }
-        ilogbf(arg_arg1)
+        __significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogb(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogb(arg_arg1)
+        copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogbl(arg_arg1)
+        __copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbnf(arg_arg1, arg_arg2)
+        nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbn(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbn(arg_arg1, arg_arg2)
+        __nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        scalbnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_long) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-        }
-        scalblnf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalbln(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalbln(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalblnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsf(arg1: f32) -> f32;
-        }
-        fabsf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabs(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabs(arg1: f64) -> f64;
-        }
-        fabs(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsl(arg1: f64) -> f64;
-        }
-        fabsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtf(arg1: f32) -> f32;
-        }
-        cbrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrt(arg1: f64) -> f64;
-        }
-        cbrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtl(arg1: f64) -> f64;
-        }
-        cbrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-        }
-        hypotf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypot(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypot(arg1: f64, arg2: f64) -> f64;
-        }
-        hypot(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-        }
-        hypotl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powf(arg1: f32, arg2: f32) -> f32;
-        }
-        powf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pow(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pow(arg1: f64, arg2: f64) -> f64;
-        }
-        pow(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powl(arg1: f64, arg2: f64) -> f64;
-        }
-        powl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtf(arg1: f32) -> f32;
-        }
-        sqrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrt(arg1: f64) -> f64;
-        }
-        sqrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtl(arg1: f64) -> f64;
-        }
-        sqrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erff(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erff(arg1: f32) -> f32;
-        }
-        erff(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erf(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erf(arg1: f64) -> f64;
-        }
-        erf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfl(arg1: f64) -> f64;
-        }
-        erfl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcf(arg1: f32) -> f32;
-        }
-        erfcf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfc(arg1: f64) -> f64;
-        }
-        erfc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcl(arg1: f64) -> f64;
-        }
-        erfcl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammaf(arg1: f32) -> f32;
-        }
-        lgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgamma(arg1: f64) -> f64;
-        }
-        lgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammal(arg1: f64) -> f64;
-        }
-        lgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammaf(arg1: f32) -> f32;
-        }
-        tgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgamma(arg1: f64) -> f64;
-        }
-        tgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammal(arg1: f64) -> f64;
-        }
-        tgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceilf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceilf(arg1: f32) -> f32;
-        }
-        ceilf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceil(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceil(arg1: f64) -> f64;
-        }
-        ceil(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceill(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceill(arg1: f64) -> f64;
-        }
-        ceill(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorf(arg1: f32) -> f32;
-        }
-        floorf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floor(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floor(arg1: f64) -> f64;
-        }
-        floor(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorl(arg1: f64) -> f64;
-        }
-        floorl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintf(arg1: f32) -> f32;
-        }
-        nearbyintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyint(arg1: f64) -> f64;
-        }
-        nearbyint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintl(arg1: f64) -> f64;
-        }
-        nearbyintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintf(arg1: f32) -> f32;
-        }
-        rintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rint(arg1: f64) -> f64;
-        }
-        rint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintl(arg1: f64) -> f64;
-        }
-        rintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrint(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundf(arg1: f32) -> f32;
-        }
-        roundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn round(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn round(arg1: f64) -> f64;
-        }
-        round(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundl(arg1: f64) -> f64;
-        }
-        roundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lround(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrint(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llround(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncf(arg1: f32) -> f32;
-        }
-        truncf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn trunc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn trunc(arg1: f64) -> f64;
-        }
-        trunc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncl(arg1: f64) -> f64;
-        }
-        truncl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmodf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmod(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmod(arg1: f64, arg2: f64) -> f64;
-        }
-        fmod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmodl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-        }
-        remainderf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainder(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainder(arg1: f64, arg2: f64) -> f64;
-        }
-        remainder(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-        }
-        remainderl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remquof(arg_arg1: f32, arg_arg2: f32, arg_arg3: *mut ::std::os::raw::c_int) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-        }
-        remquof(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquo(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquo(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquol(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquol(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-        }
-        copysignf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysign(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysign(arg1: f64, arg2: f64) -> f64;
-        }
-        copysign(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-        }
-        copysignl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nanf(arg_arg1: *const ::std::os::raw::c_char) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-        }
-        nanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nan(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nan(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nanl(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nanl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-        }
-        nextafterf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafter(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafter(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafterl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttoward(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttoward(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardf(arg_arg1: f32, arg_arg2: f64) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-        }
-        nexttowardf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttowardl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdimf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-        }
-        fdimf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdim(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdim(arg1: f64, arg2: f64) -> f64;
-        }
-        fdim(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdiml(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-        }
-        fdiml(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmaxf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmax(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmax(arg1: f64, arg2: f64) -> f64;
-        }
-        fmax(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmaxl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminf(arg1: f32, arg2: f32) -> f32;
-        }
-        fminf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmin(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmin(arg1: f64, arg2: f64) -> f64;
-        }
-        fmin(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminl(arg1: f64, arg2: f64) -> f64;
-        }
-        fminl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaf(arg_arg1: f32, arg_arg2: f32, arg_arg3: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-        }
-        fmaf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fma(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fma(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fmal(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fmal(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10f(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10f(arg1: f32) -> f32;
-        }
-        __exp10f(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10(arg1: f64) -> f64;
-        }
-        __exp10(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospif(arg1: f32) -> f32;
-        }
-        __cospif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospi(arg1: f64) -> f64;
-        }
-        __cospi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpif(arg1: f32) -> f32;
-        }
-        __sinpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpi(arg1: f64) -> f64;
-        }
-        __sinpi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpif(arg1: f32) -> f32;
-        }
-        __tanpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpi(arg1: f64) -> f64;
-        }
-        __tanpi(arg_arg1)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[track_caller]
-pub unsafe fn __sincosf_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincosf_stret(arg1: f32) -> __float2;
-        }
-        __sincosf_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincos_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincos_stret(arg1: f64) -> __double2;
-        }
-        __sincos_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospif_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospif_stret(arg1: f32) -> __float2;
-        }
-        __sincospif_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospi_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospi_stret(arg1: f64) -> __double2;
-        }
-        __sincospi_stret(arg_arg1)
+        isnan(arg___value)
     })
 }
 #[track_caller]
@@ -13626,12 +11415,30 @@ pub unsafe fn j0(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __j0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0(arg1: f64) -> f64;
+        }
+        __j0(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn j1(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn j1(arg1: f64) -> f64;
         }
         j1(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1(arg1: f64) -> f64;
+        }
+        __j1(arg_arg1)
     })
 }
 #[track_caller]
@@ -13644,12 +11451,30 @@ pub unsafe fn jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+        }
+        __jn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
 pub unsafe fn y0(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn y0(arg1: f64) -> f64;
         }
         y0(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0(arg1: f64) -> f64;
+        }
+        __y0(arg_arg1)
     })
 }
 #[track_caller]
@@ -13662,6 +11487,15 @@ pub unsafe fn y1(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __y1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1(arg1: f64) -> f64;
+        }
+        __y1(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -13671,34 +11505,3156 @@ pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
-pub unsafe fn scalb(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalb(arg1: f64, arg2: f64) -> f64;
+            pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
         }
-        scalb(arg_arg1, arg_arg2)
+        __yn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erf(arg1: f64) -> f64;
+        }
+        erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erf(arg1: f64) -> f64;
+        }
+        __erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfc(arg1: f64) -> f64;
+        }
+        erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfc(arg1: f64) -> f64;
+        }
+        __erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma(arg1: f64) -> f64;
+        }
+        lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma(arg1: f64) -> f64;
+        }
+        __lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgamma(arg1: f64) -> f64;
+        }
+        tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgamma(arg1: f64) -> f64;
+        }
+        __tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gamma(arg1: f64) -> f64;
+        }
+        gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gamma(arg1: f64) -> f64;
+        }
+        __gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rint(__x: f64) -> f64;
+        }
+        rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rint(__x: f64) -> f64;
+        }
+        __rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafter(__x: f64, __y: f64) -> f64;
+        }
+        nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafter(__x: f64, __y: f64) -> f64;
+        }
+        __nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        __nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainder(__x: f64, __y: f64) -> f64;
+        }
+        remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainder(__x: f64, __y: f64) -> f64;
+        }
+        __remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        __scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        __ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        __scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyint(__x: f64) -> f64;
+        }
+        nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyint(__x: f64) -> f64;
+        }
+        __nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn round(__x: f64) -> f64;
+        }
+        round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __round(__x: f64) -> f64;
+        }
+        __round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn trunc(__x: f64) -> f64;
+        }
+        trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __trunc(__x: f64) -> f64;
+        }
+        __trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdim(__x: f64, __y: f64) -> f64;
+        }
+        fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdim(__x: f64, __y: f64) -> f64;
+        }
+        __fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmax(__x: f64, __y: f64) -> f64;
+        }
+        fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmax(__x: f64, __y: f64) -> f64;
+        }
+        __fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmin(__x: f64, __y: f64) -> f64;
+        }
+        fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmin(__x: f64, __y: f64) -> f64;
+        }
+        __fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        __fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalb(__x: f64, __n: f64) -> f64;
+        }
+        scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalb(__x: f64, __n: f64) -> f64;
+        }
+        __scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __signbitf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigf(arg___x: f32, arg___y: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+        }
+        __iseqsigf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __issignalingf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosf(__x: f32) -> f32;
+        }
+        acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosf(__x: f32) -> f32;
+        }
+        __acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinf(__x: f32) -> f32;
+        }
+        asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinf(__x: f32) -> f32;
+        }
+        __asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanf(__x: f32) -> f32;
+        }
+        atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanf(__x: f32) -> f32;
+        }
+        __atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2f(__y: f32, __x: f32) -> f32;
+        }
+        atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2f(__y: f32, __x: f32) -> f32;
+        }
+        __atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosf(__x: f32) -> f32;
+        }
+        cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosf(__x: f32) -> f32;
+        }
+        __cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinf(__x: f32) -> f32;
+        }
+        sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinf(__x: f32) -> f32;
+        }
+        __sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanf(__x: f32) -> f32;
+        }
+        tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanf(__x: f32) -> f32;
+        }
+        __tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshf(__x: f32) -> f32;
+        }
+        coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshf(__x: f32) -> f32;
+        }
+        __coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhf(__x: f32) -> f32;
+        }
+        sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhf(__x: f32) -> f32;
+        }
+        __sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhf(__x: f32) -> f32;
+        }
+        tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhf(__x: f32) -> f32;
+        }
+        __tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshf(__x: f32) -> f32;
+        }
+        acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshf(__x: f32) -> f32;
+        }
+        __acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhf(__x: f32) -> f32;
+        }
+        asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhf(__x: f32) -> f32;
+        }
+        __asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhf(__x: f32) -> f32;
+        }
+        atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhf(__x: f32) -> f32;
+        }
+        __atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expf(__x: f32) -> f32;
+        }
+        expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expf(__x: f32) -> f32;
+        }
+        __expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        __ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logf(__x: f32) -> f32;
+        }
+        logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logf(__x: f32) -> f32;
+        }
+        __logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10f(__x: f32) -> f32;
+        }
+        log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10f(__x: f32) -> f32;
+        }
+        __log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        __modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1f(__x: f32) -> f32;
+        }
+        expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1f(__x: f32) -> f32;
+        }
+        __expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pf(__x: f32) -> f32;
+        }
+        log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pf(__x: f32) -> f32;
+        }
+        __log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbf(__x: f32) -> f32;
+        }
+        logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbf(__x: f32) -> f32;
+        }
+        __logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2f(__x: f32) -> f32;
+        }
+        exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2f(__x: f32) -> f32;
+        }
+        __exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2f(__x: f32) -> f32;
+        }
+        log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2f(__x: f32) -> f32;
+        }
+        __log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powf(__x: f32, __y: f32) -> f32;
+        }
+        powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powf(__x: f32, __y: f32) -> f32;
+        }
+        __powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtf(__x: f32) -> f32;
+        }
+        sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtf(__x: f32) -> f32;
+        }
+        __sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotf(__x: f32, __y: f32) -> f32;
+        }
+        hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotf(__x: f32, __y: f32) -> f32;
+        }
+        __hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtf(__x: f32) -> f32;
+        }
+        cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtf(__x: f32) -> f32;
+        }
+        __cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceilf(__x: f32) -> f32;
+        }
+        ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceilf(__x: f32) -> f32;
+        }
+        __ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsf(__x: f32) -> f32;
+        }
+        fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsf(__x: f32) -> f32;
+        }
+        __fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorf(__x: f32) -> f32;
+        }
+        floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorf(__x: f32) -> f32;
+        }
+        __floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodf(__x: f32, __y: f32) -> f32;
+        }
+        fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodf(__x: f32, __y: f32) -> f32;
+        }
+        __fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dremf(__x: f32, __y: f32) -> f32;
+        }
+        dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dremf(__x: f32, __y: f32) -> f32;
+        }
+        __dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandf(__x: f32) -> f32;
+        }
+        significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandf(__x: f32) -> f32;
+        }
+        __significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignf(__x: f32, __y: f32) -> f32;
+        }
+        copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignf(__x: f32, __y: f32) -> f32;
+        }
+        __copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        __nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0f(arg1: f32) -> f32;
+        }
+        j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0f(arg1: f32) -> f32;
+        }
+        __j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1f(arg1: f32) -> f32;
+        }
+        j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1f(arg1: f32) -> f32;
+        }
+        __j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0f(arg1: f32) -> f32;
+        }
+        y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0f(arg1: f32) -> f32;
+        }
+        __y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1f(arg1: f32) -> f32;
+        }
+        y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1f(arg1: f32) -> f32;
+        }
+        __y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erff(arg1: f32) -> f32;
+        }
+        erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erff(arg1: f32) -> f32;
+        }
+        __erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcf(arg1: f32) -> f32;
+        }
+        erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcf(arg1: f32) -> f32;
+        }
+        __erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf(arg1: f32) -> f32;
+        }
+        lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf(arg1: f32) -> f32;
+        }
+        __lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammaf(arg1: f32) -> f32;
+        }
+        tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammaf(arg1: f32) -> f32;
+        }
+        __tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammaf(arg1: f32) -> f32;
+        }
+        gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammaf(arg1: f32) -> f32;
+        }
+        __gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintf(__x: f32) -> f32;
+        }
+        rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintf(__x: f32) -> f32;
+        }
+        __rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        __nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        __nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderf(__x: f32, __y: f32) -> f32;
+        }
+        remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderf(__x: f32, __y: f32) -> f32;
+        }
+        __remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        __scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        __ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        __scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintf(__x: f32) -> f32;
+        }
+        nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintf(__x: f32) -> f32;
+        }
+        __nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundf(__x: f32) -> f32;
+        }
+        roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundf(__x: f32) -> f32;
+        }
+        __roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncf(__x: f32) -> f32;
+        }
+        truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncf(__x: f32) -> f32;
+        }
+        __truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdimf(__x: f32, __y: f32) -> f32;
+        }
+        fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdimf(__x: f32, __y: f32) -> f32;
+        }
+        __fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        __fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminf(__x: f32, __y: f32) -> f32;
+        }
+        fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminf(__x: f32, __y: f32) -> f32;
+        }
+        __fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        __fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbf(__x: f32, __n: f32) -> f32;
+        }
+        scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbf(__x: f32, __n: f32) -> f32;
+        }
+        __scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __signbitl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigl(arg___x: u128, arg___y: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+        }
+        __iseqsigl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __issignalingl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosl(__x: u128) -> u128;
+        }
+        acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosl(__x: u128) -> u128;
+        }
+        __acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinl(__x: u128) -> u128;
+        }
+        asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinl(__x: u128) -> u128;
+        }
+        __asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanl(__x: u128) -> u128;
+        }
+        atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanl(__x: u128) -> u128;
+        }
+        __atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2l(__y: u128, __x: u128) -> u128;
+        }
+        atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2l(__y: u128, __x: u128) -> u128;
+        }
+        __atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosl(__x: u128) -> u128;
+        }
+        cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosl(__x: u128) -> u128;
+        }
+        __cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinl(__x: u128) -> u128;
+        }
+        sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinl(__x: u128) -> u128;
+        }
+        __sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanl(__x: u128) -> u128;
+        }
+        tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanl(__x: u128) -> u128;
+        }
+        __tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshl(__x: u128) -> u128;
+        }
+        coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshl(__x: u128) -> u128;
+        }
+        __coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhl(__x: u128) -> u128;
+        }
+        sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhl(__x: u128) -> u128;
+        }
+        __sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhl(__x: u128) -> u128;
+        }
+        tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhl(__x: u128) -> u128;
+        }
+        __tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshl(__x: u128) -> u128;
+        }
+        acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshl(__x: u128) -> u128;
+        }
+        __acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhl(__x: u128) -> u128;
+        }
+        asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhl(__x: u128) -> u128;
+        }
+        __asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhl(__x: u128) -> u128;
+        }
+        atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhl(__x: u128) -> u128;
+        }
+        __atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expl(__x: u128) -> u128;
+        }
+        expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expl(__x: u128) -> u128;
+        }
+        __expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        __ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logl(__x: u128) -> u128;
+        }
+        logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logl(__x: u128) -> u128;
+        }
+        __logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10l(__x: u128) -> u128;
+        }
+        log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10l(__x: u128) -> u128;
+        }
+        __log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        __modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1l(__x: u128) -> u128;
+        }
+        expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1l(__x: u128) -> u128;
+        }
+        __expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pl(__x: u128) -> u128;
+        }
+        log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pl(__x: u128) -> u128;
+        }
+        __log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbl(__x: u128) -> u128;
+        }
+        logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbl(__x: u128) -> u128;
+        }
+        __logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2l(__x: u128) -> u128;
+        }
+        exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2l(__x: u128) -> u128;
+        }
+        __exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2l(__x: u128) -> u128;
+        }
+        log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2l(__x: u128) -> u128;
+        }
+        __log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powl(__x: u128, __y: u128) -> u128;
+        }
+        powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powl(__x: u128, __y: u128) -> u128;
+        }
+        __powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtl(__x: u128) -> u128;
+        }
+        sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtl(__x: u128) -> u128;
+        }
+        __sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotl(__x: u128, __y: u128) -> u128;
+        }
+        hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotl(__x: u128, __y: u128) -> u128;
+        }
+        __hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtl(__x: u128) -> u128;
+        }
+        cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtl(__x: u128) -> u128;
+        }
+        __cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceill(__x: u128) -> u128;
+        }
+        ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceill(__x: u128) -> u128;
+        }
+        __ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsl(__x: u128) -> u128;
+        }
+        fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsl(__x: u128) -> u128;
+        }
+        __fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorl(__x: u128) -> u128;
+        }
+        floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorl(__x: u128) -> u128;
+        }
+        __floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodl(__x: u128, __y: u128) -> u128;
+        }
+        fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodl(__x: u128, __y: u128) -> u128;
+        }
+        __fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dreml(__x: u128, __y: u128) -> u128;
+        }
+        dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dreml(__x: u128, __y: u128) -> u128;
+        }
+        __dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandl(__x: u128) -> u128;
+        }
+        significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandl(__x: u128) -> u128;
+        }
+        __significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignl(__x: u128, __y: u128) -> u128;
+        }
+        copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignl(__x: u128, __y: u128) -> u128;
+        }
+        __copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        __nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0l(arg1: u128) -> u128;
+        }
+        j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0l(arg1: u128) -> u128;
+        }
+        __j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1l(arg1: u128) -> u128;
+        }
+        j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1l(arg1: u128) -> u128;
+        }
+        __j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0l(arg1: u128) -> u128;
+        }
+        y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0l(arg1: u128) -> u128;
+        }
+        __y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1l(arg1: u128) -> u128;
+        }
+        y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1l(arg1: u128) -> u128;
+        }
+        __y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfl(arg1: u128) -> u128;
+        }
+        erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfl(arg1: u128) -> u128;
+        }
+        __erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcl(arg1: u128) -> u128;
+        }
+        erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcl(arg1: u128) -> u128;
+        }
+        __erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal(arg1: u128) -> u128;
+        }
+        lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal(arg1: u128) -> u128;
+        }
+        __lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammal(arg1: u128) -> u128;
+        }
+        tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammal(arg1: u128) -> u128;
+        }
+        __tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammal(arg1: u128) -> u128;
+        }
+        gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammal(arg1: u128) -> u128;
+        }
+        __gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintl(__x: u128) -> u128;
+        }
+        rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintl(__x: u128) -> u128;
+        }
+        __rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        __nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        __nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderl(__x: u128, __y: u128) -> u128;
+        }
+        remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderl(__x: u128, __y: u128) -> u128;
+        }
+        __remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        __scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        __ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        __scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintl(__x: u128) -> u128;
+        }
+        nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintl(__x: u128) -> u128;
+        }
+        __nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundl(__x: u128) -> u128;
+        }
+        roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundl(__x: u128) -> u128;
+        }
+        __roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncl(__x: u128) -> u128;
+        }
+        truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncl(__x: u128) -> u128;
+        }
+        __truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquol(arg___x: u128, arg___y: u128, arg___quo: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquol(
+    arg___x: u128,
+    arg___y: u128,
+    arg___quo: *mut ::std::os::raw::c_int,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdiml(__x: u128, __y: u128) -> u128;
+        }
+        fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdiml(__x: u128, __y: u128) -> u128;
+        }
+        __fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        __fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminl(__x: u128, __y: u128) -> u128;
+        }
+        fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminl(__x: u128, __y: u128) -> u128;
+        }
+        __fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        __fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbl(__x: u128, __n: u128) -> u128;
+        }
+        scalbl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbl(__x: u128, __n: u128) -> u128;
+        }
+        __scalbl(arg___x, arg___n)
     })
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-impl Default for exception {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
+pub const FP_NAN: _bindgen_ty_8 = 0;
+pub const FP_INFINITE: _bindgen_ty_8 = 1;
+pub const FP_ZERO: _bindgen_ty_8 = 2;
+pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
+pub const FP_NORMAL: _bindgen_ty_8 = 4;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[track_caller]
+pub unsafe fn strlcat(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlcat(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
         }
-    }
+        strlcat(arg_dst, arg_src, arg_siz)
+    })
+}
+#[track_caller]
+pub unsafe fn strlcpy(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlcpy(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strlcpy(arg_dst, arg_src, arg_siz)
+    })
 }
 #[track_caller]
 pub unsafe fn pg_qsort(
@@ -13907,17 +14863,16 @@ pub unsafe fn wait_result_is_any_signal(
         wait_result_is_any_signal(arg_exit_status, arg_include_command_not_found)
     })
 }
-pub type jmp_buf = [::std::os::raw::c_int; 48usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 49usize];
-#[track_caller]
-pub unsafe fn longjmperror() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn longjmperror();
-        }
-        longjmperror()
-    })
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
 }
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[track_caller]
 pub unsafe fn errstart(
     arg_elevel: ::std::os::raw::c_int,
@@ -17922,390 +18877,147 @@ pub unsafe fn HeapTupleGetUpdateXid(arg_tuple: HeapTupleHeader) -> TransactionId
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
-#[track_caller]
-pub unsafe fn open(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        open(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn openat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn openat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        openat(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn creat(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: mode_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn creat(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: mode_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        creat(arg_arg1, arg_arg2)
-    })
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
 #[track_caller]
 pub unsafe fn fcntl(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fcntl(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        fcntl(arg_arg1, arg_arg2)
+        fcntl(arg___fd, arg___cmd)
     })
 }
 #[track_caller]
-pub unsafe fn openx_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: filesec_t,
+pub unsafe fn open(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openx_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: filesec_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        openx_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn open_dprotected_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open_dprotected_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn open(
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        open_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        open(arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_dprotected_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: ::std::os::raw::c_int,
+pub unsafe fn openat(
+    arg___fd: ::std::os::raw::c_int,
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_dprotected_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-                arg5: ::std::os::raw::c_int,
+            pub fn openat(
+                __fd: ::std::os::raw::c_int,
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        openat_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        openat(arg___fd, arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_authenticated_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
+pub unsafe fn creat(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___mode: mode_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_authenticated_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn creat(
+                __file: *const ::std::os::raw::c_char,
+                __mode: mode_t,
             ) -> ::std::os::raw::c_int;
         }
-        openat_authenticated_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        creat(arg___file, arg___mode)
     })
 }
 #[track_caller]
-pub unsafe fn flock(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn lockf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flock(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+            pub fn lockf(
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        flock(arg_arg1, arg_arg2)
+        lockf(arg___fd, arg___cmd, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_init() -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_init() -> filesec_t;
-        }
-        filesec_init()
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_dup(arg_arg1: filesec_t) -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-        }
-        filesec_dup(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_free(arg_arg1: filesec_t) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_free(arg1: filesec_t);
-        }
-        filesec_free(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_get_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_void,
+pub unsafe fn posix_fadvise(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
+    arg___advise: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_get_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_void,
+            pub fn posix_fadvise(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
+                __advise: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_get_property(arg_arg1, arg_arg2, arg_arg3)
+        posix_fadvise(arg___fd, arg___offset, arg___len, arg___advise)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_query_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_int,
+pub unsafe fn posix_fallocate(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_query_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_int,
+            pub fn posix_fallocate(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_query_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_set_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *const ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_set_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_set_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_unset_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_unset_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_unset_property(arg_arg1, arg_arg2)
+        posix_fallocate(arg___fd, arg___offset, arg___len)
     })
 }
 pub type XLogRecPtr = uint64;
@@ -20119,7 +20831,7 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
@@ -20130,26 +20842,11 @@ impl Default for tm {
         }
     }
 }
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[track_caller]
-pub unsafe fn asctime(arg_arg1: *const tm) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
-        }
-        asctime(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[track_caller]
 pub unsafe fn clock() -> clock_t {
@@ -20161,103 +20858,167 @@ pub unsafe fn clock() -> clock_t {
     })
 }
 #[track_caller]
-pub unsafe fn ctime(arg_arg1: *const time_t) -> *mut ::std::os::raw::c_char {
+pub unsafe fn time(arg___timer: *mut time_t) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+            pub fn time(__timer: *mut time_t) -> time_t;
         }
-        ctime(arg_arg1)
+        time(arg___timer)
     })
 }
 #[track_caller]
-pub unsafe fn difftime(arg_arg1: time_t, arg_arg2: time_t) -> f64 {
+pub unsafe fn difftime(arg___time1: time_t, arg___time0: time_t) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+            pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
         }
-        difftime(arg_arg1, arg_arg2)
+        difftime(arg___time1, arg___time0)
     })
 }
 #[track_caller]
-pub unsafe fn getdate(arg_arg1: *const ::std::os::raw::c_char) -> *mut tm {
+pub unsafe fn mktime(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+            pub fn mktime(__tp: *mut tm) -> time_t;
         }
-        getdate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gmtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gmtime(arg1: *const time_t) -> *mut tm;
-        }
-        gmtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime(arg1: *const time_t) -> *mut tm;
-        }
-        localtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mktime(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mktime(arg1: *mut tm) -> time_t;
-        }
-        mktime(arg_arg1)
+        mktime(arg___tp)
     })
 }
 #[track_caller]
 pub unsafe fn strftime(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const tm,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
 ) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strftime(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const tm,
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
             ) -> usize;
         }
-        strftime(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        strftime(arg___s, arg___maxsize, arg___format, arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn strptime(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut tm,
+pub unsafe fn strftime_l(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
+    arg___loc: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strftime_l(
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
+                __loc: locale_t,
+            ) -> usize;
+        }
+        strftime_l(arg___s, arg___maxsize, arg___format, arg___tp, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime(__timer: *const time_t) -> *mut tm;
+        }
+        gmtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime(__timer: *const time_t) -> *mut tm;
+        }
+        localtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        gmtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        localtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime(arg___tp: *const tm) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+        }
+        asctime(arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn ctime(arg___timer: *const time_t) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+        }
+        ctime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime_r(
+    arg___tp: *const tm,
+    arg___buf: *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strptime(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut tm,
+            pub fn asctime_r(
+                __tp: *const tm,
+                __buf: *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strptime(arg_arg1, arg_arg2, arg_arg3)
+        asctime_r(arg___tp, arg___buf)
     })
 }
 #[track_caller]
-pub unsafe fn time(arg_arg1: *mut time_t) -> time_t {
+pub unsafe fn ctime_r(
+    arg___timer: *const time_t,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn time(arg1: *mut time_t) -> time_t;
+            pub fn ctime_r(
+                __timer: *const time_t,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        time(arg_arg1)
+        ctime_r(arg___timer, arg___buf)
     })
+}
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[track_caller]
 pub unsafe fn tzset() {
@@ -20268,123 +21029,54 @@ pub unsafe fn tzset() {
         tzset()
     })
 }
+extern "C" {
+    pub static mut daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut timezone: ::std::os::raw::c_long;
+}
 #[track_caller]
-pub unsafe fn asctime_r(
-    arg_arg1: *const tm,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timegm(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asctime_r(
-                arg1: *const tm,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timegm(__tp: *mut tm) -> time_t;
         }
-        asctime_r(arg_arg1, arg_arg2)
+        timegm(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn ctime_r(
-    arg_arg1: *const time_t,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timelocal(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime_r(
-                arg1: *const time_t,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timelocal(__tp: *mut tm) -> time_t;
         }
-        ctime_r(arg_arg1, arg_arg2)
+        timelocal(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn gmtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
+pub unsafe fn dysize(arg___year: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+            pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        gmtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
-        }
-        localtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn posix2time(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix2time(arg1: time_t) -> time_t;
-        }
-        posix2time(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tzsetwall() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tzsetwall();
-        }
-        tzsetwall()
-    })
-}
-#[track_caller]
-pub unsafe fn time2posix(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn time2posix(arg1: time_t) -> time_t;
-        }
-        time2posix(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timelocal(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timelocal(arg1: *mut tm) -> time_t;
-        }
-        timelocal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timegm(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timegm(arg1: *mut tm) -> time_t;
-        }
-        timegm(arg_arg1)
+        dysize(arg___year)
     })
 }
 #[track_caller]
 pub unsafe fn nanosleep(
-    arg___rqtp: *const timespec,
-    arg___rmtp: *mut timespec,
+    arg___requested_time: *const timespec,
+    arg___remaining: *mut timespec,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn nanosleep(
-                __rqtp: *const timespec,
-                __rmtp: *mut timespec,
+                __requested_time: *const timespec,
+                __remaining: *mut timespec,
             ) -> ::std::os::raw::c_int;
         }
-        nanosleep(arg___rqtp, arg___rmtp)
+        nanosleep(arg___requested_time, arg___remaining)
     })
 }
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn clock_getres(
     arg___clock_id: clockid_t,
@@ -20416,15 +21108,6 @@ pub unsafe fn clock_gettime(
     })
 }
 #[track_caller]
-pub unsafe fn clock_gettime_nsec_np(arg___clock_id: clockid_t) -> __uint64_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-        }
-        clock_gettime_nsec_np(arg___clock_id)
-    })
-}
-#[track_caller]
 pub unsafe fn clock_settime(
     arg___clock_id: clockid_t,
     arg___tp: *const timespec,
@@ -20440,18 +21123,121 @@ pub unsafe fn clock_settime(
     })
 }
 #[track_caller]
+pub unsafe fn clock_nanosleep(
+    arg___clock_id: clockid_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___req: *const timespec,
+    arg___rem: *mut timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_nanosleep(
+                __clock_id: clockid_t,
+                __flags: ::std::os::raw::c_int,
+                __req: *const timespec,
+                __rem: *mut timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_nanosleep(arg___clock_id, arg___flags, arg___req, arg___rem)
+    })
+}
+#[track_caller]
+pub unsafe fn clock_getcpuclockid(
+    arg___pid: pid_t,
+    arg___clock_id: *mut clockid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_getcpuclockid(
+                __pid: pid_t,
+                __clock_id: *mut clockid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_getcpuclockid(arg___pid, arg___clock_id)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_create(
+    arg___clock_id: clockid_t,
+    arg___evp: *mut sigevent,
+    arg___timerid: *mut timer_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_create(
+                __clock_id: clockid_t,
+                __evp: *mut sigevent,
+                __timerid: *mut timer_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_create(arg___clock_id, arg___evp, arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_delete(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_delete(arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_settime(
+    arg___timerid: timer_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___value: *const itimerspec,
+    arg___ovalue: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_settime(
+                __timerid: timer_t,
+                __flags: ::std::os::raw::c_int,
+                __value: *const itimerspec,
+                __ovalue: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_settime(arg___timerid, arg___flags, arg___value, arg___ovalue)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_gettime(
+    arg___timerid: timer_t,
+    arg___value: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_gettime(
+                __timerid: timer_t,
+                __value: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_gettime(arg___timerid, arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_getoverrun(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_getoverrun(arg___timerid)
+    })
+}
+#[track_caller]
 pub unsafe fn timespec_get(
-    arg_ts: *mut timespec,
-    arg_base: ::std::os::raw::c_int,
+    arg___ts: *mut timespec,
+    arg___base: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn timespec_get(
-                ts: *mut timespec,
-                base: ::std::os::raw::c_int,
+                __ts: *mut timespec,
+                __base: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        timespec_get(arg_ts, arg_base)
+        timespec_get(arg___ts, arg___base)
     })
 }
 pub type instr_time = timespec;
@@ -21405,6 +22191,7 @@ pub struct SubPlan {
     pub args: *mut List,
     pub startup_cost: Cost,
     pub per_call_cost: Cost,
+    pub subLinkId: ::std::os::raw::c_int,
 }
 impl Default for SubPlan {
     fn default() -> Self {
@@ -23549,12 +24336,11 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
@@ -23565,146 +24351,119 @@ impl Default for dirent {
         }
     }
 }
+pub const DT_UNKNOWN: _bindgen_ty_9 = 0;
+pub const DT_FIFO: _bindgen_ty_9 = 1;
+pub const DT_CHR: _bindgen_ty_9 = 2;
+pub const DT_DIR: _bindgen_ty_9 = 4;
+pub const DT_BLK: _bindgen_ty_9 = 6;
+pub const DT_REG: _bindgen_ty_9 = 8;
+pub const DT_LNK: _bindgen_ty_9 = 10;
+pub const DT_SOCK: _bindgen_ty_9 = 12;
+pub const DT_WHT: _bindgen_ty_9 = 14;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type DIR = __dirstream;
 #[track_caller]
-pub unsafe fn closedir(arg_arg1: *mut DIR) -> ::std::os::raw::c_int {
+pub unsafe fn closedir(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+            pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        closedir(arg_arg1)
+        closedir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn opendir(arg_arg1: *const ::std::os::raw::c_char) -> *mut DIR {
+pub unsafe fn opendir(arg___name: *const ::std::os::raw::c_char) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+            pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
         }
-        opendir(arg_arg1)
+        opendir(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn readdir(arg_arg1: *mut DIR) -> *mut dirent {
+pub unsafe fn fdopendir(arg___fd: ::std::os::raw::c_int) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+            pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
         }
-        readdir(arg_arg1)
+        fdopendir(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn readdir(arg___dirp: *mut DIR) -> *mut dirent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+        }
+        readdir(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn readdir_r(
-    arg_arg1: *mut DIR,
-    arg_arg2: *mut dirent,
-    arg_arg3: *mut *mut dirent,
+    arg___dirp: *mut DIR,
+    arg___entry: *mut dirent,
+    arg___result: *mut *mut dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn readdir_r(
-                arg1: *mut DIR,
-                arg2: *mut dirent,
-                arg3: *mut *mut dirent,
+                __dirp: *mut DIR,
+                __entry: *mut dirent,
+                __result: *mut *mut dirent,
             ) -> ::std::os::raw::c_int;
         }
-        readdir_r(arg_arg1, arg_arg2, arg_arg3)
+        readdir_r(arg___dirp, arg___entry, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn rewinddir(arg_arg1: *mut DIR) {
+pub unsafe fn rewinddir(arg___dirp: *mut DIR) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rewinddir(arg1: *mut DIR);
+            pub fn rewinddir(__dirp: *mut DIR);
         }
-        rewinddir(arg_arg1)
+        rewinddir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn seekdir(arg_arg1: *mut DIR, arg_arg2: ::std::os::raw::c_long) {
+pub unsafe fn seekdir(arg___dirp: *mut DIR, arg___pos: ::std::os::raw::c_long) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+            pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
         }
-        seekdir(arg_arg1, arg_arg2)
+        seekdir(arg___dirp, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn telldir(arg_arg1: *mut DIR) -> ::std::os::raw::c_long {
+pub unsafe fn telldir(arg___dirp: *mut DIR) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+            pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
         }
-        telldir(arg_arg1)
+        telldir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn fdopendir(arg_arg1: ::std::os::raw::c_int) -> *mut DIR {
+pub unsafe fn dirfd(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+            pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        fdopendir(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn alphasort(
-    arg_arg1: *mut *const dirent,
-    arg_arg2: *mut *const dirent,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alphasort(
-                arg1: *mut *const dirent,
-                arg2: *mut *const dirent,
-            ) -> ::std::os::raw::c_int;
-        }
-        alphasort(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn dirfd(arg_dirp: *mut DIR) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-        }
-        dirfd(arg_dirp)
+        dirfd(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn scandir(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: ::std::option::Option<
+    arg___dir: *const ::std::os::raw::c_char,
+    arg___namelist: *mut *mut *mut dirent,
+    arg___selector: ::std::option::Option<
         unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
     >,
-    arg_arg4: ::std::option::Option<
+    arg___cmp: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut *const dirent,
             arg2: *mut *const dirent,
@@ -23714,12 +24473,12 @@ pub unsafe fn scandir(
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn scandir(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: ::std::option::Option<
+                __dir: *const ::std::os::raw::c_char,
+                __namelist: *mut *mut *mut dirent,
+                __selector: ::std::option::Option<
                     unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
                 >,
-                arg4: ::std::option::Option<
+                __cmp: ::std::option::Option<
                     unsafe extern "C" fn(
                         arg1: *mut *const dirent,
                         arg2: *mut *const dirent,
@@ -23727,61 +24486,41 @@ pub unsafe fn scandir(
                 >,
             ) -> ::std::os::raw::c_int;
         }
-        scandir(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        scandir(arg___dir, arg___namelist, arg___selector, arg___cmp)
     })
 }
 #[track_caller]
-pub unsafe fn scandir_b(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: *mut ::std::os::raw::c_void,
+pub unsafe fn alphasort(
+    arg___e1: *mut *const dirent,
+    arg___e2: *mut *const dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scandir_b(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: *mut ::std::os::raw::c_void,
+            pub fn alphasort(
+                __e1: *mut *const dirent,
+                __e2: *mut *const dirent,
             ) -> ::std::os::raw::c_int;
         }
-        scandir_b(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        alphasort(arg___e1, arg___e2)
     })
 }
 #[track_caller]
 pub unsafe fn getdirentries(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___nbytes: usize,
+    arg___basep: *mut __off_t,
+) -> __ssize_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
             pub fn getdirentries(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __nbytes: usize,
+                __basep: *mut __off_t,
+            ) -> __ssize_t;
         }
-        getdirentries(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __opendir2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut DIR {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __opendir2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut DIR;
-        }
-        __opendir2(arg_arg1, arg_arg2)
+        getdirentries(arg___fd, arg___buf, arg___nbytes, arg___basep)
     })
 }
 pub type File = ::std::os::raw::c_int;
@@ -24741,7 +25480,7 @@ pub unsafe fn reset_on_dsm_detach() {
         reset_on_dsm_detach()
     })
 }
-pub type slock_t = ::std::os::raw::c_int;
+pub type slock_t = ::std::os::raw::c_uchar;
 extern "C" {
     pub static mut dummy_spinlock: slock_t;
 }
@@ -26396,7 +27135,7 @@ pub unsafe fn tuplesort_restorepos(arg_state: *mut Tuplesortstate) {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct pg_atomic_flag {
-    pub value: ::std::os::raw::c_int,
+    pub value: ::std::os::raw::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -35210,356 +35949,943 @@ pub unsafe fn extract_variadic_args(
         )
     })
 }
-extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
 }
-extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+impl Default for sigval {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const SI_ASYNCNL: _bindgen_ty_10 = -60;
+pub const SI_DETHREAD: _bindgen_ty_10 = -7;
+pub const SI_TKILL: _bindgen_ty_10 = -6;
+pub const SI_SIGIO: _bindgen_ty_10 = -5;
+pub const SI_ASYNCIO: _bindgen_ty_10 = -4;
+pub const SI_MESGQ: _bindgen_ty_10 = -3;
+pub const SI_TIMER: _bindgen_ty_10 = -2;
+pub const SI_QUEUE: _bindgen_ty_10 = -1;
+pub const SI_USER: _bindgen_ty_10 = 0;
+pub const SI_KERNEL: _bindgen_ty_10 = 128;
+pub type _bindgen_ty_10 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: _bindgen_ty_11 = 1;
+pub const ILL_ILLOPN: _bindgen_ty_11 = 2;
+pub const ILL_ILLADR: _bindgen_ty_11 = 3;
+pub const ILL_ILLTRP: _bindgen_ty_11 = 4;
+pub const ILL_PRVOPC: _bindgen_ty_11 = 5;
+pub const ILL_PRVREG: _bindgen_ty_11 = 6;
+pub const ILL_COPROC: _bindgen_ty_11 = 7;
+pub const ILL_BADSTK: _bindgen_ty_11 = 8;
+pub const ILL_BADIADDR: _bindgen_ty_11 = 9;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: _bindgen_ty_12 = 1;
+pub const FPE_INTOVF: _bindgen_ty_12 = 2;
+pub const FPE_FLTDIV: _bindgen_ty_12 = 3;
+pub const FPE_FLTOVF: _bindgen_ty_12 = 4;
+pub const FPE_FLTUND: _bindgen_ty_12 = 5;
+pub const FPE_FLTRES: _bindgen_ty_12 = 6;
+pub const FPE_FLTINV: _bindgen_ty_12 = 7;
+pub const FPE_FLTSUB: _bindgen_ty_12 = 8;
+pub const FPE_FLTUNK: _bindgen_ty_12 = 14;
+pub const FPE_CONDTRAP: _bindgen_ty_12 = 15;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: _bindgen_ty_13 = 1;
+pub const SEGV_ACCERR: _bindgen_ty_13 = 2;
+pub const SEGV_BNDERR: _bindgen_ty_13 = 3;
+pub const SEGV_PKUERR: _bindgen_ty_13 = 4;
+pub const SEGV_ACCADI: _bindgen_ty_13 = 5;
+pub const SEGV_ADIDERR: _bindgen_ty_13 = 6;
+pub const SEGV_ADIPERR: _bindgen_ty_13 = 7;
+pub const SEGV_MTEAERR: _bindgen_ty_13 = 8;
+pub const SEGV_MTESERR: _bindgen_ty_13 = 9;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: _bindgen_ty_14 = 1;
+pub const BUS_ADRERR: _bindgen_ty_14 = 2;
+pub const BUS_OBJERR: _bindgen_ty_14 = 3;
+pub const BUS_MCEERR_AR: _bindgen_ty_14 = 4;
+pub const BUS_MCEERR_AO: _bindgen_ty_14 = 5;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: _bindgen_ty_15 = 1;
+pub const CLD_KILLED: _bindgen_ty_15 = 2;
+pub const CLD_DUMPED: _bindgen_ty_15 = 3;
+pub const CLD_TRAPPED: _bindgen_ty_15 = 4;
+pub const CLD_STOPPED: _bindgen_ty_15 = 5;
+pub const CLD_CONTINUED: _bindgen_ty_15 = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub const POLL_IN: _bindgen_ty_16 = 1;
+pub const POLL_OUT: _bindgen_ty_16 = 2;
+pub const POLL_MSG: _bindgen_ty_16 = 3;
+pub const POLL_ERR: _bindgen_ty_16 = 4;
+pub const POLL_PRI: _bindgen_ty_16 = 5;
+pub const POLL_HUP: _bindgen_ty_16 = 6;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: _bindgen_ty_17 = 0;
+pub const SIGEV_NONE: _bindgen_ty_17 = 1;
+pub const SIGEV_THREAD: _bindgen_ty_17 = 2;
+pub const SIGEV_THREAD_ID: _bindgen_ty_17 = 4;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[track_caller]
-pub unsafe fn raise(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __sysv_signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __sysv_signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        raise(arg_arg1)
+        __sysv_signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn bsd_signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bsd_signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        bsd_signal(arg_arg1, arg_arg2)
+        signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn kill(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn kill(arg___pid: __pid_t, arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        kill(arg_arg1, arg_arg2)
+        kill(arg___pid, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn killpg(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        killpg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pthread_kill(
-    arg_arg1: pthread_t,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn killpg(
+    arg___pgrp: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_kill(
-                arg1: pthread_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_kill(arg_arg1, arg_arg2)
+        killpg(arg___pgrp, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn pthread_sigmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
-) -> ::std::os::raw::c_int {
+pub unsafe fn raise(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_sigmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
-            ) -> ::std::os::raw::c_int;
+            pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_sigmask(arg_arg1, arg_arg2, arg_arg3)
+        raise(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn sigaction(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigaction,
-    arg_arg3: *mut sigaction,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ssignal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigaction(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigaction,
-                arg3: *mut sigaction,
-            ) -> ::std::os::raw::c_int;
+            pub fn ssignal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        sigaction(arg_arg1, arg_arg2, arg_arg3)
+        ssignal(arg___sig, arg___handler)
+    })
+}
+#[track_caller]
+pub unsafe fn gsignal(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        gsignal(arg___sig)
+    })
+}
+#[track_caller]
+pub unsafe fn psignal(arg___sig: ::std::os::raw::c_int, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
+        }
+        psignal(arg___sig, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn psiginfo(arg___pinfo: *const siginfo_t, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
+        }
+        psiginfo(arg___pinfo, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn sigblock(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigblock(arg___mask)
+    })
+}
+#[track_caller]
+pub unsafe fn sigsetmask(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigsetmask(arg___mask)
+    })
+}
+pub type sig_t = __sighandler_t;
+#[track_caller]
+pub unsafe fn sigemptyset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigemptyset(arg___set)
+    })
+}
+#[track_caller]
+pub unsafe fn sigfillset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigfillset(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigaddset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigaddset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigaddset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigaltstack(
-    arg_arg1: *const stack_t,
-    arg_arg2: *mut stack_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
-        }
-        sigaltstack(arg_arg1, arg_arg2)
+        sigaddset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigdelset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigdelset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigdelset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigemptyset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigemptyset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigfillset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigfillset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sighold(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sighold(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigignore(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigignore(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn siginterrupt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn siginterrupt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        siginterrupt(arg_arg1, arg_arg2)
+        sigdelset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigismember(
-    arg_arg1: *const sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigismember(
-                arg1: *const sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigismember(arg_arg1, arg_arg2)
+        sigismember(arg___set, arg___signo)
     })
 }
-#[track_caller]
-pub unsafe fn sigpause(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigpause(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
 }
-#[track_caller]
-pub unsafe fn sigpending(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        sigpending(arg_arg1)
-    })
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[track_caller]
 pub unsafe fn sigprocmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
+    arg___how: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___oset: *mut sigset_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigprocmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
+                __how: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __oset: *mut sigset_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigprocmask(arg_arg1, arg_arg2, arg_arg3)
+        sigprocmask(arg___how, arg___set, arg___oset)
     })
 }
 #[track_caller]
-pub unsafe fn sigrelse(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn sigsuspend(arg___set: *const sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
         }
-        sigrelse(arg_arg1)
+        sigsuspend(arg___set)
     })
 }
 #[track_caller]
-pub unsafe fn sigset(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn sigaction(
+    arg___sig: ::std::os::raw::c_int,
+    arg___act: *const sigaction,
+    arg___oact: *mut sigaction,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigset(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn sigaction(
+                __sig: ::std::os::raw::c_int,
+                __act: *const sigaction,
+                __oact: *mut sigaction,
+            ) -> ::std::os::raw::c_int;
         }
-        sigset(arg_arg1, arg_arg2)
+        sigaction(arg___sig, arg___act, arg___oact)
     })
 }
 #[track_caller]
-pub unsafe fn sigsuspend(arg_arg1: *const sigset_t) -> ::std::os::raw::c_int {
+pub unsafe fn sigpending(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+            pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
         }
-        sigsuspend(arg_arg1)
+        sigpending(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigwait(
-    arg_arg1: *const sigset_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___sig: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigwait(
-                arg1: *const sigset_t,
-                arg2: *mut ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __sig: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigwait(arg_arg1, arg_arg2)
+        sigwait(arg___set, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn psignal(arg_arg1: ::std::os::raw::c_uint, arg_arg2: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
-        }
-        psignal(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigblock(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigblock(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigsetmask(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigsetmask(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigvec(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sigvec,
-    arg_arg3: *mut sigvec,
+pub unsafe fn sigwaitinfo(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigvec(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sigvec,
-                arg3: *mut sigvec,
+            pub fn sigwaitinfo(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigvec(arg_arg1, arg_arg2, arg_arg3)
+        sigwaitinfo(arg___set, arg___info)
+    })
+}
+#[track_caller]
+pub unsafe fn sigtimedwait(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
+    arg___timeout: *const timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigtimedwait(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
+                __timeout: *const timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigtimedwait(arg___set, arg___info, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn sigqueue(
+    arg___pid: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
+    arg___val: sigval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigqueue(
+                __pid: __pid_t,
+                __sig: ::std::os::raw::c_int,
+                __val: sigval,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigqueue(arg___pid, arg___sig, arg___val)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn siginterrupt(
+    arg___sig: ::std::os::raw::c_int,
+    arg___interrupt: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn siginterrupt(
+                __sig: ::std::os::raw::c_int,
+                __interrupt: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        siginterrupt(arg___sig, arg___interrupt)
+    })
+}
+pub const SS_ONSTACK: _bindgen_ty_18 = 1;
+pub const SS_DISABLE: _bindgen_ty_18 = 2;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[track_caller]
+pub unsafe fn sigaltstack(
+    arg___ss: *const stack_t,
+    arg___oss: *mut stack_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+        }
+        sigaltstack(arg___ss, arg___oss)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn pthread_sigmask(
+    arg___how: ::std::os::raw::c_int,
+    arg___newmask: *const __sigset_t,
+    arg___oldmask: *mut __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_sigmask(
+                __how: ::std::os::raw::c_int,
+                __newmask: *const __sigset_t,
+                __oldmask: *mut __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_sigmask(arg___how, arg___newmask, arg___oldmask)
+    })
+}
+#[track_caller]
+pub unsafe fn pthread_kill(
+    arg___threadid: pthread_t,
+    arg___signo: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_kill(
+                __threadid: pthread_t,
+                __signo: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_kill(arg___threadid, arg___signo)
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmin() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmin()
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmax() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmax()
     })
 }
 pub type pg_time_t = int64;
@@ -36574,9 +37900,8 @@ pub unsafe fn CancelBackup() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -36671,20 +37996,46 @@ pub const RmgrIds_RM_NEXT_ID: RmgrIds = 22;
 pub type RmgrIds = ::std::os::raw::c_uint;
 pub type pg_crc32c = uint32;
 #[track_caller]
-pub unsafe fn pg_comp_crc32c_armv8(
+pub unsafe fn pg_comp_crc32c_sb8(
     arg_crc: pg_crc32c,
     arg_data: *const ::std::os::raw::c_void,
     arg_len: usize,
 ) -> pg_crc32c {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pg_comp_crc32c_armv8(
+            pub fn pg_comp_crc32c_sb8(
                 crc: pg_crc32c,
                 data: *const ::std::os::raw::c_void,
                 len: usize,
             ) -> pg_crc32c;
         }
-        pg_comp_crc32c_armv8(arg_crc, arg_data, arg_len)
+        pg_comp_crc32c_sb8(arg_crc, arg_data, arg_len)
+    })
+}
+extern "C" {
+    pub static mut pg_comp_crc32c: ::std::option::Option<
+        unsafe extern "C" fn(
+            crc: pg_crc32c,
+            data: *const ::std::os::raw::c_void,
+            len: usize,
+        ) -> pg_crc32c,
+    >;
+}
+#[track_caller]
+pub unsafe fn pg_comp_crc32c_sse42(
+    arg_crc: pg_crc32c,
+    arg_data: *const ::std::os::raw::c_void,
+    arg_len: usize,
+) -> pg_crc32c {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pg_comp_crc32c_sse42(
+                crc: pg_crc32c,
+                data: *const ::std::os::raw::c_void,
+                len: usize,
+            ) -> pg_crc32c;
+        }
+        pg_comp_crc32c_sse42(arg_crc, arg_data, arg_len)
     })
 }
 pub const ForkNumber_InvalidForkNumber: ForkNumber = -1;
@@ -103949,8 +105300,29 @@ pub unsafe fn make_empty_range(arg_typcache: *mut TypeCacheEntry) -> *mut RangeT
         make_empty_range(arg_typcache)
     })
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+impl Default for __va_list_tag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AttrMissing {
@@ -104026,2436 +105398,2842 @@ pub struct RowSecurityDesc {
 pub struct SnapBuild {
     pub _address: u8,
 }
+impl pg_sys::seal::Sealed for A_ArrayExpr {}
 impl pg_sys::PgNode for A_ArrayExpr {}
 impl std::fmt::Display for A_ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Const {}
 impl pg_sys::PgNode for A_Const {}
 impl std::fmt::Display for A_Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Expr {}
 impl pg_sys::PgNode for A_Expr {}
 impl std::fmt::Display for A_Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indices {}
 impl pg_sys::PgNode for A_Indices {}
 impl std::fmt::Display for A_Indices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indirection {}
 impl pg_sys::PgNode for A_Indirection {}
 impl std::fmt::Display for A_Indirection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Star {}
 impl pg_sys::PgNode for A_Star {}
 impl std::fmt::Display for A_Star {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AccessPriv {}
 impl pg_sys::PgNode for AccessPriv {}
 impl std::fmt::Display for AccessPriv {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Agg {}
 impl pg_sys::PgNode for Agg {}
 impl std::fmt::Display for Agg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggPath {}
 impl pg_sys::PgNode for AggPath {}
 impl std::fmt::Display for AggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggState {}
 impl pg_sys::PgNode for AggState {}
 impl std::fmt::Display for AggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Aggref {}
 impl pg_sys::PgNode for Aggref {}
 impl std::fmt::Display for Aggref {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggrefExprState {}
 impl pg_sys::PgNode for AggrefExprState {}
 impl std::fmt::Display for AggrefExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Alias {}
 impl pg_sys::PgNode for Alias {}
 impl std::fmt::Display for Alias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterCollationStmt {}
 impl pg_sys::PgNode for AlterCollationStmt {}
 impl std::fmt::Display for AlterCollationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseSetStmt {}
 impl pg_sys::PgNode for AlterDatabaseSetStmt {}
 impl std::fmt::Display for AlterDatabaseSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseStmt {}
 impl pg_sys::PgNode for AlterDatabaseStmt {}
 impl std::fmt::Display for AlterDatabaseStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDefaultPrivilegesStmt {}
 impl pg_sys::PgNode for AlterDefaultPrivilegesStmt {}
 impl std::fmt::Display for AlterDefaultPrivilegesStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDomainStmt {}
 impl pg_sys::PgNode for AlterDomainStmt {}
 impl std::fmt::Display for AlterDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEnumStmt {}
 impl pg_sys::PgNode for AlterEnumStmt {}
 impl std::fmt::Display for AlterEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEventTrigStmt {}
 impl pg_sys::PgNode for AlterEventTrigStmt {}
 impl std::fmt::Display for AlterEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionContentsStmt {}
 impl pg_sys::PgNode for AlterExtensionContentsStmt {}
 impl std::fmt::Display for AlterExtensionContentsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionStmt {}
 impl pg_sys::PgNode for AlterExtensionStmt {}
 impl std::fmt::Display for AlterExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFdwStmt {}
 impl pg_sys::PgNode for AlterFdwStmt {}
 impl std::fmt::Display for AlterFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterForeignServerStmt {}
 impl pg_sys::PgNode for AlterForeignServerStmt {}
 impl std::fmt::Display for AlterForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFunctionStmt {}
 impl pg_sys::PgNode for AlterFunctionStmt {}
 impl std::fmt::Display for AlterFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectDependsStmt {}
 impl pg_sys::PgNode for AlterObjectDependsStmt {}
 impl std::fmt::Display for AlterObjectDependsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectSchemaStmt {}
 impl pg_sys::PgNode for AlterObjectSchemaStmt {}
 impl std::fmt::Display for AlterObjectSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOpFamilyStmt {}
 impl pg_sys::PgNode for AlterOpFamilyStmt {}
 impl std::fmt::Display for AlterOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOperatorStmt {}
 impl pg_sys::PgNode for AlterOperatorStmt {}
 impl std::fmt::Display for AlterOperatorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOwnerStmt {}
 impl pg_sys::PgNode for AlterOwnerStmt {}
 impl std::fmt::Display for AlterOwnerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPolicyStmt {}
 impl pg_sys::PgNode for AlterPolicyStmt {}
 impl std::fmt::Display for AlterPolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPublicationStmt {}
 impl pg_sys::PgNode for AlterPublicationStmt {}
 impl std::fmt::Display for AlterPublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleSetStmt {}
 impl pg_sys::PgNode for AlterRoleSetStmt {}
 impl std::fmt::Display for AlterRoleSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleStmt {}
 impl pg_sys::PgNode for AlterRoleStmt {}
 impl std::fmt::Display for AlterRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSeqStmt {}
 impl pg_sys::PgNode for AlterSeqStmt {}
 impl std::fmt::Display for AlterSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSubscriptionStmt {}
 impl pg_sys::PgNode for AlterSubscriptionStmt {}
 impl std::fmt::Display for AlterSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSystemStmt {}
 impl pg_sys::PgNode for AlterSystemStmt {}
 impl std::fmt::Display for AlterSystemStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSConfigurationStmt {}
 impl pg_sys::PgNode for AlterTSConfigurationStmt {}
 impl std::fmt::Display for AlterTSConfigurationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSDictionaryStmt {}
 impl pg_sys::PgNode for AlterTSDictionaryStmt {}
 impl std::fmt::Display for AlterTSDictionaryStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableCmd {}
 impl pg_sys::PgNode for AlterTableCmd {}
 impl std::fmt::Display for AlterTableCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableMoveAllStmt {}
 impl pg_sys::PgNode for AlterTableMoveAllStmt {}
 impl std::fmt::Display for AlterTableMoveAllStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableSpaceOptionsStmt {}
 impl pg_sys::PgNode for AlterTableSpaceOptionsStmt {}
 impl std::fmt::Display for AlterTableSpaceOptionsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableStmt {}
 impl pg_sys::PgNode for AlterTableStmt {}
 impl std::fmt::Display for AlterTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterUserMappingStmt {}
 impl pg_sys::PgNode for AlterUserMappingStmt {}
 impl std::fmt::Display for AlterUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlan {}
 impl pg_sys::PgNode for AlternativeSubPlan {}
 impl std::fmt::Display for AlternativeSubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlanState {}
 impl pg_sys::PgNode for AlternativeSubPlanState {}
 impl std::fmt::Display for AlternativeSubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Append {}
 impl pg_sys::PgNode for Append {}
 impl std::fmt::Display for Append {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendPath {}
 impl pg_sys::PgNode for AppendPath {}
 impl std::fmt::Display for AppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendRelInfo {}
 impl pg_sys::PgNode for AppendRelInfo {}
 impl std::fmt::Display for AppendRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendState {}
 impl pg_sys::PgNode for AppendState {}
 impl std::fmt::Display for AppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayCoerceExpr {}
 impl pg_sys::PgNode for ArrayCoerceExpr {}
 impl std::fmt::Display for ArrayCoerceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayExpr {}
 impl pg_sys::PgNode for ArrayExpr {}
 impl std::fmt::Display for ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BaseBackupCmd {}
 impl pg_sys::PgNode for BaseBackupCmd {}
 impl std::fmt::Display for BaseBackupCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAnd {}
 impl pg_sys::PgNode for BitmapAnd {}
 impl std::fmt::Display for BitmapAnd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndPath {}
 impl pg_sys::PgNode for BitmapAndPath {}
 impl std::fmt::Display for BitmapAndPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndState {}
 impl pg_sys::PgNode for BitmapAndState {}
 impl std::fmt::Display for BitmapAndState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapPath {}
 impl pg_sys::PgNode for BitmapHeapPath {}
 impl std::fmt::Display for BitmapHeapPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScan {}
 impl pg_sys::PgNode for BitmapHeapScan {}
 impl std::fmt::Display for BitmapHeapScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScanState {}
 impl pg_sys::PgNode for BitmapHeapScanState {}
 impl std::fmt::Display for BitmapHeapScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScan {}
 impl pg_sys::PgNode for BitmapIndexScan {}
 impl std::fmt::Display for BitmapIndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScanState {}
 impl pg_sys::PgNode for BitmapIndexScanState {}
 impl std::fmt::Display for BitmapIndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOr {}
 impl pg_sys::PgNode for BitmapOr {}
 impl std::fmt::Display for BitmapOr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrPath {}
 impl pg_sys::PgNode for BitmapOrPath {}
 impl std::fmt::Display for BitmapOrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrState {}
 impl pg_sys::PgNode for BitmapOrState {}
 impl std::fmt::Display for BitmapOrState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BoolExpr {}
 impl pg_sys::PgNode for BoolExpr {}
 impl std::fmt::Display for BoolExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BooleanTest {}
 impl pg_sys::PgNode for BooleanTest {}
 impl std::fmt::Display for BooleanTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BufferHeapTupleTableSlot {}
 impl pg_sys::PgNode for BufferHeapTupleTableSlot {}
 impl std::fmt::Display for BufferHeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallContext {}
 impl pg_sys::PgNode for CallContext {}
 impl std::fmt::Display for CallContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallStmt {}
 impl pg_sys::PgNode for CallStmt {}
 impl std::fmt::Display for CallStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseExpr {}
 impl pg_sys::PgNode for CaseExpr {}
 impl std::fmt::Display for CaseExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseTestExpr {}
 impl pg_sys::PgNode for CaseTestExpr {}
 impl std::fmt::Display for CaseTestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseWhen {}
 impl pg_sys::PgNode for CaseWhen {}
 impl std::fmt::Display for CaseWhen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CheckPointStmt {}
 impl pg_sys::PgNode for CheckPointStmt {}
 impl std::fmt::Display for CheckPointStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClosePortalStmt {}
 impl pg_sys::PgNode for ClosePortalStmt {}
 impl std::fmt::Display for ClosePortalStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClusterStmt {}
 impl pg_sys::PgNode for ClusterStmt {}
 impl std::fmt::Display for ClusterStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoalesceExpr {}
 impl pg_sys::PgNode for CoalesceExpr {}
 impl std::fmt::Display for CoalesceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomain {}
 impl pg_sys::PgNode for CoerceToDomain {}
 impl std::fmt::Display for CoerceToDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomainValue {}
 impl pg_sys::PgNode for CoerceToDomainValue {}
 impl std::fmt::Display for CoerceToDomainValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceViaIO {}
 impl pg_sys::PgNode for CoerceViaIO {}
 impl std::fmt::Display for CoerceViaIO {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateClause {}
 impl pg_sys::PgNode for CollateClause {}
 impl std::fmt::Display for CollateClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateExpr {}
 impl pg_sys::PgNode for CollateExpr {}
 impl std::fmt::Display for CollateExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnDef {}
 impl pg_sys::PgNode for ColumnDef {}
 impl std::fmt::Display for ColumnDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnRef {}
 impl pg_sys::PgNode for ColumnRef {}
 impl std::fmt::Display for ColumnRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommentStmt {}
 impl pg_sys::PgNode for CommentStmt {}
 impl std::fmt::Display for CommentStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommonTableExpr {}
 impl pg_sys::PgNode for CommonTableExpr {}
 impl std::fmt::Display for CommonTableExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CompositeTypeStmt {}
 impl pg_sys::PgNode for CompositeTypeStmt {}
 impl std::fmt::Display for CompositeTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Const {}
 impl pg_sys::PgNode for Const {}
 impl std::fmt::Display for Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Constraint {}
 impl pg_sys::PgNode for Constraint {}
 impl std::fmt::Display for Constraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConstraintsSetStmt {}
 impl pg_sys::PgNode for ConstraintsSetStmt {}
 impl std::fmt::Display for ConstraintsSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConvertRowtypeExpr {}
 impl pg_sys::PgNode for ConvertRowtypeExpr {}
 impl std::fmt::Display for ConvertRowtypeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CopyStmt {}
 impl pg_sys::PgNode for CopyStmt {}
 impl std::fmt::Display for CopyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateAmStmt {}
 impl pg_sys::PgNode for CreateAmStmt {}
 impl std::fmt::Display for CreateAmStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateCastStmt {}
 impl pg_sys::PgNode for CreateCastStmt {}
 impl std::fmt::Display for CreateCastStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateConversionStmt {}
 impl pg_sys::PgNode for CreateConversionStmt {}
 impl std::fmt::Display for CreateConversionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateDomainStmt {}
 impl pg_sys::PgNode for CreateDomainStmt {}
 impl std::fmt::Display for CreateDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEnumStmt {}
 impl pg_sys::PgNode for CreateEnumStmt {}
 impl std::fmt::Display for CreateEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEventTrigStmt {}
 impl pg_sys::PgNode for CreateEventTrigStmt {}
 impl std::fmt::Display for CreateEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateExtensionStmt {}
 impl pg_sys::PgNode for CreateExtensionStmt {}
 impl std::fmt::Display for CreateExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFdwStmt {}
 impl pg_sys::PgNode for CreateFdwStmt {}
 impl std::fmt::Display for CreateFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignServerStmt {}
 impl pg_sys::PgNode for CreateForeignServerStmt {}
 impl std::fmt::Display for CreateForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignTableStmt {}
 impl pg_sys::PgNode for CreateForeignTableStmt {}
 impl std::fmt::Display for CreateForeignTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFunctionStmt {}
 impl pg_sys::PgNode for CreateFunctionStmt {}
 impl std::fmt::Display for CreateFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassItem {}
 impl pg_sys::PgNode for CreateOpClassItem {}
 impl std::fmt::Display for CreateOpClassItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassStmt {}
 impl pg_sys::PgNode for CreateOpClassStmt {}
 impl std::fmt::Display for CreateOpClassStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpFamilyStmt {}
 impl pg_sys::PgNode for CreateOpFamilyStmt {}
 impl std::fmt::Display for CreateOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePLangStmt {}
 impl pg_sys::PgNode for CreatePLangStmt {}
 impl std::fmt::Display for CreatePLangStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePolicyStmt {}
 impl pg_sys::PgNode for CreatePolicyStmt {}
 impl std::fmt::Display for CreatePolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePublicationStmt {}
 impl pg_sys::PgNode for CreatePublicationStmt {}
 impl std::fmt::Display for CreatePublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRangeStmt {}
 impl pg_sys::PgNode for CreateRangeStmt {}
 impl std::fmt::Display for CreateRangeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateReplicationSlotCmd {}
 impl pg_sys::PgNode for CreateReplicationSlotCmd {}
 impl std::fmt::Display for CreateReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRoleStmt {}
 impl pg_sys::PgNode for CreateRoleStmt {}
 impl std::fmt::Display for CreateRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSchemaStmt {}
 impl pg_sys::PgNode for CreateSchemaStmt {}
 impl std::fmt::Display for CreateSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSeqStmt {}
 impl pg_sys::PgNode for CreateSeqStmt {}
 impl std::fmt::Display for CreateSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStatsStmt {}
 impl pg_sys::PgNode for CreateStatsStmt {}
 impl std::fmt::Display for CreateStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStmt {}
 impl pg_sys::PgNode for CreateStmt {}
 impl std::fmt::Display for CreateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSubscriptionStmt {}
 impl pg_sys::PgNode for CreateSubscriptionStmt {}
 impl std::fmt::Display for CreateSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableAsStmt {}
 impl pg_sys::PgNode for CreateTableAsStmt {}
 impl std::fmt::Display for CreateTableAsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableSpaceStmt {}
 impl pg_sys::PgNode for CreateTableSpaceStmt {}
 impl std::fmt::Display for CreateTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTransformStmt {}
 impl pg_sys::PgNode for CreateTransformStmt {}
 impl std::fmt::Display for CreateTransformStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTrigStmt {}
 impl pg_sys::PgNode for CreateTrigStmt {}
 impl std::fmt::Display for CreateTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateUserMappingStmt {}
 impl pg_sys::PgNode for CreateUserMappingStmt {}
 impl std::fmt::Display for CreateUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatedbStmt {}
 impl pg_sys::PgNode for CreatedbStmt {}
 impl std::fmt::Display for CreatedbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScan {}
 impl pg_sys::PgNode for CteScan {}
 impl std::fmt::Display for CteScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScanState {}
 impl pg_sys::PgNode for CteScanState {}
 impl std::fmt::Display for CteScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CurrentOfExpr {}
 impl pg_sys::PgNode for CurrentOfExpr {}
 impl std::fmt::Display for CurrentOfExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomPath {}
 impl pg_sys::PgNode for CustomPath {}
 impl std::fmt::Display for CustomPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScan {}
 impl pg_sys::PgNode for CustomScan {}
 impl std::fmt::Display for CustomScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScanState {}
 impl pg_sys::PgNode for CustomScanState {}
 impl std::fmt::Display for CustomScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeallocateStmt {}
 impl pg_sys::PgNode for DeallocateStmt {}
 impl std::fmt::Display for DeallocateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeclareCursorStmt {}
 impl pg_sys::PgNode for DeclareCursorStmt {}
 impl std::fmt::Display for DeclareCursorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefElem {}
 impl pg_sys::PgNode for DefElem {}
 impl std::fmt::Display for DefElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefineStmt {}
 impl pg_sys::PgNode for DefineStmt {}
 impl std::fmt::Display for DefineStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeleteStmt {}
 impl pg_sys::PgNode for DeleteStmt {}
 impl std::fmt::Display for DeleteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DiscardStmt {}
 impl pg_sys::PgNode for DiscardStmt {}
 impl std::fmt::Display for DiscardStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DoStmt {}
 impl pg_sys::PgNode for DoStmt {}
 impl std::fmt::Display for DoStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DomainConstraintState {}
 impl pg_sys::PgNode for DomainConstraintState {}
 impl std::fmt::Display for DomainConstraintState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropOwnedStmt {}
 impl pg_sys::PgNode for DropOwnedStmt {}
 impl std::fmt::Display for DropOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropReplicationSlotCmd {}
 impl pg_sys::PgNode for DropReplicationSlotCmd {}
 impl std::fmt::Display for DropReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropRoleStmt {}
 impl pg_sys::PgNode for DropRoleStmt {}
 impl std::fmt::Display for DropRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropStmt {}
 impl pg_sys::PgNode for DropStmt {}
 impl std::fmt::Display for DropStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropSubscriptionStmt {}
 impl pg_sys::PgNode for DropSubscriptionStmt {}
 impl std::fmt::Display for DropSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropTableSpaceStmt {}
 impl pg_sys::PgNode for DropTableSpaceStmt {}
 impl std::fmt::Display for DropTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropUserMappingStmt {}
 impl pg_sys::PgNode for DropUserMappingStmt {}
 impl std::fmt::Display for DropUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropdbStmt {}
 impl pg_sys::PgNode for DropdbStmt {}
 impl std::fmt::Display for DropdbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EState {}
 impl pg_sys::PgNode for EState {}
 impl std::fmt::Display for EState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceClass {}
 impl pg_sys::PgNode for EquivalenceClass {}
 impl std::fmt::Display for EquivalenceClass {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceMember {}
 impl pg_sys::PgNode for EquivalenceMember {}
 impl std::fmt::Display for EquivalenceMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EventTriggerData {}
 impl pg_sys::PgNode for EventTriggerData {}
 impl std::fmt::Display for EventTriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExecuteStmt {}
 impl pg_sys::PgNode for ExecuteStmt {}
 impl std::fmt::Display for ExecuteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExplainStmt {}
 impl pg_sys::PgNode for ExplainStmt {}
 impl std::fmt::Display for ExplainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Expr {}
 impl pg_sys::PgNode for Expr {}
 impl std::fmt::Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprContext {}
 impl pg_sys::PgNode for ExprContext {}
 impl std::fmt::Display for ExprContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprState {}
 impl pg_sys::PgNode for ExprState {}
 impl std::fmt::Display for ExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExtensibleNode {}
 impl pg_sys::PgNode for ExtensibleNode {}
 impl std::fmt::Display for ExtensibleNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FdwRoutine {}
 impl pg_sys::PgNode for FdwRoutine {}
 impl std::fmt::Display for FdwRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FetchStmt {}
 impl pg_sys::PgNode for FetchStmt {}
 impl std::fmt::Display for FetchStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldSelect {}
 impl pg_sys::PgNode for FieldSelect {}
 impl std::fmt::Display for FieldSelect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldStore {}
 impl pg_sys::PgNode for FieldStore {}
 impl std::fmt::Display for FieldStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyCacheInfo {}
 impl pg_sys::PgNode for ForeignKeyCacheInfo {}
 impl std::fmt::Display for ForeignKeyCacheInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyOptInfo {}
 impl pg_sys::PgNode for ForeignKeyOptInfo {}
 impl std::fmt::Display for ForeignKeyOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignPath {}
 impl pg_sys::PgNode for ForeignPath {}
 impl std::fmt::Display for ForeignPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScan {}
 impl pg_sys::PgNode for ForeignScan {}
 impl std::fmt::Display for ForeignScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScanState {}
 impl pg_sys::PgNode for ForeignScanState {}
 impl std::fmt::Display for ForeignScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FromExpr {}
 impl pg_sys::PgNode for FromExpr {}
 impl std::fmt::Display for FromExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncCall {}
 impl pg_sys::PgNode for FuncCall {}
 impl std::fmt::Display for FuncCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncExpr {}
 impl pg_sys::PgNode for FuncExpr {}
 impl std::fmt::Display for FuncExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionParameter {}
 impl pg_sys::PgNode for FunctionParameter {}
 impl std::fmt::Display for FunctionParameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScan {}
 impl pg_sys::PgNode for FunctionScan {}
 impl std::fmt::Display for FunctionScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScanState {}
 impl pg_sys::PgNode for FunctionScanState {}
 impl std::fmt::Display for FunctionScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Gather {}
 impl pg_sys::PgNode for Gather {}
 impl std::fmt::Display for Gather {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMerge {}
 impl pg_sys::PgNode for GatherMerge {}
 impl std::fmt::Display for GatherMerge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergePath {}
 impl pg_sys::PgNode for GatherMergePath {}
 impl std::fmt::Display for GatherMergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergeState {}
 impl pg_sys::PgNode for GatherMergeState {}
 impl std::fmt::Display for GatherMergeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherPath {}
 impl pg_sys::PgNode for GatherPath {}
 impl std::fmt::Display for GatherPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherState {}
 impl pg_sys::PgNode for GatherState {}
 impl std::fmt::Display for GatherState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantRoleStmt {}
 impl pg_sys::PgNode for GrantRoleStmt {}
 impl std::fmt::Display for GrantRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantStmt {}
 impl pg_sys::PgNode for GrantStmt {}
 impl std::fmt::Display for GrantStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Group {}
 impl pg_sys::PgNode for Group {}
 impl std::fmt::Display for Group {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupPath {}
 impl pg_sys::PgNode for GroupPath {}
 impl std::fmt::Display for GroupPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupResultPath {}
 impl pg_sys::PgNode for GroupResultPath {}
 impl std::fmt::Display for GroupResultPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupState {}
 impl pg_sys::PgNode for GroupState {}
 impl std::fmt::Display for GroupState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingFunc {}
 impl pg_sys::PgNode for GroupingFunc {}
 impl std::fmt::Display for GroupingFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSet {}
 impl pg_sys::PgNode for GroupingSet {}
 impl std::fmt::Display for GroupingSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetData {}
 impl pg_sys::PgNode for GroupingSetData {}
 impl std::fmt::Display for GroupingSetData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetsPath {}
 impl pg_sys::PgNode for GroupingSetsPath {}
 impl std::fmt::Display for GroupingSetsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Hash {}
 impl pg_sys::PgNode for Hash {}
 impl std::fmt::Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoin {}
 impl pg_sys::PgNode for HashJoin {}
 impl std::fmt::Display for HashJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoinState {}
 impl pg_sys::PgNode for HashJoinState {}
 impl std::fmt::Display for HashJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashPath {}
 impl pg_sys::PgNode for HashPath {}
 impl std::fmt::Display for HashPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashState {}
 impl pg_sys::PgNode for HashState {}
 impl std::fmt::Display for HashState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HeapTupleTableSlot {}
 impl pg_sys::PgNode for HeapTupleTableSlot {}
 impl std::fmt::Display for HeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IdentifySystemCmd {}
 impl pg_sys::PgNode for IdentifySystemCmd {}
 impl std::fmt::Display for IdentifySystemCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ImportForeignSchemaStmt {}
 impl pg_sys::PgNode for ImportForeignSchemaStmt {}
 impl std::fmt::Display for ImportForeignSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexAmRoutine {}
 impl pg_sys::PgNode for IndexAmRoutine {}
 impl std::fmt::Display for IndexAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexClause {}
 impl pg_sys::PgNode for IndexClause {}
 impl std::fmt::Display for IndexClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexElem {}
 impl pg_sys::PgNode for IndexElem {}
 impl std::fmt::Display for IndexElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexInfo {}
 impl pg_sys::PgNode for IndexInfo {}
 impl std::fmt::Display for IndexInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScan {}
 impl pg_sys::PgNode for IndexOnlyScan {}
 impl std::fmt::Display for IndexOnlyScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScanState {}
 impl pg_sys::PgNode for IndexOnlyScanState {}
 impl std::fmt::Display for IndexOnlyScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOptInfo {}
 impl pg_sys::PgNode for IndexOptInfo {}
 impl std::fmt::Display for IndexOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexPath {}
 impl pg_sys::PgNode for IndexPath {}
 impl std::fmt::Display for IndexPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScan {}
 impl pg_sys::PgNode for IndexScan {}
 impl std::fmt::Display for IndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScanState {}
 impl pg_sys::PgNode for IndexScanState {}
 impl std::fmt::Display for IndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexStmt {}
 impl pg_sys::PgNode for IndexStmt {}
 impl std::fmt::Display for IndexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferClause {}
 impl pg_sys::PgNode for InferClause {}
 impl std::fmt::Display for InferClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferenceElem {}
 impl pg_sys::PgNode for InferenceElem {}
 impl std::fmt::Display for InferenceElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InlineCodeBlock {}
 impl pg_sys::PgNode for InlineCodeBlock {}
 impl std::fmt::Display for InlineCodeBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InsertStmt {}
 impl pg_sys::PgNode for InsertStmt {}
 impl std::fmt::Display for InsertStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IntoClause {}
 impl pg_sys::PgNode for IntoClause {}
 impl std::fmt::Display for IntoClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Join {}
 impl pg_sys::PgNode for Join {}
 impl std::fmt::Display for Join {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinExpr {}
 impl pg_sys::PgNode for JoinExpr {}
 impl std::fmt::Display for JoinExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinPath {}
 impl pg_sys::PgNode for JoinPath {}
 impl std::fmt::Display for JoinPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinState {}
 impl pg_sys::PgNode for JoinState {}
 impl std::fmt::Display for JoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JunkFilter {}
 impl pg_sys::PgNode for JunkFilter {}
 impl std::fmt::Display for JunkFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Limit {}
 impl pg_sys::PgNode for Limit {}
 impl std::fmt::Display for Limit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitPath {}
 impl pg_sys::PgNode for LimitPath {}
 impl std::fmt::Display for LimitPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitState {}
 impl pg_sys::PgNode for LimitState {}
 impl std::fmt::Display for LimitState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for List {}
 impl pg_sys::PgNode for List {}
 impl std::fmt::Display for List {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ListenStmt {}
 impl pg_sys::PgNode for ListenStmt {}
 impl std::fmt::Display for ListenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LoadStmt {}
 impl pg_sys::PgNode for LoadStmt {}
 impl std::fmt::Display for LoadStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRows {}
 impl pg_sys::PgNode for LockRows {}
 impl std::fmt::Display for LockRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsPath {}
 impl pg_sys::PgNode for LockRowsPath {}
 impl std::fmt::Display for LockRowsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsState {}
 impl pg_sys::PgNode for LockRowsState {}
 impl std::fmt::Display for LockRowsState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockStmt {}
 impl pg_sys::PgNode for LockStmt {}
 impl std::fmt::Display for LockStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockingClause {}
 impl pg_sys::PgNode for LockingClause {}
 impl std::fmt::Display for LockingClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Material {}
 impl pg_sys::PgNode for Material {}
 impl std::fmt::Display for Material {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialPath {}
 impl pg_sys::PgNode for MaterialPath {}
 impl std::fmt::Display for MaterialPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialState {}
 impl pg_sys::PgNode for MaterialState {}
 impl std::fmt::Display for MaterialState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoryContextData {}
 impl pg_sys::PgNode for MemoryContextData {}
 impl std::fmt::Display for MemoryContextData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppend {}
 impl pg_sys::PgNode for MergeAppend {}
 impl std::fmt::Display for MergeAppend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendPath {}
 impl pg_sys::PgNode for MergeAppendPath {}
 impl std::fmt::Display for MergeAppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendState {}
 impl pg_sys::PgNode for MergeAppendState {}
 impl std::fmt::Display for MergeAppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoin {}
 impl pg_sys::PgNode for MergeJoin {}
 impl std::fmt::Display for MergeJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoinState {}
 impl pg_sys::PgNode for MergeJoinState {}
 impl std::fmt::Display for MergeJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergePath {}
 impl pg_sys::PgNode for MergePath {}
 impl std::fmt::Display for MergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggInfo {}
 impl pg_sys::PgNode for MinMaxAggInfo {}
 impl std::fmt::Display for MinMaxAggInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggPath {}
 impl pg_sys::PgNode for MinMaxAggPath {}
 impl std::fmt::Display for MinMaxAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxExpr {}
 impl pg_sys::PgNode for MinMaxExpr {}
 impl std::fmt::Display for MinMaxExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinimalTupleTableSlot {}
 impl pg_sys::PgNode for MinimalTupleTableSlot {}
 impl std::fmt::Display for MinimalTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTable {}
 impl pg_sys::PgNode for ModifyTable {}
 impl std::fmt::Display for ModifyTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTablePath {}
 impl pg_sys::PgNode for ModifyTablePath {}
 impl std::fmt::Display for ModifyTablePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTableState {}
 impl pg_sys::PgNode for ModifyTableState {}
 impl std::fmt::Display for ModifyTableState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MultiAssignRef {}
 impl pg_sys::PgNode for MultiAssignRef {}
 impl std::fmt::Display for MultiAssignRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedArgExpr {}
 impl pg_sys::PgNode for NamedArgExpr {}
 impl std::fmt::Display for NamedArgExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScan {}
 impl pg_sys::PgNode for NamedTuplestoreScan {}
 impl std::fmt::Display for NamedTuplestoreScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScanState {}
 impl pg_sys::PgNode for NamedTuplestoreScanState {}
 impl std::fmt::Display for NamedTuplestoreScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoop {}
 impl pg_sys::PgNode for NestLoop {}
 impl std::fmt::Display for NestLoop {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopParam {}
 impl pg_sys::PgNode for NestLoopParam {}
 impl std::fmt::Display for NestLoopParam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopState {}
 impl pg_sys::PgNode for NestLoopState {}
 impl std::fmt::Display for NestLoopState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NextValueExpr {}
 impl pg_sys::PgNode for NextValueExpr {}
 impl std::fmt::Display for NextValueExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Node {}
 impl pg_sys::PgNode for Node {}
 impl std::fmt::Display for Node {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NotifyStmt {}
 impl pg_sys::PgNode for NotifyStmt {}
 impl std::fmt::Display for NotifyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NullTest {}
 impl pg_sys::PgNode for NullTest {}
 impl std::fmt::Display for NullTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ObjectWithArgs {}
 impl pg_sys::PgNode for ObjectWithArgs {}
 impl std::fmt::Display for ObjectWithArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictClause {}
 impl pg_sys::PgNode for OnConflictClause {}
 impl std::fmt::Display for OnConflictClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictExpr {}
 impl pg_sys::PgNode for OnConflictExpr {}
 impl std::fmt::Display for OnConflictExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictSetState {}
 impl pg_sys::PgNode for OnConflictSetState {}
 impl std::fmt::Display for OnConflictSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OpExpr {}
 impl pg_sys::PgNode for OpExpr {}
 impl std::fmt::Display for OpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Param {}
 impl pg_sys::PgNode for Param {}
 impl std::fmt::Display for Param {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamPathInfo {}
 impl pg_sys::PgNode for ParamPathInfo {}
 impl std::fmt::Display for ParamPathInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamRef {}
 impl pg_sys::PgNode for ParamRef {}
 impl std::fmt::Display for ParamRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionBoundSpec {}
 impl pg_sys::PgNode for PartitionBoundSpec {}
 impl std::fmt::Display for PartitionBoundSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionCmd {}
 impl pg_sys::PgNode for PartitionCmd {}
 impl std::fmt::Display for PartitionCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionElem {}
 impl pg_sys::PgNode for PartitionElem {}
 impl std::fmt::Display for PartitionElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneInfo {}
 impl pg_sys::PgNode for PartitionPruneInfo {}
 impl std::fmt::Display for PartitionPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStep {}
 impl pg_sys::PgNode for PartitionPruneStep {}
 impl std::fmt::Display for PartitionPruneStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepCombine {}
 impl pg_sys::PgNode for PartitionPruneStepCombine {}
 impl std::fmt::Display for PartitionPruneStepCombine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepOp {}
 impl pg_sys::PgNode for PartitionPruneStepOp {}
 impl std::fmt::Display for PartitionPruneStepOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionRangeDatum {}
 impl pg_sys::PgNode for PartitionRangeDatum {}
 impl std::fmt::Display for PartitionRangeDatum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionSpec {}
 impl pg_sys::PgNode for PartitionSpec {}
 impl std::fmt::Display for PartitionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionedRelPruneInfo {}
 impl pg_sys::PgNode for PartitionedRelPruneInfo {}
 impl std::fmt::Display for PartitionedRelPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Path {}
 impl pg_sys::PgNode for Path {}
 impl std::fmt::Display for Path {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathKey {}
 impl pg_sys::PgNode for PathKey {}
 impl std::fmt::Display for PathKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathTarget {}
 impl pg_sys::PgNode for PathTarget {}
 impl std::fmt::Display for PathTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderInfo {}
 impl pg_sys::PgNode for PlaceHolderInfo {}
 impl std::fmt::Display for PlaceHolderInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderVar {}
 impl pg_sys::PgNode for PlaceHolderVar {}
 impl std::fmt::Display for PlaceHolderVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Plan {}
 impl pg_sys::PgNode for Plan {}
 impl std::fmt::Display for Plan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanInvalItem {}
 impl pg_sys::PgNode for PlanInvalItem {}
 impl std::fmt::Display for PlanInvalItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanRowMark {}
 impl pg_sys::PgNode for PlanRowMark {}
 impl std::fmt::Display for PlanRowMark {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanState {}
 impl pg_sys::PgNode for PlanState {}
 impl std::fmt::Display for PlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannedStmt {}
 impl pg_sys::PgNode for PlannedStmt {}
 impl std::fmt::Display for PlannedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerGlobal {}
 impl pg_sys::PgNode for PlannerGlobal {}
 impl std::fmt::Display for PlannerGlobal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerInfo {}
 impl pg_sys::PgNode for PlannerInfo {}
 impl std::fmt::Display for PlannerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerParamItem {}
 impl pg_sys::PgNode for PlannerParamItem {}
 impl std::fmt::Display for PlannerParamItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PrepareStmt {}
 impl pg_sys::PgNode for PrepareStmt {}
 impl std::fmt::Display for PrepareStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSet {}
 impl pg_sys::PgNode for ProjectSet {}
 impl std::fmt::Display for ProjectSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetPath {}
 impl pg_sys::PgNode for ProjectSetPath {}
 impl std::fmt::Display for ProjectSetPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetState {}
 impl pg_sys::PgNode for ProjectSetState {}
 impl std::fmt::Display for ProjectSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionInfo {}
 impl pg_sys::PgNode for ProjectionInfo {}
 impl std::fmt::Display for ProjectionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionPath {}
 impl pg_sys::PgNode for ProjectionPath {}
 impl std::fmt::Display for ProjectionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Query {}
 impl pg_sys::PgNode for Query {}
 impl std::fmt::Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeFunction {}
 impl pg_sys::PgNode for RangeFunction {}
 impl std::fmt::Display for RangeFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeSubselect {}
 impl pg_sys::PgNode for RangeSubselect {}
 impl std::fmt::Display for RangeSubselect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFunc {}
 impl pg_sys::PgNode for RangeTableFunc {}
 impl std::fmt::Display for RangeTableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFuncCol {}
 impl pg_sys::PgNode for RangeTableFuncCol {}
 impl std::fmt::Display for RangeTableFuncCol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableSample {}
 impl pg_sys::PgNode for RangeTableSample {}
 impl std::fmt::Display for RangeTableSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblEntry {}
 impl pg_sys::PgNode for RangeTblEntry {}
 impl std::fmt::Display for RangeTblEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblFunction {}
 impl pg_sys::PgNode for RangeTblFunction {}
 impl std::fmt::Display for RangeTblFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblRef {}
 impl pg_sys::PgNode for RangeTblRef {}
 impl std::fmt::Display for RangeTblRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeVar {}
 impl pg_sys::PgNode for RangeVar {}
 impl std::fmt::Display for RangeVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RawStmt {}
 impl pg_sys::PgNode for RawStmt {}
 impl std::fmt::Display for RawStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReassignOwnedStmt {}
 impl pg_sys::PgNode for ReassignOwnedStmt {}
 impl std::fmt::Display for ReassignOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnion {}
 impl pg_sys::PgNode for RecursiveUnion {}
 impl std::fmt::Display for RecursiveUnion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionPath {}
 impl pg_sys::PgNode for RecursiveUnionPath {}
 impl std::fmt::Display for RecursiveUnionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionState {}
 impl pg_sys::PgNode for RecursiveUnionState {}
 impl std::fmt::Display for RecursiveUnionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RefreshMatViewStmt {}
 impl pg_sys::PgNode for RefreshMatViewStmt {}
 impl std::fmt::Display for RefreshMatViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReindexStmt {}
 impl pg_sys::PgNode for ReindexStmt {}
 impl std::fmt::Display for ReindexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelOptInfo {}
 impl pg_sys::PgNode for RelOptInfo {}
 impl std::fmt::Display for RelOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelabelType {}
 impl pg_sys::PgNode for RelabelType {}
 impl std::fmt::Display for RelabelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RenameStmt {}
 impl pg_sys::PgNode for RenameStmt {}
 impl std::fmt::Display for RenameStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReplicaIdentityStmt {}
 impl pg_sys::PgNode for ReplicaIdentityStmt {}
 impl std::fmt::Display for ReplicaIdentityStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResTarget {}
 impl pg_sys::PgNode for ResTarget {}
 impl std::fmt::Display for ResTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RestrictInfo {}
 impl pg_sys::PgNode for RestrictInfo {}
 impl std::fmt::Display for RestrictInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Result {}
 impl pg_sys::PgNode for Result {}
 impl std::fmt::Display for Result {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultRelInfo {}
 impl pg_sys::PgNode for ResultRelInfo {}
 impl std::fmt::Display for ResultRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultState {}
 impl pg_sys::PgNode for ResultState {}
 impl std::fmt::Display for ResultState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReturnSetInfo {}
 impl pg_sys::PgNode for ReturnSetInfo {}
 impl std::fmt::Display for ReturnSetInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RoleSpec {}
 impl pg_sys::PgNode for RoleSpec {}
 impl std::fmt::Display for RoleSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RollupData {}
 impl pg_sys::PgNode for RollupData {}
 impl std::fmt::Display for RollupData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowCompareExpr {}
 impl pg_sys::PgNode for RowCompareExpr {}
 impl std::fmt::Display for RowCompareExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowExpr {}
 impl pg_sys::PgNode for RowExpr {}
 impl std::fmt::Display for RowExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowMarkClause {}
 impl pg_sys::PgNode for RowMarkClause {}
 impl std::fmt::Display for RowMarkClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RuleStmt {}
 impl pg_sys::PgNode for RuleStmt {}
 impl std::fmt::Display for RuleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLCmd {}
 impl pg_sys::PgNode for SQLCmd {}
 impl std::fmt::Display for SQLCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLValueFunction {}
 impl pg_sys::PgNode for SQLValueFunction {}
 impl std::fmt::Display for SQLValueFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScan {}
 impl pg_sys::PgNode for SampleScan {}
 impl std::fmt::Display for SampleScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScanState {}
 impl pg_sys::PgNode for SampleScanState {}
 impl std::fmt::Display for SampleScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScalarArrayOpExpr {}
 impl pg_sys::PgNode for ScalarArrayOpExpr {}
 impl std::fmt::Display for ScalarArrayOpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Scan {}
 impl pg_sys::PgNode for Scan {}
 impl std::fmt::Display for Scan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScanState {}
 impl pg_sys::PgNode for ScanState {}
 impl std::fmt::Display for ScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SecLabelStmt {}
 impl pg_sys::PgNode for SecLabelStmt {}
 impl std::fmt::Display for SecLabelStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SelectStmt {}
 impl pg_sys::PgNode for SelectStmt {}
 impl std::fmt::Display for SelectStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SeqScanState {}
 impl pg_sys::PgNode for SeqScanState {}
 impl std::fmt::Display for SeqScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetExprState {}
 impl pg_sys::PgNode for SetExprState {}
 impl std::fmt::Display for SetExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOp {}
 impl pg_sys::PgNode for SetOp {}
 impl std::fmt::Display for SetOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpPath {}
 impl pg_sys::PgNode for SetOpPath {}
 impl std::fmt::Display for SetOpPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpState {}
 impl pg_sys::PgNode for SetOpState {}
 impl std::fmt::Display for SetOpState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOperationStmt {}
 impl pg_sys::PgNode for SetOperationStmt {}
 impl std::fmt::Display for SetOperationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetToDefault {}
 impl pg_sys::PgNode for SetToDefault {}
 impl std::fmt::Display for SetToDefault {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Sort {}
 impl pg_sys::PgNode for Sort {}
 impl std::fmt::Display for Sort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortBy {}
 impl pg_sys::PgNode for SortBy {}
 impl std::fmt::Display for SortBy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortGroupClause {}
 impl pg_sys::PgNode for SortGroupClause {}
 impl std::fmt::Display for SortGroupClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortPath {}
 impl pg_sys::PgNode for SortPath {}
 impl std::fmt::Display for SortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortState {}
 impl pg_sys::PgNode for SortState {}
 impl std::fmt::Display for SortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SpecialJoinInfo {}
 impl pg_sys::PgNode for SpecialJoinInfo {}
 impl std::fmt::Display for SpecialJoinInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StartReplicationCmd {}
 impl pg_sys::PgNode for StartReplicationCmd {}
 impl std::fmt::Display for StartReplicationCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StatisticExtInfo {}
 impl pg_sys::PgNode for StatisticExtInfo {}
 impl std::fmt::Display for StatisticExtInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubLink {}
 impl pg_sys::PgNode for SubLink {}
 impl std::fmt::Display for SubLink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlan {}
 impl pg_sys::PgNode for SubPlan {}
 impl std::fmt::Display for SubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlanState {}
 impl pg_sys::PgNode for SubPlanState {}
 impl std::fmt::Display for SubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScan {}
 impl pg_sys::PgNode for SubqueryScan {}
 impl std::fmt::Display for SubqueryScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanPath {}
 impl pg_sys::PgNode for SubqueryScanPath {}
 impl std::fmt::Display for SubqueryScanPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanState {}
 impl pg_sys::PgNode for SubqueryScanState {}
 impl std::fmt::Display for SubqueryScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubscriptingRef {}
 impl pg_sys::PgNode for SubscriptingRef {}
 impl std::fmt::Display for SubscriptingRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestCost {}
 impl pg_sys::PgNode for SupportRequestCost {}
 impl std::fmt::Display for SupportRequestCost {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestIndexCondition {}
 impl pg_sys::PgNode for SupportRequestIndexCondition {}
 impl std::fmt::Display for SupportRequestIndexCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestRows {}
 impl pg_sys::PgNode for SupportRequestRows {}
 impl std::fmt::Display for SupportRequestRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSelectivity {}
 impl pg_sys::PgNode for SupportRequestSelectivity {}
 impl std::fmt::Display for SupportRequestSelectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSimplify {}
 impl pg_sys::PgNode for SupportRequestSimplify {}
 impl std::fmt::Display for SupportRequestSimplify {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableAmRoutine {}
 impl pg_sys::PgNode for TableAmRoutine {}
 impl std::fmt::Display for TableAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFunc {}
 impl pg_sys::PgNode for TableFunc {}
 impl std::fmt::Display for TableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScan {}
 impl pg_sys::PgNode for TableFuncScan {}
 impl std::fmt::Display for TableFuncScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScanState {}
 impl pg_sys::PgNode for TableFuncScanState {}
 impl std::fmt::Display for TableFuncScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableLikeClause {}
 impl pg_sys::PgNode for TableLikeClause {}
 impl std::fmt::Display for TableLikeClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableSampleClause {}
 impl pg_sys::PgNode for TableSampleClause {}
 impl std::fmt::Display for TableSampleClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TargetEntry {}
 impl pg_sys::PgNode for TargetEntry {}
 impl std::fmt::Display for TargetEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidPath {}
 impl pg_sys::PgNode for TidPath {}
 impl std::fmt::Display for TidPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScan {}
 impl pg_sys::PgNode for TidScan {}
 impl std::fmt::Display for TidScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScanState {}
 impl pg_sys::PgNode for TidScanState {}
 impl std::fmt::Display for TidScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TimeLineHistoryCmd {}
 impl pg_sys::PgNode for TimeLineHistoryCmd {}
 impl std::fmt::Display for TimeLineHistoryCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TransactionStmt {}
 impl pg_sys::PgNode for TransactionStmt {}
 impl std::fmt::Display for TransactionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerData {}
 impl pg_sys::PgNode for TriggerData {}
 impl std::fmt::Display for TriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerTransition {}
 impl pg_sys::PgNode for TriggerTransition {}
 impl std::fmt::Display for TriggerTransition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TruncateStmt {}
 impl pg_sys::PgNode for TruncateStmt {}
 impl std::fmt::Display for TruncateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TupleTableSlot {}
 impl pg_sys::PgNode for TupleTableSlot {}
 impl std::fmt::Display for TupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeCast {}
 impl pg_sys::PgNode for TypeCast {}
 impl std::fmt::Display for TypeCast {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeName {}
 impl pg_sys::PgNode for TypeName {}
 impl std::fmt::Display for TypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Unique {}
 impl pg_sys::PgNode for Unique {}
 impl std::fmt::Display for Unique {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniquePath {}
 impl pg_sys::PgNode for UniquePath {}
 impl std::fmt::Display for UniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniqueState {}
 impl pg_sys::PgNode for UniqueState {}
 impl std::fmt::Display for UniqueState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UnlistenStmt {}
 impl pg_sys::PgNode for UnlistenStmt {}
 impl std::fmt::Display for UnlistenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpdateStmt {}
 impl pg_sys::PgNode for UpdateStmt {}
 impl std::fmt::Display for UpdateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpperUniquePath {}
 impl pg_sys::PgNode for UpperUniquePath {}
 impl std::fmt::Display for UpperUniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumRelation {}
 impl pg_sys::PgNode for VacuumRelation {}
 impl std::fmt::Display for VacuumRelation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumStmt {}
 impl pg_sys::PgNode for VacuumStmt {}
 impl std::fmt::Display for VacuumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Value {}
 impl pg_sys::PgNode for Value {}
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScan {}
 impl pg_sys::PgNode for ValuesScan {}
 impl std::fmt::Display for ValuesScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScanState {}
 impl pg_sys::PgNode for ValuesScanState {}
 impl std::fmt::Display for ValuesScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Var {}
 impl pg_sys::PgNode for Var {}
 impl std::fmt::Display for Var {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableSetStmt {}
 impl pg_sys::PgNode for VariableSetStmt {}
 impl std::fmt::Display for VariableSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableShowStmt {}
 impl pg_sys::PgNode for VariableShowStmt {}
 impl std::fmt::Display for VariableShowStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ViewStmt {}
 impl pg_sys::PgNode for ViewStmt {}
 impl std::fmt::Display for ViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VirtualTupleTableSlot {}
 impl pg_sys::PgNode for VirtualTupleTableSlot {}
 impl std::fmt::Display for VirtualTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAgg {}
 impl pg_sys::PgNode for WindowAgg {}
 impl std::fmt::Display for WindowAgg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggPath {}
 impl pg_sys::PgNode for WindowAggPath {}
 impl std::fmt::Display for WindowAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggState {}
 impl pg_sys::PgNode for WindowAggState {}
 impl std::fmt::Display for WindowAggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowClause {}
 impl pg_sys::PgNode for WindowClause {}
 impl std::fmt::Display for WindowClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowDef {}
 impl pg_sys::PgNode for WindowDef {}
 impl std::fmt::Display for WindowDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFunc {}
 impl pg_sys::PgNode for WindowFunc {}
 impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFuncExprState {}
 impl pg_sys::PgNode for WindowFuncExprState {}
 impl std::fmt::Display for WindowFuncExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithCheckOption {}
 impl pg_sys::PgNode for WithCheckOption {}
 impl std::fmt::Display for WithCheckOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithClause {}
 impl pg_sys::PgNode for WithClause {}
 impl std::fmt::Display for WithClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScan {}
 impl pg_sys::PgNode for WorkTableScan {}
 impl std::fmt::Display for WorkTableScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScanState {}
 impl pg_sys::PgNode for WorkTableScanState {}
 impl std::fmt::Display for WorkTableScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlExpr {}
 impl pg_sys::PgNode for XmlExpr {}
 impl std::fmt::Display for XmlExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlSerialize {}
 impl pg_sys::PgNode for XmlSerialize {}
 impl std::fmt::Display for XmlSerialize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -164,30 +164,29 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 107usize] = b" '--prefix=/Users/e_ridge/.pgx/13.8/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 106usize] = b" '--prefix=/home/atelier/.pgx/13.9/pgx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_BACKTRACE_SYMBOLS: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
-pub const HAVE_COPYFILE: u32 = 1;
-pub const HAVE_COPYFILE_H: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_EXECINFO_H: u32 = 1;
+pub const HAVE_EXPLICIT_BZERO: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -197,11 +196,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -210,10 +209,8 @@ pub const HAVE_IFADDRS_H: u32 = 1;
 pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
-pub const HAVE_KQUEUE: u32 = 1;
 pub const HAVE_LANGINFO_H: u32 = 1;
 pub const HAVE_LIBM: u32 = 1;
 pub const HAVE_LIBREADLINE: u32 = 1;
@@ -221,17 +218,17 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LINK: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
-pub const HAVE_MEMSET_S: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
 pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
+pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
@@ -240,7 +237,11 @@ pub const HAVE_READLINE_READLINE_H: u32 = 1;
 pub const HAVE_READLINK: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
+pub const HAVE_RL_COMPLETION_SUPPRESS_QUOTE: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTE_CHARACTERS: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTING_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETENV: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
@@ -249,11 +250,10 @@ pub const HAVE_SRANDOM: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
+pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -261,33 +261,30 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_UN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EVENT_H: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
+pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
 pub const HAVE_USELOCALE: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
+pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP16: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP32: u32 = 1;
@@ -300,25 +297,26 @@ pub const HAVE__BUILTIN_OP_OVERFLOW: u32 = 1;
 pub const HAVE__BUILTIN_POPCOUNT: u32 = 1;
 pub const HAVE__BUILTIN_TYPES_COMPATIBLE_P: u32 = 1;
 pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
+pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &[u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 13.8\0";
+pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 13.9\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28usize] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5usize] = b"13.8\0";
+pub const PACKAGE_VERSION: &[u8; 5usize] = b"13.9\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"13\0";
 pub const PG_MAJORVERSION_NUM: u32 = 13;
-pub const PG_MINORVERSION_NUM: u32 = 8;
+pub const PG_MINORVERSION_NUM: u32 = 9;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5usize] = b"13.8\0";
-pub const PG_VERSION_NUM: u32 = 130008;
-pub const PG_VERSION_STR : & [u8 ; 112usize] = b"PostgreSQL 13.8 on arm-apple-darwin22.1.0, compiled by Apple clang version 14.0.0 (clang-1400.0.29.202), 64-bit\0" ;
+pub const PG_VERSION: &[u8; 5usize] = b"13.9\0";
+pub const PG_VERSION_NUM: u32 = 130009;
+pub const PG_VERSION_STR: &[u8; 77usize] =
+    b"PostgreSQL 13.9 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -326,13 +324,11 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
-pub const USE_ARMV8_CRC32C: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
+pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -348,566 +344,214 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &[u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &[u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_13_0: u32 = 130000;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 130000;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 36;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
+pub const P_tmpdir: &[u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -918,7 +562,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -942,92 +586,151 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4usize] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4usize] = b"%lu\0";
 pub const HAVE_INT128: u32 = 1;
@@ -1053,376 +756,366 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &[u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &[u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &[u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_PRIMARY_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const SO_RESOLVER_SIGNATURE: u32 = 4401;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MCTP: u32 = 45;
+pub const PF_MAX: u32 = 46;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MCTP: u32 = 45;
+pub const AF_MAX: u32 = 46;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_NETNS_COOKIE: u32 = 71;
+pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_RECVERR_RFC4884: u32 = 26;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_RECVERR_RFC4884: u32 = 31;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1434,285 +1127,68 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &[u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_ULA_USETEMPADDR: u32 = 51;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &[u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &[u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &[u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &[u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &[u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &[u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &[u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &[u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &[u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &[u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &[u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &[u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &[u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &[u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &[u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &[u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &[u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 13.8\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 13.9\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1726,13 +1202,9 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 48;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
+pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1802,162 +1274,136 @@ pub const LP_DEAD: u32 = 3;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const O_EXEC: u32 = 1073741824;
-pub const O_SEARCH: u32 = 1074790400;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const AT_SYMLINK_NOFOLLOW_ANY: u32 = 2048;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const O_DP_AUTHENTICATE: u32 = 4;
-pub const AUTH_OPEN_NOAUTHFD: i32 = -1;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const F_SETLEASE: u32 = 106;
-pub const F_GETLEASE: u32 = 107;
-pub const F_TRANSFEREXTENTS: u32 = 110;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_ALLOCATEPERSIST: u32 = 8;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstBootstrapObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -2261,7 +1707,24 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ISNULL: u32 = 4;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ARGS: u32 = 6;
 pub const PG_MAGIC_FUNCTION_NAME_STRING: &[u8; 14usize] = b"Pg_magic_func\0";
@@ -2310,121 +1773,84 @@ pub const OUTER_VAR: u32 = 65001;
 pub const INDEX_VAR: u32 = 65002;
 pub const PRS2_OLD_VARNO: u32 = 1;
 pub const PRS2_NEW_VARNO: u32 = 2;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
 pub const DSM_IMPL_WINDOWS: u32 = 3;
@@ -2455,25 +1881,9 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const SHARED_TUPLESTORE_SINGLE_PASS: u32 = 1;
@@ -2587,7 +1997,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 32;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 64;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 128;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 256;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const REINDEXOPT_VERBOSE: u32 = 1;
 pub const REINDEXOPT_REPORT_PROGRESS: u32 = 2;
 pub const MaxAllocHugeSize: u32 = 0;
@@ -2606,6 +2015,85 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2624,13 +2112,7 @@ pub const MAXTZLEN: u32 = 10;
 pub const SECURITY_LOCAL_USERID_CHANGE: u32 = 1;
 pub const SECURITY_RESTRICTED_OPERATION: u32 = 2;
 pub const SECURITY_NOFORCE_RLS: u32 = 4;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const SM_DATABASE: u32 = 64;
 pub const SM_USER: u32 = 32;
 pub const SM_DATABASE_USER: u32 = 97;
@@ -2820,7 +2302,6 @@ pub const F_HAS_GARBAGE: u32 = 16;
 pub const GIST_PAGE_ID: u32 = 65409;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const EA_MAGIC: u32 = 689375833;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3837,22 +3318,95 @@ pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
@@ -3863,45 +3417,13 @@ impl Default for __mbstate_t {
         }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
 }
-impl Default for __darwin_pthread_handler_rec {
+impl Default for _G_fpos_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3910,13 +3432,14 @@ impl Default for __darwin_pthread_handler_rec {
         }
     }
 }
+pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
 }
-impl Default for _opaque_pthread_attr_t {
+impl Default for _G_fpos64_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3925,241 +3448,59 @@ impl Default for _opaque_pthread_attr_t {
         }
     }
 }
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[track_caller]
-pub unsafe fn renameat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameat(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn renamex_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renamex_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renamex_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn renameatx_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameatx_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameatx_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -4168,327 +3509,24 @@ impl Default for __sFILE {
         }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
-}
-extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stdout: *mut FILE;
+}
+extern "C" {
+    pub static mut stderr: *mut FILE;
 }
 #[track_caller]
-pub unsafe fn clearerr(arg_arg1: *mut FILE) {
+pub unsafe fn remove(arg___filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn clearerr(arg1: *mut FILE);
+            pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        clearerr(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn feof(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        feof(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ferror(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        ferror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fflush(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fflush(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fgetc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetpos(arg_arg1: *mut FILE, arg_arg2: *mut fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-        }
-        fgetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fgets(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut FILE,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgets(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut FILE,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fgets(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fopen(
-    arg___filename: *const ::std::os::raw::c_char,
-    arg___mode: *const ::std::os::raw::c_char,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fopen(
-                __filename: *const ::std::os::raw::c_char,
-                __mode: *const ::std::os::raw::c_char,
-            ) -> *mut FILE;
-        }
-        fopen(arg___filename, arg___mode)
-    })
-}
-#[track_caller]
-pub unsafe fn fprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fputc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputs(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputs(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut FILE,
-            ) -> ::std::os::raw::c_int;
-        }
-        fputs(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fread(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fread(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fread(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn freopen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut FILE,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freopen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut FILE,
-            ) -> *mut FILE;
-        }
-        freopen(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fscanf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fseek(
-    arg_arg1: *mut FILE,
-    arg_arg2: ::std::os::raw::c_long,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fseek(
-                arg1: *mut FILE,
-                arg2: ::std::os::raw::c_long,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        fseek(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fsetpos(arg_arg1: *mut FILE, arg_arg2: *const fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-        }
-        fsetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn ftell(arg_arg1: *mut FILE) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-        }
-        ftell(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fwrite(
-    arg___ptr: *const ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fwrite(
-                __ptr: *const ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fwrite(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn getc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        getc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getchar() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getchar() -> ::std::os::raw::c_int;
-        }
-        getchar()
-    })
-}
-#[track_caller]
-pub unsafe fn perror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn perror(arg1: *const ::std::os::raw::c_char);
-        }
-        perror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn printf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        printf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn putc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        putc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn putchar(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        putchar(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn puts(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        puts(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn remove(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        remove(arg_arg1)
+        remove(arg___filename)
     })
 }
 #[track_caller]
@@ -4507,81 +3545,31 @@ pub unsafe fn rename(
     })
 }
 #[track_caller]
-pub unsafe fn rewind(arg_arg1: *mut FILE) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rewind(arg1: *mut FILE);
-        }
-        rewind(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn scanf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        scanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuf(arg_arg1: *mut FILE, arg_arg2: *mut ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-        }
-        setbuf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setvbuf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
+pub unsafe fn renameat(
+    arg___oldfd: ::std::os::raw::c_int,
+    arg___old: *const ::std::os::raw::c_char,
+    arg___newfd: ::std::os::raw::c_int,
+    arg___new: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setvbuf(
-                arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
+            pub fn renameat(
+                __oldfd: ::std::os::raw::c_int,
+                __old: *const ::std::os::raw::c_char,
+                __newfd: ::std::os::raw::c_int,
+                __new: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        setvbuf(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        renameat(arg___oldfd, arg___old, arg___newfd, arg___new)
     })
 }
 #[track_caller]
-pub unsafe fn sprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        sprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sscanf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sscanf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        sscanf(arg_arg1, arg_arg2)
+        fclose(arg___stream)
     })
 }
 #[track_caller]
@@ -4594,195 +3582,540 @@ pub unsafe fn tmpfile() -> *mut FILE {
     })
 }
 #[track_caller]
-pub unsafe fn ungetc(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ungetc(arg_arg1, arg_arg2)
+        fflush(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vfprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vfprintf(arg_arg1, arg_arg2, arg_arg3)
+        fflush_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vprintf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vprintf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+            ) -> *mut FILE;
         }
-        vprintf(arg_arg1, arg_arg2)
+        fopen(arg___filename, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn vsprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn freopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn freopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> *mut FILE;
         }
-        vsprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ctermid(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        ctermid(arg_arg1)
+        freopen(arg___filename, arg___modes, arg___stream)
     })
 }
 #[track_caller]
 pub unsafe fn fdopen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
+    arg___fd: ::std::os::raw::c_int,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fdopen(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
+                __fd: ::std::os::raw::c_int,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fdopen(arg_arg1, arg_arg2)
+        fdopen(arg___fd, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn fileno(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fileno(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn pclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        pclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn popen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
+pub unsafe fn fmemopen(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___len: usize,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn popen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
+            pub fn fmemopen(
+                __s: *mut ::std::os::raw::c_void,
+                __len: usize,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        popen(arg_arg1, arg_arg2)
+        fmemopen(arg___s, arg___len, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn __srget(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn open_memstream(
+    arg___bufloc: *mut *mut ::std::os::raw::c_char,
+    arg___sizeloc: *mut usize,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn open_memstream(
+                __bufloc: *mut *mut ::std::os::raw::c_char,
+                __sizeloc: *mut usize,
+            ) -> *mut FILE;
         }
-        __srget(arg_arg1)
+        open_memstream(arg___bufloc, arg___sizeloc)
     })
 }
 #[track_caller]
-pub unsafe fn __svfscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
+pub unsafe fn setbuf(arg___stream: *mut FILE, arg___buf: *mut ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+        }
+        setbuf(arg___stream, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setvbuf(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___modes: ::std::os::raw::c_int,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __svfscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
+            pub fn setvbuf(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __modes: ::std::os::raw::c_int,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        __svfscanf(arg_arg1, arg_arg2, arg_arg3)
+        setvbuf(arg___stream, arg___buf, arg___modes, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn __swbuf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+pub unsafe fn setbuffer(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___size: usize,
+) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuffer(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __size: usize,
+            );
+        }
+        setbuffer(arg___stream, arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn setlinebuf(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlinebuf(__stream: *mut FILE);
+        }
+        setlinebuf(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fprintf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fprintf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        __swbuf(arg_arg1, arg_arg2)
+        fprintf(arg___stream, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn flockfile(arg_arg1: *mut FILE) {
+pub unsafe fn printf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flockfile(arg1: *mut FILE);
+            pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
         }
-        flockfile(arg_arg1)
+        printf(arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn ftrylockfile(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn sprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn sprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        ftrylockfile(arg_arg1)
+        sprintf(arg___s, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn funlockfile(arg_arg1: *mut FILE) {
+pub unsafe fn vfprintf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn funlockfile(arg1: *mut FILE);
+            pub fn vfprintf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        funlockfile(arg_arg1)
+        vfprintf(arg___s, arg___format, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn getc_unlocked(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn vprintf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn vprintf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        getc_unlocked(arg_arg1)
+        vprintf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsprintf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn snprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn snprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        snprintf(arg___s, arg___maxlen, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vsnprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsnprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsnprintf(arg___s, arg___maxlen, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vdprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vdprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vdprintf(arg___fd, arg___fmt, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn dprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        dprintf(arg___fd, arg___fmt)
+    })
+}
+#[track_caller]
+pub unsafe fn fscanf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fscanf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf(arg___s, arg___format)
+    })
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[track_caller]
+pub unsafe fn fscanf1(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_fscanf"]
+            pub fn fscanf1(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf1(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf1(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_scanf"]
+            pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf1(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_sscanf"]
+            pub fn sscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf1(arg___s, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vfscanf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vscanf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf1(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vfscanf"]
+            pub fn vfscanf1(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf1(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vscanf"]
+            pub fn vscanf1(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf1(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vsscanf"]
+            pub fn vsscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getchar() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getchar() -> ::std::os::raw::c_int;
+        }
+        getchar()
+    })
+}
+#[track_caller]
+pub unsafe fn getc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc_unlocked(arg___stream)
     })
 }
 #[track_caller]
@@ -4795,1508 +4128,537 @@ pub unsafe fn getchar_unlocked() -> ::std::os::raw::c_int {
     })
 }
 #[track_caller]
+pub unsafe fn fgetc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fputc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putchar(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        putchar(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc_unlocked(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc_unlocked(
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputc_unlocked(arg___c, arg___stream)
+    })
+}
+#[track_caller]
 pub unsafe fn putc_unlocked(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn putc_unlocked(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut FILE,
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
             ) -> ::std::os::raw::c_int;
         }
-        putc_unlocked(arg_arg1, arg_arg2)
+        putc_unlocked(arg___c, arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putchar_unlocked(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn putchar_unlocked(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        putchar_unlocked(arg_arg1)
+        putchar_unlocked(arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn getw(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn getw(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getw(arg_arg1)
+        getw(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putw(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn putw(
+    arg___w: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        putw(arg_arg1, arg_arg2)
+        putw(arg___w, arg___stream)
     })
 }
-pub type off_t = __darwin_off_t;
+#[track_caller]
+pub unsafe fn fgets(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgets(
+                __s: *mut ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fgets(arg___s, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn __getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        __getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getline(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getline(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getline(arg___lineptr, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputs(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputs(
+                __s: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputs(arg___s, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn puts(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        puts(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn ungetc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+                -> ::std::os::raw::c_int;
+        }
+        ungetc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fread(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fread(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___s: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __s: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fwrite(arg___ptr, arg___size, arg___n, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn fread_unlocked(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread_unlocked(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fread_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite_unlocked(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite_unlocked(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fwrite_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fseek(
+    arg___stream: *mut FILE,
+    arg___off: ::std::os::raw::c_long,
+    arg___whence: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fseek(
+                __stream: *mut FILE,
+                __off: ::std::os::raw::c_long,
+                __whence: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        fseek(arg___stream, arg___off, arg___whence)
+    })
+}
+#[track_caller]
+pub unsafe fn ftell(arg___stream: *mut FILE) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+        }
+        ftell(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn rewind(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rewind(__stream: *mut FILE);
+        }
+        rewind(arg___stream)
+    })
+}
 #[track_caller]
 pub unsafe fn fseeko(
     arg___stream: *mut FILE,
-    arg___offset: off_t,
+    arg___off: __off_t,
     arg___whence: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fseeko(
                 __stream: *mut FILE,
-                __offset: off_t,
+                __off: __off_t,
                 __whence: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        fseeko(arg___stream, arg___offset, arg___whence)
+        fseeko(arg___stream, arg___off, arg___whence)
     })
 }
 #[track_caller]
-pub unsafe fn ftello(arg___stream: *mut FILE) -> off_t {
+pub unsafe fn ftello(arg___stream: *mut FILE) -> __off_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftello(__stream: *mut FILE) -> off_t;
+            pub fn ftello(__stream: *mut FILE) -> __off_t;
         }
         ftello(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn snprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fgetpos(arg___stream: *mut FILE, arg___pos: *mut fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn snprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
         }
-        snprintf(arg___str, arg___size, arg___format)
+        fgetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vfscanf(
-    arg___stream: *mut FILE,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fsetpos(arg___stream: *mut FILE, arg___pos: *const fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfscanf(
-                __stream: *mut FILE,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
         }
-        vfscanf(arg___stream, arg___format, arg_arg1)
+        fsetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vscanf(
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vscanf(
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr(__stream: *mut FILE);
         }
-        vscanf(arg___format, arg_arg1)
+        clearerr(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsnprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsnprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsnprintf(arg___str, arg___size, arg___format, arg_arg1)
+        feof(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsscanf(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ferror(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsscanf(
-                __str: *const ::std::os::raw::c_char,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsscanf(arg___str, arg___format, arg_arg1)
+        ferror(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn dprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr_unlocked(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn dprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr_unlocked(__stream: *mut FILE);
         }
-        dprintf(arg_arg1, arg_arg2)
+        clearerr_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vdprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vdprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vdprintf(arg_arg1, arg_arg2, arg_arg3)
+        feof_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getdelim(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___delimiter: ::std::os::raw::c_int,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn ferror_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdelim(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __delimiter: ::std::os::raw::c_int,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getdelim(arg___linep, arg___linecapp, arg___delimiter, arg___stream)
+        ferror_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getline(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn perror(arg___s: *const ::std::os::raw::c_char) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getline(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn perror(__s: *const ::std::os::raw::c_char);
         }
-        getline(arg___linep, arg___linecapp, arg___stream)
+        perror(arg___s)
     })
 }
 #[track_caller]
-pub unsafe fn fmemopen(
-    arg___buf: *mut ::std::os::raw::c_void,
-    arg___size: usize,
-    arg___mode: *const ::std::os::raw::c_char,
+pub unsafe fn fileno(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fileno_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn pclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        pclose(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn popen(
+    arg___command: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmemopen(
-                __buf: *mut ::std::os::raw::c_void,
-                __size: usize,
-                __mode: *const ::std::os::raw::c_char,
+            pub fn popen(
+                __command: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fmemopen(arg___buf, arg___size, arg___mode)
+        popen(arg___command, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn open_memstream(
-    arg___bufp: *mut *mut ::std::os::raw::c_char,
-    arg___sizep: *mut usize,
-) -> *mut FILE {
+pub unsafe fn ctermid(arg___s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn open_memstream(
-                __bufp: *mut *mut ::std::os::raw::c_char,
-                __sizep: *mut usize,
-            ) -> *mut FILE;
+            pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
         }
-        open_memstream(arg___bufp, arg___sizep)
+        ctermid(arg___s)
     })
 }
-extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
-}
 #[track_caller]
-pub unsafe fn asprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn flockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn flockfile(__stream: *mut FILE);
         }
-        asprintf(arg_arg1, arg_arg2)
+        flockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn ctermid_r(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ftrylockfile(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ctermid_r(arg_arg1)
+        ftrylockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fgetln(arg_arg1: *mut FILE, arg_arg2: *mut usize) -> *mut ::std::os::raw::c_char {
+pub unsafe fn funlockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+            pub fn funlockfile(__stream: *mut FILE);
         }
-        fgetln(arg_arg1, arg_arg2)
+        funlockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fmtcheck(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *const ::std::os::raw::c_char {
+pub unsafe fn __uflow(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmtcheck(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *const ::std::os::raw::c_char;
+            pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
         }
-        fmtcheck(arg_arg1, arg_arg2)
+        __uflow(arg_arg1)
     })
 }
 #[track_caller]
-pub unsafe fn fpurge(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fpurge(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuffer(
+pub unsafe fn __overflow(
     arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) {
+    arg_arg2: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setbuffer(
+            pub fn __overflow(
                 arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            );
-        }
-        setbuffer(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setlinebuf(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        setlinebuf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn vasprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn vasprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        vasprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn funopen(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg3: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg4: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    arg_arg5: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn funopen(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *mut ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg3: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg4: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: fpos_t,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> fpos_t,
-                >,
-                arg5: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> *mut FILE;
-        }
-        funopen(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __sprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __sprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __snprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __snprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __snprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsnprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-    arg_arg6: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsnprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                arg6: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsnprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
-}
-impl Default for __darwin_arm_vfp_state {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
-        }
-        signal(arg_arg1, arg_arg2)
-    })
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_reserved: [u64; 14usize],
-}
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[track_caller]
-pub unsafe fn getpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-        }
-        getpriority(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getiopolicy_np(
-                arg1: ::std::os::raw::c_int,
                 arg2: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getiopolicy_np(arg_arg1, arg_arg2)
+        __overflow(arg_arg1, arg_arg2)
     })
 }
-#[track_caller]
-pub unsafe fn getrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getrusage(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rusage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrusage(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rusage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrusage(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpriority(
-                arg1: ::std::os::raw::c_int,
-                arg2: id_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setpriority(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setiopolicy_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setiopolicy_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        setrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn wait(arg_arg1: *mut ::std::os::raw::c_int) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-        }
-        wait(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn waitpid(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitpid(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> pid_t;
-        }
-        waitpid(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn waitid(
-    arg_arg1: idtype_t,
-    arg_arg2: id_t,
-    arg_arg3: *mut siginfo_t,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitid(
-                arg1: idtype_t,
-                arg2: id_t,
-                arg3: *mut siginfo_t,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        waitid(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn wait3(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait3(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut rusage,
-            ) -> pid_t;
-        }
-        wait3(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn wait4(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait4(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut rusage,
-            ) -> pid_t;
-        }
-        wait4(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn alloca(arg_arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-        }
-        alloca(arg_arg1)
-    })
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6315,8 +4677,1000 @@ pub struct lldiv_t {
     pub quot: ::std::os::raw::c_longlong,
     pub rem: ::std::os::raw::c_longlong,
 }
-extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+#[track_caller]
+pub unsafe fn __ctype_get_mb_cur_max() -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ctype_get_mb_cur_max() -> usize;
+        }
+        __ctype_get_mb_cur_max()
+    })
+}
+#[track_caller]
+pub unsafe fn atof(arg___nptr: *const ::std::os::raw::c_char) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+        }
+        atof(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoi(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        atoi(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atol(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        atol(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoll(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+        }
+        atoll(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtod(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtod(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f64;
+        }
+        strtod(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtof(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtof(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f32;
+        }
+        strtof(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtold(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtold(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> u128;
+        }
+        strtold(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtol(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtol(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_long;
+        }
+        strtol(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoul(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoul(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strtoul(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtouq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtouq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtouq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoll(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoll(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoll(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoull(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoull(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtoull(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn l64a(arg___n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+        }
+        l64a(arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn a64l(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        a64l(arg___s)
+    })
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[track_caller]
+pub unsafe fn select(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *mut timeval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn select(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *mut timeval,
+            ) -> ::std::os::raw::c_int;
+        }
+        select(arg___nfds, arg___readfds, arg___writefds, arg___exceptfds, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn pselect(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *const timespec,
+    arg___sigmask: *const __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pselect(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *const timespec,
+                __sigmask: *const __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pselect(
+            arg___nfds,
+            arg___readfds,
+            arg___writefds,
+            arg___exceptfds,
+            arg___timeout,
+            arg___sigmask,
+        )
+    })
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __atomic_wide_counter {
+    pub __value64: ::std::os::raw::c_ulonglong,
+    pub __value32: __atomic_wide_counter__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __atomic_wide_counter__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __atomic_wide_counter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __wseq: __atomic_wide_counter,
+    pub __g1_start: __atomic_wide_counter,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random() -> ::std::os::raw::c_long;
+        }
+        random()
+    })
+}
+#[track_caller]
+pub unsafe fn srandom(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom(__seed: ::std::os::raw::c_uint);
+        }
+        srandom(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        initstate(arg___seed, arg___statebuf, arg___statelen)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate(arg___statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate(__statebuf: *mut ::std::os::raw::c_char)
+                -> *mut ::std::os::raw::c_char;
+        }
+        setstate(arg___statebuf)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random_r(
+    arg___buf: *mut random_data,
+    arg___result: *mut i32,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+        }
+        random_r(arg___buf, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srandom_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom_r(
+                __seed: ::std::os::raw::c_uint,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srandom_r(arg___seed, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate_r(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        initstate_r(arg___seed, arg___statebuf, arg___statelen, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate_r(
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate_r(
+                __statebuf: *mut ::std::os::raw::c_char,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        setstate_r(arg___statebuf, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn rand() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand() -> ::std::os::raw::c_int;
+        }
+        rand()
+    })
+}
+#[track_caller]
+pub unsafe fn srand(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand(__seed: ::std::os::raw::c_uint);
+        }
+        srand(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn rand_r(arg___seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+        }
+        rand_r(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn drand48() -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48() -> f64;
+        }
+        drand48()
+    })
+}
+#[track_caller]
+pub unsafe fn erand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+        }
+        erand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48() -> ::std::os::raw::c_long;
+        }
+        lrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        nrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48() -> ::std::os::raw::c_long;
+        }
+        mrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        jrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48(arg___seedval: ::std::os::raw::c_long) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48(__seedval: ::std::os::raw::c_long);
+        }
+        srand48(arg___seedval)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+) -> *mut ::std::os::raw::c_ushort {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+            ) -> *mut ::std::os::raw::c_ushort;
+        }
+        seed48(arg___seed16v)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48(arg___param: *mut ::std::os::raw::c_ushort) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+        }
+        lcong48(arg___param)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[track_caller]
+pub unsafe fn drand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        drand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn erand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        erand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        lrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        nrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        mrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        jrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48_r(
+    arg___seedval: ::std::os::raw::c_long,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48_r(
+                __seedval: ::std::os::raw::c_long,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srand48_r(arg___seedval, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48_r(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48_r(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        seed48_r(arg___seed16v, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48_r(
+    arg___param: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48_r(
+                __param: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        lcong48_r(arg___param, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random() -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random() -> __uint32_t;
+        }
+        arc4random()
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___size: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+        }
+        arc4random_buf(arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_uniform(arg___upper_bound: __uint32_t) -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+        }
+        arc4random_uniform(arg___upper_bound)
+    })
 }
 #[track_caller]
 pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
@@ -6329,26 +5683,17 @@ pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw
 }
 #[track_caller]
 pub unsafe fn calloc(
-    arg___count: ::std::os::raw::c_ulong,
+    arg___nmemb: ::std::os::raw::c_ulong,
     arg___size: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn calloc(
-                __count: ::std::os::raw::c_ulong,
+                __nmemb: ::std::os::raw::c_ulong,
                 __size: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        calloc(arg___count, arg___size)
-    })
-}
-#[track_caller]
-pub unsafe fn free(arg_arg1: *mut ::std::os::raw::c_void) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn free(arg1: *mut ::std::os::raw::c_void);
-        }
-        free(arg_arg1)
+        calloc(arg___nmemb, arg___size)
     })
 }
 #[track_caller]
@@ -6367,27 +5712,47 @@ pub unsafe fn realloc(
     })
 }
 #[track_caller]
-pub unsafe fn valloc(arg_arg1: usize) -> *mut ::std::os::raw::c_void {
+pub unsafe fn free(arg___ptr: *mut ::std::os::raw::c_void) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+            pub fn free(__ptr: *mut ::std::os::raw::c_void);
         }
-        valloc(arg_arg1)
+        free(arg___ptr)
     })
 }
 #[track_caller]
-pub unsafe fn aligned_alloc(
-    arg___alignment: ::std::os::raw::c_ulong,
-    arg___size: ::std::os::raw::c_ulong,
+pub unsafe fn reallocarray(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn aligned_alloc(
-                __alignment: ::std::os::raw::c_ulong,
-                __size: ::std::os::raw::c_ulong,
+            pub fn reallocarray(
+                __ptr: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
             ) -> *mut ::std::os::raw::c_void;
         }
-        aligned_alloc(arg___alignment, arg___size)
+        reallocarray(arg___ptr, arg___nmemb, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn alloca(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+        }
+        alloca(arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn valloc(arg___size: usize) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+        }
+        valloc(arg___size)
     })
 }
 #[track_caller]
@@ -6408,6 +5773,21 @@ pub unsafe fn posix_memalign(
     })
 }
 #[track_caller]
+pub unsafe fn aligned_alloc(
+    arg___alignment: ::std::os::raw::c_ulong,
+    arg___size: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn aligned_alloc(
+                __alignment: ::std::os::raw::c_ulong,
+                __size: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        aligned_alloc(arg___alignment, arg___size)
+    })
+}
+#[track_caller]
 pub unsafe fn abort() {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -6417,161 +5797,500 @@ pub unsafe fn abort() {
     })
 }
 #[track_caller]
-pub unsafe fn abs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        abs(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn atexit(
-    arg_arg1: ::std::option::Option<unsafe extern "C" fn()>,
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn atexit(
-                arg1: ::std::option::Option<unsafe extern "C" fn()>,
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
             ) -> ::std::os::raw::c_int;
         }
-        atexit(arg_arg1)
+        atexit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atof(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
+pub unsafe fn at_quick_exit(
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+            pub fn at_quick_exit(
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
+            ) -> ::std::os::raw::c_int;
         }
-        atof(arg_arg1)
+        at_quick_exit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atoi(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+pub unsafe fn on_exit(
+    arg___func: ::std::option::Option<
+        unsafe extern "C" fn(__status: ::std::os::raw::c_int, __arg: *mut ::std::os::raw::c_void),
+    >,
+    arg___arg: *mut ::std::os::raw::c_void,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+            pub fn on_exit(
+                __func: ::std::option::Option<
+                    unsafe extern "C" fn(
+                        __status: ::std::os::raw::c_int,
+                        __arg: *mut ::std::os::raw::c_void,
+                    ),
+                >,
+                __arg: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int;
         }
-        atoi(arg_arg1)
+        on_exit(arg___func, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn atol(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn exit(__status: ::std::os::raw::c_int);
         }
-        atol(arg_arg1)
+        exit(arg___status)
     })
 }
 #[track_caller]
-pub unsafe fn atoll(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+pub unsafe fn quick_exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+            pub fn quick_exit(__status: ::std::os::raw::c_int);
         }
-        atoll(arg_arg1)
+        quick_exit(arg___status)
     })
 }
+#[track_caller]
+pub unsafe fn _Exit(arg___status: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _Exit(__status: ::std::os::raw::c_int);
+        }
+        _Exit(arg___status)
+    })
+}
+#[track_caller]
+pub unsafe fn getenv(arg___name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        getenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn putenv(arg___string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        putenv(arg___string)
+    })
+}
+#[track_caller]
+pub unsafe fn setenv(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___value: *const ::std::os::raw::c_char,
+    arg___replace: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setenv(
+                __name: *const ::std::os::raw::c_char,
+                __value: *const ::std::os::raw::c_char,
+                __replace: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        setenv(arg___name, arg___value, arg___replace)
+    })
+}
+#[track_caller]
+pub unsafe fn unsetenv(arg___name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        unsetenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn clearenv() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clearenv() -> ::std::os::raw::c_int;
+        }
+        clearenv()
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemp(arg___template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        mkstemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemps(
+    arg___template: *mut ::std::os::raw::c_char,
+    arg___suffixlen: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemps(
+                __template: *mut ::std::os::raw::c_char,
+                __suffixlen: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        mkstemps(arg___template, arg___suffixlen)
+    })
+}
+#[track_caller]
+pub unsafe fn mkdtemp(arg___template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        mkdtemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn system(arg___command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        system(arg___command)
+    })
+}
+#[track_caller]
+pub unsafe fn realpath(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resolved: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn realpath(
+                __name: *const ::std::os::raw::c_char,
+                __resolved: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        realpath(arg___name, arg___resolved)
+    })
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[track_caller]
 pub unsafe fn bsearch(
     arg___key: *const ::std::os::raw::c_void,
     arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bsearch(
                 __key: *const ::std::os::raw::c_void,
                 __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
             ) -> *mut ::std::os::raw::c_void;
         }
-        bsearch(arg___key, arg___base, arg___nel, arg___width, arg___compar)
+        bsearch(arg___key, arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn div(arg_arg1: ::std::os::raw::c_int, arg_arg2: ::std::os::raw::c_int) -> div_t {
+pub unsafe fn qsort(
+    arg___base: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+            pub fn qsort(
+                __base: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
+            );
         }
-        div(arg_arg1, arg_arg2)
+        qsort(arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn abs(arg___x: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exit(arg1: ::std::os::raw::c_int);
+            pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        exit(arg_arg1)
+        abs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn getenv(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn labs(arg___x: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
         }
-        getenv(arg_arg1)
+        labs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn labs(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
+pub unsafe fn llabs(arg___x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+            pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
         }
-        labs(arg_arg1)
+        llabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ldiv(arg_arg1: ::std::os::raw::c_long, arg_arg2: ::std::os::raw::c_long) -> ldiv_t {
+pub unsafe fn div(arg___numer: ::std::os::raw::c_int, arg___denom: ::std::os::raw::c_int) -> div_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+            pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
         }
-        ldiv(arg_arg1, arg_arg2)
+        div(arg___numer, arg___denom)
     })
 }
 #[track_caller]
-pub unsafe fn llabs(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
+pub unsafe fn ldiv(
+    arg___numer: ::std::os::raw::c_long,
+    arg___denom: ::std::os::raw::c_long,
+) -> ldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+            pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long)
+                -> ldiv_t;
         }
-        llabs(arg_arg1)
+        ldiv(arg___numer, arg___denom)
     })
 }
 #[track_caller]
 pub unsafe fn lldiv(
-    arg_arg1: ::std::os::raw::c_longlong,
-    arg_arg2: ::std::os::raw::c_longlong,
+    arg___numer: ::std::os::raw::c_longlong,
+    arg___denom: ::std::os::raw::c_longlong,
 ) -> lldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn lldiv(
-                arg1: ::std::os::raw::c_longlong,
-                arg2: ::std::os::raw::c_longlong,
+                __numer: ::std::os::raw::c_longlong,
+                __denom: ::std::os::raw::c_longlong,
             ) -> lldiv_t;
         }
-        lldiv(arg_arg1, arg_arg2)
+        lldiv(arg___numer, arg___denom)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        ecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn gcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        gcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qfcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qgcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qgcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qgcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        ecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        fcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qfcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
     })
 }
 #[track_caller]
@@ -6587,1295 +6306,180 @@ pub unsafe fn mblen(
     })
 }
 #[track_caller]
-pub unsafe fn mbstowcs(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mbstowcs(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> usize;
-        }
-        mbstowcs(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
 pub unsafe fn mbtowc(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
+    arg___pwc: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn mbtowc(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
+                __pwc: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        mbtowc(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn rand() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand() -> ::std::os::raw::c_int;
-        }
-        rand()
-    })
-}
-#[track_caller]
-pub unsafe fn srand(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand(arg1: ::std::os::raw::c_uint);
-        }
-        srand(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn strtod(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtod(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtof(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtof(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f32;
-        }
-        strtof(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtol(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtol(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_long;
-        }
-        strtol(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtold(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtold(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtold(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoll(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoll(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoll(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoul(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoul(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strtoul(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoull(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoull(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtoull(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn system(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        system(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn wcstombs(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const wchar_t,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wcstombs(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const wchar_t,
-                arg3: usize,
-            ) -> usize;
-        }
-        wcstombs(arg_arg1, arg_arg2, arg_arg3)
+        mbtowc(arg___pwc, arg___s, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn wctomb(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: wchar_t,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___wchar: wchar_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn wctomb(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: wchar_t,
+                __s: *mut ::std::os::raw::c_char,
+                __wchar: wchar_t,
             ) -> ::std::os::raw::c_int;
         }
-        wctomb(arg_arg1, arg_arg2)
+        wctomb(arg___s, arg___wchar)
     })
 }
 #[track_caller]
-pub unsafe fn _Exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn mbstowcs(
+    arg___pwcs: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn _Exit(arg1: ::std::os::raw::c_int);
+            pub fn mbstowcs(
+                __pwcs: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> usize;
         }
-        _Exit(arg_arg1)
+        mbstowcs(arg___pwcs, arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn a64l(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn wcstombs(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___pwcs: *const wchar_t,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn wcstombs(
+                __s: *mut ::std::os::raw::c_char,
+                __pwcs: *const wchar_t,
+                __n: usize,
+            ) -> usize;
         }
-        a64l(arg_arg1)
+        wcstombs(arg___s, arg___pwcs, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn drand48() -> f64 {
+pub unsafe fn rpmatch(arg___response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn drand48() -> f64;
+            pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        drand48()
-    })
-}
-#[track_caller]
-pub unsafe fn ecvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ecvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        ecvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn erand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-        }
-        erand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fcvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        gcvt(arg_arg1, arg_arg2, arg_arg3)
+        rpmatch(arg___response)
     })
 }
 #[track_caller]
 pub unsafe fn getsubopt(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+    arg___optionp: *mut *mut ::std::os::raw::c_char,
+    arg___tokens: *const *mut ::std::os::raw::c_char,
+    arg___valuep: *mut *mut ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn getsubopt(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+                __optionp: *mut *mut ::std::os::raw::c_char,
+                __tokens: *const *mut ::std::os::raw::c_char,
+                __valuep: *mut *mut ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        getsubopt(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn grantpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        grantpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn initstate(
-    arg_arg1: ::std::os::raw::c_uint,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn initstate(
-                arg1: ::std::os::raw::c_uint,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        initstate(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn jrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        jrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn l64a(arg_arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-        }
-        l64a(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lcong48(arg_arg1: *mut ::std::os::raw::c_ushort) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-        }
-        lcong48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrand48() -> ::std::os::raw::c_long;
-        }
-        lrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn mkstemp(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        mkstemp(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mrand48() -> ::std::os::raw::c_long;
-        }
-        mrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn nrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        nrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn posix_openpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        posix_openpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname(arg_arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        ptsname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname_r(
-    arg_fildes: ::std::os::raw::c_int,
-    arg_buffer: *mut ::std::os::raw::c_char,
-    arg_buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname_r(
-                fildes: ::std::os::raw::c_int,
-                buffer: *mut ::std::os::raw::c_char,
-                buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        ptsname_r(arg_fildes, arg_buffer, arg_buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn putenv(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        putenv(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn random() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn random() -> ::std::os::raw::c_long;
-        }
-        random()
-    })
-}
-#[track_caller]
-pub unsafe fn rand_r(arg_arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-        }
-        rand_r(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn realpath(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-            pub fn realpath(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        realpath(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn seed48(arg_arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-        }
-        seed48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setenv(
-    arg___name: *const ::std::os::raw::c_char,
-    arg___value: *const ::std::os::raw::c_char,
-    arg___overwrite: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setenv(
-                __name: *const ::std::os::raw::c_char,
-                __value: *const ::std::os::raw::c_char,
-                __overwrite: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setenv(arg___name, arg___value, arg___overwrite)
-    })
-}
-#[track_caller]
-pub unsafe fn setkey(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setkey(arg1: *const ::std::os::raw::c_char);
-        }
-        setkey(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setstate(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        setstate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srand48(arg_arg1: ::std::os::raw::c_long) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand48(arg1: ::std::os::raw::c_long);
-        }
-        srand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srandom(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandom(arg1: ::std::os::raw::c_uint);
-        }
-        srandom(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unlockpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        unlockpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unsetenv(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        unsetenv(arg_arg1)
-    })
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[track_caller]
-pub unsafe fn arc4random() -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random() -> u32;
-        }
-        arc4random()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_addrandom(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: ::std::os::raw::c_int,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_addrandom(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: ::std::os::raw::c_int,
-            );
-        }
-        arc4random_addrandom(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___nbytes: usize) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-        }
-        arc4random_buf(arg___buf, arg___nbytes)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_stir() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_stir();
-        }
-        arc4random_stir()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_uniform(arg___upper_bound: u32) -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-        }
-        arc4random_uniform(arg___upper_bound)
-    })
-}
-#[track_caller]
-pub unsafe fn atexit_b(arg_arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-        }
-        atexit_b(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn bsearch_b(
-    arg___key: *const ::std::os::raw::c_void,
-    arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bsearch_b(
-                __key: *const ::std::os::raw::c_void,
-                __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        bsearch_b(arg___key, arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetcap(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetcap(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        cgetcap(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetclose() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetclose() -> ::std::os::raw::c_int;
-        }
-        cgetclose()
-    })
-}
-#[track_caller]
-pub unsafe fn cgetent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetent(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetfirst(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetfirst(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetfirst(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetmatch(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetmatch(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetmatch(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnext(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnext(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnext(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnum(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnum(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnum(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetset(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        cgetset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetstr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetstr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetstr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetustr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetustr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetustr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn daemon(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn daemon(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        daemon(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname(arg_arg1: dev_t, arg_arg2: mode_t) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-        }
-        devname(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname_r(
-    arg_arg1: dev_t,
-    arg_arg2: mode_t,
-    arg_buf: *mut ::std::os::raw::c_char,
-    arg_len: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname_r(
-                arg1: dev_t,
-                arg2: mode_t,
-                buf: *mut ::std::os::raw::c_char,
-                len: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        devname_r(arg_arg1, arg_arg2, arg_buf, arg_len)
-    })
-}
-#[track_caller]
-pub unsafe fn getbsize(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_long,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getbsize(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_long,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        getbsize(arg_arg1, arg_arg2)
+        getsubopt(arg___optionp, arg___tokens, arg___valuep)
     })
 }
 #[track_caller]
 pub unsafe fn getloadavg(
-    arg_arg1: *mut f64,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___loadavg: *mut f64,
+    arg___nelem: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int)
-                -> ::std::os::raw::c_int;
-        }
-        getloadavg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getprogname() -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprogname() -> *const ::std::os::raw::c_char;
-        }
-        getprogname()
-    })
-}
-#[track_caller]
-pub unsafe fn setprogname(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-        }
-        setprogname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn heapsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+            pub fn getloadavg(
+                __loadavg: *mut f64,
+                __nelem: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        heapsort(arg___base, arg___nel, arg___width, arg___compar)
+        getloadavg(arg___loadavg, arg___nelem)
     })
 }
 #[track_caller]
-pub unsafe fn heapsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        heapsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        psort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        qsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn radixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn radixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        radixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn rpmatch(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        rpmatch(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sradixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sradixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        sradixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn sranddev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sranddev();
-        }
-        sranddev()
-    })
-}
-#[track_caller]
-pub unsafe fn srandomdev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandomdev();
-        }
-        srandomdev()
-    })
-}
-#[track_caller]
-pub unsafe fn reallocf(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: usize,
+pub unsafe fn memcpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn reallocf(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: usize,
+            pub fn memcpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        reallocf(arg___ptr, arg___size)
+        memcpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtonum(
-    arg___numstr: *const ::std::os::raw::c_char,
-    arg___minval: ::std::os::raw::c_longlong,
-    arg___maxval: ::std::os::raw::c_longlong,
-    arg___errstrp: *mut *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_longlong {
+pub unsafe fn memmove(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strtonum(
-                __numstr: *const ::std::os::raw::c_char,
-                __minval: ::std::os::raw::c_longlong,
-                __maxval: ::std::os::raw::c_longlong,
-                __errstrp: *mut *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_longlong;
+            pub fn memmove(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
         }
-        strtonum(arg___numstr, arg___minval, arg___maxval, arg___errstrp)
+        memmove(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtoq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoq(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtouq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtouq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtouq(arg___str, arg___endptr, arg___base)
-    })
-}
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[track_caller]
-pub unsafe fn memchr(
-    arg___s: *const ::std::os::raw::c_void,
+pub unsafe fn memccpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
     arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memchr(
-                __s: *const ::std::os::raw::c_void,
+            pub fn memccpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
                 __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memchr(arg___s, arg___c, arg___n)
+        memccpy(arg___dest, arg___src, arg___c, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memset(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn memset(
+                __s: *mut ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        memset(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
@@ -7896,84 +6500,101 @@ pub unsafe fn memcmp(
     })
 }
 #[track_caller]
-pub unsafe fn memcpy(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
+pub unsafe fn __memcmpeq(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __memcmpeq(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        __memcmpeq(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memchr(
+    arg___s: *const ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memcpy(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
+            pub fn memchr(
+                __s: *const ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memcpy(arg___dst, arg___src, arg___n)
+        memchr(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn memmove(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memmove(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memmove(arg___dst, arg___src, arg___len)
+        strcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn memset(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset(
-                __b: *mut ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset(arg___b, arg___c, arg___len)
+        strncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn strcat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strcat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcat(arg___s1, arg___s2)
+        strcat(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn strchr(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___c: ::std::os::raw::c_int,
+pub unsafe fn strncat(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strchr(
-                __s: *const ::std::os::raw::c_char,
-                __c: ::std::os::raw::c_int,
+            pub fn strncat(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strchr(arg___s, arg___c)
+        strncat(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
@@ -7989,86 +6610,6 @@ pub unsafe fn strcmp(
             ) -> ::std::os::raw::c_int;
         }
         strcmp(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcoll(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcoll(
-                __s1: *const ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        strcoll(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strcpy(arg___dst, arg___src)
-    })
-}
-#[track_caller]
-pub unsafe fn strcspn(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcspn(
-                __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strcspn(arg___s, arg___charset)
-    })
-}
-#[track_caller]
-pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strerror(arg___errnum)
-    })
-}
-#[track_caller]
-pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-        }
-        strlen(arg___s)
-    })
-}
-#[track_caller]
-pub unsafe fn strncat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strncat(arg___s1, arg___s2, arg___n)
     })
 }
 #[track_caller]
@@ -8089,35 +6630,130 @@ pub unsafe fn strncmp(
     })
 }
 #[track_caller]
-pub unsafe fn strncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
+pub unsafe fn strcoll(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm(
+    arg___dest: *mut ::std::os::raw::c_char,
     arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strxfrm(arg___dest, arg___src, arg___n)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[track_caller]
+pub unsafe fn strcoll_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __l: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll_l(arg___s1, arg___s2, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm_l(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___l: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm_l(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+                __l: locale_t,
+            ) -> usize;
+        }
+        strxfrm_l(arg___dest, arg___src, arg___n, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strdup(arg___s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        strdup(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strndup(
+    arg___string: *const ::std::os::raw::c_char,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
+            pub fn strndup(
+                __string: *const ::std::os::raw::c_char,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strncpy(arg___dst, arg___src, arg___n)
+        strndup(arg___string, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strpbrk(
+pub unsafe fn strchr(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strpbrk(
+            pub fn strchr(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strpbrk(arg___s, arg___charset)
+        strchr(arg___s, arg___c)
     })
 }
 #[track_caller]
@@ -8136,358 +6772,349 @@ pub unsafe fn strrchr(
     })
 }
 #[track_caller]
+pub unsafe fn strcspn(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___reject: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcspn(
+                __s: *const ::std::os::raw::c_char,
+                __reject: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strcspn(arg___s, arg___reject)
+    })
+}
+#[track_caller]
 pub unsafe fn strspn(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strspn(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_ulong;
         }
-        strspn(arg___s, arg___charset)
+        strspn(arg___s, arg___accept)
+    })
+}
+#[track_caller]
+pub unsafe fn strpbrk(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strpbrk(
+                __s: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        strpbrk(arg___s, arg___accept)
     })
 }
 #[track_caller]
 pub unsafe fn strstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+    arg___haystack: *const ::std::os::raw::c_char,
+    arg___needle: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+                __haystack: *const ::std::os::raw::c_char,
+                __needle: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strstr(arg___big, arg___little)
+        strstr(arg___haystack, arg___needle)
     })
 }
 #[track_caller]
 pub unsafe fn strtok(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok(arg___str, arg___sep)
+        strtok(arg___s, arg___delim)
     })
 }
 #[track_caller]
-pub unsafe fn strxfrm(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn __strtok_r(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strxfrm(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn __strtok_r(
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strxfrm(arg___s1, arg___s2, arg___n)
+        __strtok_r(arg___s, arg___delim, arg___save_ptr)
     })
 }
 #[track_caller]
 pub unsafe fn strtok_r(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
-    arg___lasts: *mut *mut ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok_r(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
-                __lasts: *mut *mut ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok_r(arg___str, arg___sep, arg___lasts)
+        strtok_r(arg___s, arg___delim, arg___save_ptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+        }
+        strlen(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strnlen(arg___string: *const ::std::os::raw::c_char, arg___maxlen: usize) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+        }
+        strnlen(arg___string, arg___maxlen)
+    })
+}
+#[track_caller]
+pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+        }
+        strerror(arg___errnum)
     })
 }
 #[track_caller]
 pub unsafe fn strerror_r(
     arg___errnum: ::std::os::raw::c_int,
-    arg___strerrbuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut ::std::os::raw::c_char,
     arg___buflen: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
+            #[link_name = "\u{1}__xpg_strerror_r"]
             pub fn strerror_r(
                 __errnum: ::std::os::raw::c_int,
-                __strerrbuf: *mut ::std::os::raw::c_char,
+                __buf: *mut ::std::os::raw::c_char,
                 __buflen: usize,
             ) -> ::std::os::raw::c_int;
         }
-        strerror_r(arg___errnum, arg___strerrbuf, arg___buflen)
+        strerror_r(arg___errnum, arg___buf, arg___buflen)
     })
 }
 #[track_caller]
-pub unsafe fn strdup(arg___s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn strerror_l(
+    arg___errnum: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn strerror_l(
+                __errnum: ::std::os::raw::c_int,
+                __l: locale_t,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strdup(arg___s1)
+        strerror_l(arg___errnum, arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn memccpy(
-    arg___dst: *mut ::std::os::raw::c_void,
+pub unsafe fn bcmp(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn bcmp(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        bcmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn bcopy(
     arg___src: *const ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memccpy(
-                __dst: *mut ::std::os::raw::c_void,
+            pub fn bcopy(
                 __src: *const ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+                __dest: *mut ::std::os::raw::c_void,
+                __n: usize,
+            );
         }
-        memccpy(arg___dst, arg___src, arg___c, arg___n)
+        bcopy(arg___src, arg___dest, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: ::std::os::raw::c_ulong) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn stpcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
         }
-        stpcpy(arg___dst, arg___src)
+        bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn stpncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        stpncpy(arg___dst, arg___src, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strndup(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strndup(
-                __s1: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strndup(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strnlen(arg___s1: *const ::std::os::raw::c_char, arg___n: usize) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
-        }
-        strnlen(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strsignal(arg___sig)
-    })
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[track_caller]
-pub unsafe fn memset_s(
-    arg___s: *mut ::std::os::raw::c_void,
-    arg___smax: rsize_t,
+pub unsafe fn index(
+    arg___s: *const ::std::os::raw::c_char,
     arg___c: ::std::os::raw::c_int,
-    arg___n: rsize_t,
-) -> errno_t {
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset_s(
-                __s: *mut ::std::os::raw::c_void,
-                __smax: rsize_t,
+            pub fn index(
+                __s: *const ::std::os::raw::c_char,
                 __c: ::std::os::raw::c_int,
-                __n: rsize_t,
-            ) -> errno_t;
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset_s(arg___s, arg___smax, arg___c, arg___n)
+        index(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn memmem(
-    arg___big: *const ::std::os::raw::c_void,
-    arg___big_len: usize,
-    arg___little: *const ::std::os::raw::c_void,
-    arg___little_len: usize,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memmem(
-                __big: *const ::std::os::raw::c_void,
-                __big_len: usize,
-                __little: *const ::std::os::raw::c_void,
-                __little_len: usize,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        memmem(arg___big, arg___big_len, arg___little, arg___little_len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern4(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern4: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern4(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern4: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern4(arg___b, arg___pattern4, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern8(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern8: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern8(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern8: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern8(arg___b, arg___pattern8, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern16(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern16: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern16(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern16: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern16(arg___b, arg___pattern16, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strcasestr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+pub unsafe fn rindex(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasestr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+            pub fn rindex(
+                __s: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcasestr(arg___big, arg___little)
+        rindex(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn strnstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
-    arg___len: usize,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ffs(arg___i: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strnstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
-                __len: usize,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        strnstr(arg___big, arg___little, arg___len)
+        ffs(arg___i)
     })
 }
 #[track_caller]
-pub unsafe fn strlcat(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsl(arg___l: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcat(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
         }
-        strlcat(arg___dst, arg___source, arg___size)
+        ffsl(arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn strlcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsll(arg___ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
         }
-        strlcpy(arg___dst, arg___source, arg___size)
+        ffsll(arg___ll)
     })
 }
 #[track_caller]
-pub unsafe fn strmode(arg___mode: ::std::os::raw::c_int, arg___bp: *mut ::std::os::raw::c_char) {
+pub unsafe fn strcasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+            pub fn strcasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        strmode(arg___mode, arg___bp)
+        strcasecmp(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn strcasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcasecmp_l(arg___s1, arg___s2, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: usize,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp_l(arg___s1, arg___s2, arg___n, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn explicit_bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+        }
+        explicit_bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
@@ -8506,285 +7133,111 @@ pub unsafe fn strsep(
     })
 }
 #[track_caller]
-pub unsafe fn swab(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: isize,
-) {
+pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn swab(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: isize,
-            );
+            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
         }
-        swab(arg_arg1, arg_arg2, arg_arg3)
+        strsignal(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn timingsafe_bcmp(
-    arg___b1: *const ::std::os::raw::c_void,
-    arg___b2: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timingsafe_bcmp(
-                __b1: *const ::std::os::raw::c_void,
-                __b2: *const ::std::os::raw::c_void,
-                __len: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        timingsafe_bcmp(arg___b1, arg___b2, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal_r(
-    arg___sig: ::std::os::raw::c_int,
-    arg___strsignalbuf: *mut ::std::os::raw::c_char,
-    arg___buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal_r(
-                __sig: ::std::os::raw::c_int,
-                __strsignalbuf: *mut ::std::os::raw::c_char,
-                __buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        strsignal_r(arg___sig, arg___strsignalbuf, arg___buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn bcmp(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcmp(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        bcmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bcopy(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcopy(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-            );
-        }
-        bcopy(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bzero(arg_arg1: *mut ::std::os::raw::c_void, arg_arg2: ::std::os::raw::c_ulong) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-        }
-        bzero(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn index(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn __stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn index(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn __stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        index(arg_arg1, arg_arg2)
+        __stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn rindex(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rindex(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        rindex(arg_arg1, arg_arg2)
+        stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn ffs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        ffs(arg_arg1)
+        __stpncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strcasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
+            pub fn stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strcasecmp(arg_arg1, arg_arg2)
+        stpncpy(arg___dest, arg___src, arg___n)
     })
 }
-#[track_caller]
-pub unsafe fn strncasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        strncasecmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        ffsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        ffsll(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fls(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        fls(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        flsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        flsll(arg_arg1)
-    })
-}
-pub type max_align_t = f64;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[track_caller]
-pub unsafe fn __darwin_check_fd_set_overflow(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn __errno_location() -> *mut ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __darwin_check_fd_set_overflow(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn __errno_location() -> *mut ::std::os::raw::c_int;
         }
-        __darwin_check_fd_set_overflow(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[track_caller]
-pub unsafe fn __error() -> *mut ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __error() -> *mut ::std::os::raw::c_int;
-        }
-        __error()
+        __errno_location()
     })
 }
 #[repr(C)]
@@ -8809,8 +7262,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -8825,6 +7278,21 @@ impl Default for lconv {
     }
 }
 #[track_caller]
+pub unsafe fn setlocale(
+    arg___category: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlocale(
+                __category: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        setlocale(arg___category, arg___locale)
+    })
+}
+#[track_caller]
 pub unsafe fn localeconv() -> *mut lconv {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -8834,18 +7302,47 @@ pub unsafe fn localeconv() -> *mut lconv {
     })
 }
 #[track_caller]
-pub unsafe fn setlocale(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn newlocale(
+    arg___category_mask: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+    arg___base: locale_t,
+) -> locale_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setlocale(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn newlocale(
+                __category_mask: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+                __base: locale_t,
+            ) -> locale_t;
         }
-        setlocale(arg_arg1, arg_arg2)
+        newlocale(arg___category_mask, arg___locale, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn duplocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn duplocale(__dataset: locale_t) -> locale_t;
+        }
+        duplocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn freelocale(arg___dataset: locale_t) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freelocale(__dataset: locale_t);
+        }
+        freelocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn uselocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn uselocale(__dataset: locale_t) -> locale_t;
+        }
+        uselocale(arg___dataset)
     })
 }
 pub type Pointer = *mut ::std::os::raw::c_char;
@@ -8979,163 +7476,401 @@ impl Default for PGAlignedXLogBlock {
         }
     }
 }
+pub const _ISupper: _bindgen_ty_1 = 256;
+pub const _ISlower: _bindgen_ty_1 = 512;
+pub const _ISalpha: _bindgen_ty_1 = 1024;
+pub const _ISdigit: _bindgen_ty_1 = 2048;
+pub const _ISxdigit: _bindgen_ty_1 = 4096;
+pub const _ISspace: _bindgen_ty_1 = 8192;
+pub const _ISprint: _bindgen_ty_1 = 16384;
+pub const _ISgraph: _bindgen_ty_1 = 32768;
+pub const _ISblank: _bindgen_ty_1 = 1;
+pub const _IScntrl: _bindgen_ty_1 = 2;
+pub const _ISpunct: _bindgen_ty_1 = 4;
+pub const _ISalnum: _bindgen_ty_1 = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn fdatasync(arg_fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
         }
-        fdatasync(arg_fildes)
-    })
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
-}
-extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
-}
-#[track_caller]
-pub unsafe fn ___runetype(arg_arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
-        }
-        ___runetype(arg_arg1)
+        __ctype_b_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_tolower_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
         }
-        ___tolower(arg_arg1)
+        __ctype_tolower_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_toupper_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
         }
-        ___toupper(arg_arg1)
+        __ctype_toupper_loc()
     })
 }
 #[track_caller]
-pub unsafe fn __maskrune(
-    arg_arg1: __darwin_ct_rune_t,
-    arg_arg2: ::std::os::raw::c_ulong,
+pub unsafe fn isalnum(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalnum(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalpha(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalpha(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn iscntrl(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        iscntrl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn islower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        islower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isgraph(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isprint(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        ispunct(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isspace(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isxdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        tolower(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toupper(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isblank(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn _toupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _toupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn _tolower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _tolower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalnum_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __maskrune(
-                arg1: __darwin_ct_rune_t,
-                arg2: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
+            pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __maskrune(arg_arg1, arg_arg2)
+        isalnum_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn isalpha_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __toupper(arg_arg1)
+        isalpha_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn iscntrl_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __tolower(arg_arg1)
+        iscntrl_l(arg_arg1, arg_arg2)
     })
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[track_caller]
+pub unsafe fn isdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn islower_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        islower_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isgraph_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isprint_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        ispunct_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isspace_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isupper_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t)
+                -> ::std::os::raw::c_int;
+        }
+        isxdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isblank_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn __toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __toupper_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        toupper_l(arg___c, arg___l)
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -9151,68 +7886,30 @@ impl Default for iovec {
         }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-pub type sockaddr_ref_t = *mut sockaddr;
-pub type sockaddr_ref_ref_t = *mut *mut sockaddr;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sockaddr_header {
-    pub sa_len: __uint8_t,
-    pub sa_family: sa_family_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
@@ -9223,17 +7920,37 @@ impl Default for sockaddr_storage {
         }
     }
 }
-pub type sockaddr_storage_ref_t = *mut sockaddr_storage;
-pub type sockaddr_storage_ref_ref_t = *mut *mut sockaddr_storage;
+pub const MSG_OOB: _bindgen_ty_2 = 1;
+pub const MSG_PEEK: _bindgen_ty_2 = 2;
+pub const MSG_DONTROUTE: _bindgen_ty_2 = 4;
+pub const MSG_CTRUNC: _bindgen_ty_2 = 8;
+pub const MSG_PROXY: _bindgen_ty_2 = 16;
+pub const MSG_TRUNC: _bindgen_ty_2 = 32;
+pub const MSG_DONTWAIT: _bindgen_ty_2 = 64;
+pub const MSG_EOR: _bindgen_ty_2 = 128;
+pub const MSG_WAITALL: _bindgen_ty_2 = 256;
+pub const MSG_FIN: _bindgen_ty_2 = 512;
+pub const MSG_SYN: _bindgen_ty_2 = 1024;
+pub const MSG_CONFIRM: _bindgen_ty_2 = 2048;
+pub const MSG_RST: _bindgen_ty_2 = 4096;
+pub const MSG_ERRQUEUE: _bindgen_ty_2 = 8192;
+pub const MSG_NOSIGNAL: _bindgen_ty_2 = 16384;
+pub const MSG_MORE: _bindgen_ty_2 = 32768;
+pub const MSG_WAITFORONE: _bindgen_ty_2 = 65536;
+pub const MSG_BATCH: _bindgen_ty_2 = 262144;
+pub const MSG_ZEROCOPY: _bindgen_ty_2 = 67108864;
+pub const MSG_FASTOPEN: _bindgen_ty_2 = 536870912;
+pub const MSG_CMSG_CLOEXEC: _bindgen_ty_2 = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -9246,438 +7963,423 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[track_caller]
+pub unsafe fn __cmsg_nxthdr(arg___mhdr: *mut msghdr, arg___cmsg: *mut cmsghdr) -> *mut cmsghdr {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+        }
+        __cmsg_nxthdr(arg___mhdr, arg___cmsg)
+    })
+}
+pub const SCM_RIGHTS: _bindgen_ty_3 = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn accept(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn accept(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        accept(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bind(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bind(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        bind(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn connect(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn connect(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        connect(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getpeername(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpeername(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getpeername(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockname(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockname(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockname(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_void,
-    arg_arg5: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_void,
-                arg5: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn listen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn listen(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        listen(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn recv(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recv(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recv(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn recvfrom(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *mut sockaddr,
-    arg_arg6: *mut socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvfrom(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *mut sockaddr,
-                arg6: *mut socklen_t,
-            ) -> isize;
-        }
-        recvfrom(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn recvmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recvmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn send(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn send(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        send(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn sendmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        sendmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn sendto(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *const sockaddr,
-    arg_arg6: socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendto(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const sockaddr,
-                arg6: socklen_t,
-            ) -> isize;
-        }
-        sendto(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_void,
-    arg_arg5: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_void,
-                arg5: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn shutdown(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn shutdown(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        shutdown(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sockatmark(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sockatmark(arg_arg1)
-    })
-}
+pub const SHUT_RD: _bindgen_ty_4 = 0;
+pub const SHUT_WR: _bindgen_ty_4 = 1;
+pub const SHUT_RDWR: _bindgen_ty_4 = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn socket(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socket(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socket(arg_arg1, arg_arg2, arg_arg3)
+        socket(arg___domain, arg___type, arg___protocol)
     })
 }
 #[track_caller]
 pub unsafe fn socketpair(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
+    arg___fds: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socketpair(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
+                __fds: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socketpair(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        socketpair(arg___domain, arg___type, arg___protocol, arg___fds)
     })
 }
 #[track_caller]
-pub unsafe fn sendfile(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: off_t,
-    arg_arg4: *mut off_t,
-    arg_arg5: *mut sf_hdtr,
-    arg_arg6: ::std::os::raw::c_int,
+pub unsafe fn bind(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sendfile(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: off_t,
-                arg4: *mut off_t,
-                arg5: *mut sf_hdtr,
-                arg6: ::std::os::raw::c_int,
+            pub fn bind(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        sendfile(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
+        bind(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn pfctlinput(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut sockaddr) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-        }
-        pfctlinput(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn connectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sa_endpoints_t,
-    arg_arg3: sae_associd_t,
-    arg_arg4: ::std::os::raw::c_uint,
-    arg_arg5: *const iovec,
-    arg_arg6: ::std::os::raw::c_uint,
-    arg_arg7: *mut usize,
-    arg_arg8: *mut sae_connid_t,
+pub unsafe fn getsockname(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn connectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sa_endpoints_t,
-                arg3: sae_associd_t,
-                arg4: ::std::os::raw::c_uint,
-                arg5: *const iovec,
-                arg6: ::std::os::raw::c_uint,
-                arg7: *mut usize,
-                arg8: *mut sae_connid_t,
+            pub fn getsockname(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        connectx(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7, arg_arg8)
+        getsockname(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn disconnectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: sae_associd_t,
-    arg_arg3: sae_connid_t,
+pub unsafe fn connect(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn disconnectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: sae_associd_t,
-                arg3: sae_connid_t,
+            pub fn connect(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        disconnectx(arg_arg1, arg_arg2, arg_arg3)
+        connect(arg___fd, arg___addr, arg___len)
     })
 }
+#[track_caller]
+pub unsafe fn getpeername(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeername(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeername(arg___fd, arg___addr, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn send(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn send(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        send(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recv(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recv(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recv(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn sendto(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___addr_len: socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendto(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __addr_len: socklen_t,
+            ) -> isize;
+        }
+        sendto(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn recvfrom(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvfrom(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> isize;
+        }
+        recvfrom(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn sendmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *const msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *const msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        sendmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recvmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *mut msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *mut msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recvmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn getsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *mut ::std::os::raw::c_void,
+    arg___optlen: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *mut ::std::os::raw::c_void,
+                __optlen: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn setsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *const ::std::os::raw::c_void,
+    arg___optlen: socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *const ::std::os::raw::c_void,
+                __optlen: socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        setsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn listen(
+    arg___fd: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn listen(
+                __fd: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        listen(arg___fd, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn accept(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn accept(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        accept(arg___fd, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn shutdown(
+    arg___fd: ::std::os::raw::c_int,
+    arg___how: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn shutdown(
+                __fd: ::std::os::raw::c_int,
+                __how: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        shutdown(arg___fd, arg___how)
+    })
+}
+#[track_caller]
+pub unsafe fn sockatmark(arg___fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sockatmark(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn isfdtype(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fdtype: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isfdtype(
+                __fd: ::std::os::raw::c_int,
+                __fdtype: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        isfdtype(arg___fd, arg___fdtype)
+    })
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9696,12 +8398,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -9709,175 +8405,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn setipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: u32,
-    arg_arg5: u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: u32,
-                arg5: u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        setipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn getipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: *mut u32,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: *mut u32,
-                arg5: *mut u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        getipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: u32,
-    arg_arg6: u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: u32,
-                arg6: u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: *mut u32,
-                arg6: *mut u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: _bindgen_ty_5 = 0;
+pub const IPPROTO_ICMP: _bindgen_ty_5 = 1;
+pub const IPPROTO_IGMP: _bindgen_ty_5 = 2;
+pub const IPPROTO_IPIP: _bindgen_ty_5 = 4;
+pub const IPPROTO_TCP: _bindgen_ty_5 = 6;
+pub const IPPROTO_EGP: _bindgen_ty_5 = 8;
+pub const IPPROTO_PUP: _bindgen_ty_5 = 12;
+pub const IPPROTO_UDP: _bindgen_ty_5 = 17;
+pub const IPPROTO_IDP: _bindgen_ty_5 = 22;
+pub const IPPROTO_TP: _bindgen_ty_5 = 29;
+pub const IPPROTO_DCCP: _bindgen_ty_5 = 33;
+pub const IPPROTO_IPV6: _bindgen_ty_5 = 41;
+pub const IPPROTO_RSVP: _bindgen_ty_5 = 46;
+pub const IPPROTO_GRE: _bindgen_ty_5 = 47;
+pub const IPPROTO_ESP: _bindgen_ty_5 = 50;
+pub const IPPROTO_AH: _bindgen_ty_5 = 51;
+pub const IPPROTO_MTP: _bindgen_ty_5 = 92;
+pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
+pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
+pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
+pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
+pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
+pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
+pub const IPPROTO_ETHERNET: _bindgen_ty_5 = 143;
+pub const IPPROTO_RAW: _bindgen_ty_5 = 255;
+pub const IPPROTO_MPTCP: _bindgen_ty_5 = 262;
+pub const IPPROTO_MAX: _bindgen_ty_5 = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: _bindgen_ty_6 = 0;
+pub const IPPROTO_ROUTING: _bindgen_ty_6 = 43;
+pub const IPPROTO_FRAGMENT: _bindgen_ty_6 = 44;
+pub const IPPROTO_ICMPV6: _bindgen_ty_6 = 58;
+pub const IPPROTO_NONE: _bindgen_ty_6 = 59;
+pub const IPPROTO_DSTOPTS: _bindgen_ty_6 = 60;
+pub const IPPROTO_MH: _bindgen_ty_6 = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: _bindgen_ty_7 = 7;
+pub const IPPORT_DISCARD: _bindgen_ty_7 = 9;
+pub const IPPORT_SYSTAT: _bindgen_ty_7 = 11;
+pub const IPPORT_DAYTIME: _bindgen_ty_7 = 13;
+pub const IPPORT_NETSTAT: _bindgen_ty_7 = 15;
+pub const IPPORT_FTP: _bindgen_ty_7 = 21;
+pub const IPPORT_TELNET: _bindgen_ty_7 = 23;
+pub const IPPORT_SMTP: _bindgen_ty_7 = 25;
+pub const IPPORT_TIMESERVER: _bindgen_ty_7 = 37;
+pub const IPPORT_NAMESERVER: _bindgen_ty_7 = 42;
+pub const IPPORT_WHOIS: _bindgen_ty_7 = 43;
+pub const IPPORT_MTP: _bindgen_ty_7 = 57;
+pub const IPPORT_TFTP: _bindgen_ty_7 = 69;
+pub const IPPORT_RJE: _bindgen_ty_7 = 77;
+pub const IPPORT_FINGER: _bindgen_ty_7 = 79;
+pub const IPPORT_TTYLINK: _bindgen_ty_7 = 87;
+pub const IPPORT_SUPDUP: _bindgen_ty_7 = 95;
+pub const IPPORT_EXECSERVER: _bindgen_ty_7 = 512;
+pub const IPPORT_LOGINSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_CMDSERVER: _bindgen_ty_7 = 514;
+pub const IPPORT_EFSSERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_BIFFUDP: _bindgen_ty_7 = 512;
+pub const IPPORT_WHOSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_ROUTESERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_RESERVED: _bindgen_ty_7 = 1024;
+pub const IPPORT_USERRESERVED: _bindgen_ty_7 = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -9897,16 +8505,28 @@ impl Default for in6_addr {
         }
     }
 }
-pub type in6_addr_t = in6_addr;
+extern "C" {
+    pub static in6addr_any: in6_addr;
+}
+extern "C" {
+    pub static in6addr_loopback: in6_addr;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
     pub sin6_family: sa_family_t,
     pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
+    pub sin6_flowinfo: u32,
     pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
+    pub sin6_scope_id: u32,
 }
 impl Default for sockaddr_in6 {
     fn default() -> Self {
@@ -9917,23 +8537,18 @@ impl Default for sockaddr_in6 {
         }
     }
 }
-extern "C" {
-    pub static in6addr_any: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
 }
-extern "C" {
-    pub static in6addr_loopback: in6_addr;
-}
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -9951,12 +8566,12 @@ impl Default for ipv6_mreq {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+#[derive(Debug, Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9966,12 +8581,40 @@ impl Default for in6_pktinfo {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+#[derive(Debug, Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9981,464 +8624,236 @@ impl Default for ip6_mtuinfo {
     }
 }
 #[track_caller]
-pub unsafe fn inet6_option_space(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn ntohl(arg___netlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn ntohl(__netlong: u32) -> u32;
         }
-        inet6_option_space(arg_arg1)
+        ntohl(arg___netlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *mut *mut cmsghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ntohs(arg___netshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut *mut cmsghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn ntohs(__netshort: u16) -> u16;
         }
-        inet6_option_init(arg_arg1, arg_arg2, arg_arg3)
+        ntohs(arg___netshort)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_append(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn htonl(arg___hostlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_append(
-                arg1: *mut cmsghdr,
-                arg2: *const __uint8_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn htonl(__hostlong: u32) -> u32;
         }
-        inet6_option_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        htonl(arg___hostlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_alloc(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut __uint8_t {
+pub unsafe fn htons(arg___hostshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_alloc(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut __uint8_t;
+            pub fn htons(__hostshort: u16) -> u16;
         }
-        inet6_option_alloc(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_next(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_next(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_next(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_find(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_find(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_find(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> usize;
-        }
-        inet6_rthdr_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut cmsghdr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut cmsghdr;
-        }
-        inet6_rthdr_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_add(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const in6_addr,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_add(
-                arg1: *mut cmsghdr,
-                arg2: *const in6_addr,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_add(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_lasthop(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_lasthop(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_lasthop(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_segments(arg_arg1: *const cmsghdr) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getaddr(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getaddr(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rthdr_getaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getflags(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getflags(
-                arg1: *const cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_getflags(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_append(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: socklen_t,
-    arg_arg6: __uint8_t,
-    arg_arg7: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_append(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: socklen_t,
-                arg6: __uint8_t,
-                arg7: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_finish(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_finish(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_finish(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_set_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_set_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_set_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_next(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_next(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_next(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_find(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_find(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_find(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_get_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_get_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_get_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> socklen_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> socklen_t;
-        }
-        inet6_rth_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        inet6_rth_init(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_add(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *const in6_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_add(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const in6_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_add(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_reverse(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_reverse(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_reverse(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_segments(arg_arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void)
-                -> ::std::os::raw::c_int;
-        }
-        inet6_rth_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_getaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_getaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rth_getaddr(arg_arg1, arg_arg2)
+        htons(arg___hostshort)
     })
 }
 #[track_caller]
 pub unsafe fn bindresvport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr_in,
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bindresvport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr_in,
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport(arg_arg1, arg_arg2)
+        bindresvport(arg___sockfd, arg___sock_in)
     })
 }
 #[track_caller]
-pub unsafe fn bindresvport_sa(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
+pub unsafe fn bindresvport6(
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in6,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bindresvport_sa(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
+            pub fn bindresvport6(
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in6,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport_sa(arg_arg1, arg_arg2)
+        bindresvport6(arg___sockfd, arg___sock_in)
     })
 }
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn setrpcent(arg___stayopen: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
+        }
+        setrpcent(arg___stayopen)
+    })
+}
+#[track_caller]
+pub unsafe fn endrpcent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endrpcent();
+        }
+        endrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname(arg___name: *const ::std::os::raw::c_char) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
+        }
+        getrpcbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber(arg___number: ::std::os::raw::c_int) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
+        }
+        getrpcbynumber(arg___number)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent() -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent() -> *mut rpcent;
+        }
+        getrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbyname_r(arg___name, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber_r(
+    arg___number: ::std::os::raw::c_int,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber_r(
+                __number: ::std::os::raw::c_int,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbynumber_r(arg___number, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent_r(
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent_r(
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcent_r(arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn __h_errno_location() -> *mut ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+        }
+        __h_errno_location()
+    })
+}
+#[track_caller]
+pub unsafe fn herror(arg___str: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn herror(__str: *const ::std::os::raw::c_char);
+        }
+        herror(arg___str)
+    })
+}
+#[track_caller]
+pub unsafe fn hstrerror(arg___err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        hstrerror(arg___err_num)
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10458,22 +8873,322 @@ impl Default for hostent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
+#[track_caller]
+pub unsafe fn sethostent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sethostent(__stay_open: ::std::os::raw::c_int);
         }
-    }
+        sethostent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endhostent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endhostent();
+        }
+        endhostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent() -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent() -> *mut hostent;
+        }
+        gethostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyaddr(arg___addr, arg___len, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname(arg___name: *const ::std::os::raw::c_char) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+        }
+        gethostbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyname2(arg___name, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent_r(
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent_r(
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr_r(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr_r(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyaddr_r(
+            arg___addr,
+            arg___len,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2_r(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname2_r(
+            arg___name,
+            arg___af,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn setnetent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+        }
+        setnetent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endnetent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endnetent();
+        }
+        endnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent() -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent() -> *mut netent;
+        }
+        getnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr(arg___net: u32, arg___type: ::std::os::raw::c_int) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+        }
+        getnetbyaddr(arg___net, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname(arg___name: *const ::std::os::raw::c_char) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+        }
+        getnetbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent_r(
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent_r(
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr_r(
+    arg___net: u32,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr_r(
+                __net: u32,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyaddr_r(
+            arg___net,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10492,6 +9207,142 @@ impl Default for servent {
         }
     }
 }
+#[track_caller]
+pub unsafe fn setservent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setservent(__stay_open: ::std::os::raw::c_int);
+        }
+        setservent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endservent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endservent();
+        }
+        endservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservent() -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent() -> *mut servent;
+        }
+        getservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyname(arg___name, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyport(arg___port, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservent_r(
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent_r(
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyname_r(
+            arg___name,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport_r(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport_r(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyport_r(
+            arg___port,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -10508,59 +9359,13 @@ impl Default for protoent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
 #[track_caller]
-pub unsafe fn endhostent() {
+pub unsafe fn setprotoent(arg___stay_open: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn endhostent();
+            pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
         }
-        endhostent()
-    })
-}
-#[track_caller]
-pub unsafe fn endnetent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endnetent();
-        }
-        endnetent()
+        setprotoent(arg___stay_open)
     })
 }
 #[track_caller]
@@ -10573,157 +9378,6 @@ pub unsafe fn endprotoent() {
     })
 }
 #[track_caller]
-pub unsafe fn endservent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endservent();
-        }
-        endservent()
-    })
-}
-#[track_caller]
-pub unsafe fn freeaddrinfo(arg_arg1: *mut addrinfo) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freeaddrinfo(arg1: *mut addrinfo);
-        }
-        freeaddrinfo(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gai_strerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        gai_strerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getaddrinfo(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const addrinfo,
-    arg_arg4: *mut *mut addrinfo,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getaddrinfo(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const addrinfo,
-                arg4: *mut *mut addrinfo,
-            ) -> ::std::os::raw::c_int;
-        }
-        getaddrinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyaddr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-        }
-        gethostbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostent() -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostent() -> *mut hostent;
-        }
-        gethostent()
-    })
-}
-#[track_caller]
-pub unsafe fn getnameinfo(
-    arg_arg1: *const sockaddr,
-    arg_arg2: socklen_t,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut ::std::os::raw::c_char,
-    arg_arg6: socklen_t,
-    arg_arg7: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnameinfo(
-                arg1: *const sockaddr,
-                arg2: socklen_t,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: socklen_t,
-                arg5: *mut ::std::os::raw::c_char,
-                arg6: socklen_t,
-                arg7: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        getnameinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyaddr(arg_arg1: u32, arg_arg2: ::std::os::raw::c_int) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-        }
-        getnetbyaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-        }
-        getnetbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetent() -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetent() -> *mut netent;
-        }
-        getnetent()
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-        }
-        getprotobyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobynumber(arg_arg1: ::std::os::raw::c_int) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-        }
-        getprotobynumber(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn getprotoent() -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -10733,239 +9387,91 @@ pub unsafe fn getprotoent() -> *mut protoent {
     })
 }
 #[track_caller]
-pub unsafe fn getservbyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobyname(arg___name: *const ::std::os::raw::c_char) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
         }
-        getservbyname(arg_arg1, arg_arg2)
+        getprotobyname(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn getservbyport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobynumber(arg___proto: ::std::os::raw::c_int) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
         }
-        getservbyport(arg_arg1, arg_arg2)
+        getprotobynumber(arg___proto)
     })
 }
 #[track_caller]
-pub unsafe fn getservent() -> *mut servent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getservent() -> *mut servent;
-        }
-        getservent()
-    })
-}
-#[track_caller]
-pub unsafe fn sethostent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sethostent(arg1: ::std::os::raw::c_int);
-        }
-        sethostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setnetent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setnetent(arg1: ::std::os::raw::c_int);
-        }
-        setnetent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setprotoent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprotoent(arg1: ::std::os::raw::c_int);
-        }
-        setprotoent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setservent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setservent(arg1: ::std::os::raw::c_int);
-        }
-        setservent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn freehostent(arg_arg1: *mut hostent) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freehostent(arg1: *mut hostent);
-        }
-        freehostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyname2(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyaddr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyname(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbyname(arg_name: *const ::std::os::raw::c_char) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-        }
-        getrpcbyname(arg_name)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbynumber(arg_number: ::std::os::raw::c_int) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-        }
-        getrpcbynumber(arg_number)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcent() -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcent() -> *mut rpcent;
-        }
-        getrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn setrpcent(arg_stayopen: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrpcent(stayopen: ::std::os::raw::c_int);
-        }
-        setrpcent(arg_stayopen)
-    })
-}
-#[track_caller]
-pub unsafe fn endrpcent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endrpcent();
-        }
-        endrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn herror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn herror(arg1: *const ::std::os::raw::c_char);
-        }
-        herror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hstrerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        hstrerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn innetgr(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const ::std::os::raw::c_char,
+pub unsafe fn getprotoent_r(
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn innetgr(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const ::std::os::raw::c_char,
+            pub fn getprotoent_r(
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        innetgr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        getprotoent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn getnetgrent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+pub unsafe fn getprotobyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getnetgrent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+            pub fn getprotobyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        getnetgrent(arg_arg1, arg_arg2, arg_arg3)
+        getprotobyname_r(arg___name, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getprotobynumber_r(
+    arg___proto: ::std::os::raw::c_int,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getprotobynumber_r(
+                __proto: ::std::os::raw::c_int,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getprotobynumber_r(arg___proto, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn setnetgrent(arg___netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        setnetgrent(arg___netgroup)
     })
 }
 #[track_caller]
@@ -10978,29 +9484,283 @@ pub unsafe fn endnetgrent() {
     })
 }
 #[track_caller]
-pub unsafe fn setnetgrent(arg_arg1: *const ::std::os::raw::c_char) {
+pub unsafe fn getnetgrent(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+            pub fn getnetgrent(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        setnetgrent(arg_arg1)
+        getnetgrent(arg___hostp, arg___userp, arg___domainp)
+    })
+}
+#[track_caller]
+pub unsafe fn innetgr(
+    arg___netgroup: *const ::std::os::raw::c_char,
+    arg___host: *const ::std::os::raw::c_char,
+    arg___user: *const ::std::os::raw::c_char,
+    arg___domain: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn innetgr(
+                __netgroup: *const ::std::os::raw::c_char,
+                __host: *const ::std::os::raw::c_char,
+                __user: *const ::std::os::raw::c_char,
+                __domain: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        innetgr(arg___netgroup, arg___host, arg___user, arg___domain)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetgrent_r(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetgrent_r(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetgrent_r(arg___hostp, arg___userp, arg___domainp, arg___buffer, arg___buflen)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd(arg___ahost, arg___rport, arg___locuser, arg___remuser, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd_af(
+            arg___ahost,
+            arg___rport,
+            arg___locuser,
+            arg___remuser,
+            arg___cmd,
+            arg___fd2p,
+            arg___af,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn rexec(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rexec_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec_af(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok(arg___rhost, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok_af(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok_af(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok_af(arg___rhost, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok(
+    arg___raddr: u32,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok(
+                __raddr: u32,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok(arg___raddr, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok_af(
+    arg___raddr: *const ::std::os::raw::c_void,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok_af(
+                __raddr: *const ::std::os::raw::c_void,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok_af(arg___raddr, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport(arg___alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        rresvport(arg___alport)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport_af(
+    arg___alport: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport_af(
+                __alport: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rresvport_af(arg___alport, arg___af)
     })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -11010,73 +9770,94 @@ impl Default for passwd {
     }
 }
 #[track_caller]
-pub unsafe fn getpwuid(arg_arg1: uid_t) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-        }
-        getpwuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwnam(arg_arg1: *const ::std::os::raw::c_char) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-        }
-        getpwnam(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuid_r(
-    arg_arg1: uid_t,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getaddrinfo(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___service: *const ::std::os::raw::c_char,
+    arg___req: *const addrinfo,
+    arg___pai: *mut *mut addrinfo,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuid_r(
-                arg1: uid_t,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getaddrinfo(
+                __name: *const ::std::os::raw::c_char,
+                __service: *const ::std::os::raw::c_char,
+                __req: *const addrinfo,
+                __pai: *mut *mut addrinfo,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getaddrinfo(arg___name, arg___service, arg___req, arg___pai)
     })
 }
 #[track_caller]
-pub unsafe fn getpwnam_r(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn freeaddrinfo(arg___ai: *mut addrinfo) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freeaddrinfo(__ai: *mut addrinfo);
+        }
+        freeaddrinfo(arg___ai)
+    })
+}
+#[track_caller]
+pub unsafe fn gai_strerror(arg___ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        gai_strerror(arg___ecode)
+    })
+}
+#[track_caller]
+pub unsafe fn getnameinfo(
+    arg___sa: *const sockaddr,
+    arg___salen: socklen_t,
+    arg___host: *mut ::std::os::raw::c_char,
+    arg___hostlen: socklen_t,
+    arg___serv: *mut ::std::os::raw::c_char,
+    arg___servlen: socklen_t,
+    arg___flags: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwnam_r(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getnameinfo(
+                __sa: *const sockaddr,
+                __salen: socklen_t,
+                __host: *mut ::std::os::raw::c_char,
+                __hostlen: socklen_t,
+                __serv: *mut ::std::os::raw::c_char,
+                __servlen: socklen_t,
+                __flags: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getpwnam_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getnameinfo(
+            arg___sa,
+            arg___salen,
+            arg___host,
+            arg___hostlen,
+            arg___serv,
+            arg___servlen,
+            arg___flags,
+        )
     })
 }
-#[track_caller]
-pub unsafe fn getpwent() -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwent() -> *mut passwd;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        getpwent()
-    })
+    }
 }
 #[track_caller]
 pub unsafe fn setpwent() {
@@ -11096,192 +9877,131 @@ pub unsafe fn endpwent() {
         endpwent()
     })
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
-extern "C" {
-    pub static UUID_NULL: uuid_t;
-}
 #[track_caller]
-pub unsafe fn uuid_clear(arg_uu: *mut ::std::os::raw::c_uchar) {
+pub unsafe fn getpwent() -> *mut passwd {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+            pub fn getpwent() -> *mut passwd;
         }
-        uuid_clear(arg_uu)
+        getpwent()
     })
 }
 #[track_caller]
-pub unsafe fn uuid_compare(
-    arg_uu1: *mut ::std::os::raw::c_uchar,
-    arg_uu2: *mut ::std::os::raw::c_uchar,
+pub unsafe fn fgetpwent(arg___stream: *mut FILE) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+        }
+        fgetpwent(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putpwent(arg___p: *const passwd, arg___f: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putpwent(arg___p, arg___f)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwuid(arg___uid: __uid_t) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+        }
+        getpwuid(arg___uid)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwnam(arg___name: *const ::std::os::raw::c_char) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+        }
+        getpwnam(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwent_r(
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_compare(
-                uu1: *mut ::std::os::raw::c_uchar,
-                uu2: *mut ::std::os::raw::c_uchar,
+            pub fn getpwent_r(
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_compare(arg_uu1, arg_uu2)
+        getpwent_r(arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_copy(
-    arg_dst: *mut ::std::os::raw::c_uchar,
-    arg_src: *mut ::std::os::raw::c_uchar,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_copy(arg_dst, arg_src)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_random(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_random(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_time(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_time(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_is_null(arg_uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-        }
-        uuid_is_null(arg_uu)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_parse(
-    arg_in_: *mut ::std::os::raw::c_char,
-    arg_uu: *mut ::std::os::raw::c_uchar,
+pub unsafe fn getpwuid_r(
+    arg___uid: __uid_t,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_parse(
-                in_: *mut ::std::os::raw::c_char,
-                uu: *mut ::std::os::raw::c_uchar,
+            pub fn getpwuid_r(
+                __uid: __uid_t,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_parse(arg_in_, arg_uu)
+        getpwuid_r(arg___uid, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_unparse(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-        }
-        uuid_unparse(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_lower(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_lower(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_lower(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_upper(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_upper(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_upper(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn setpassent(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        setpassent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn user_from_uid(
-    arg_arg1: uid_t,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn user_from_uid(
-                arg1: uid_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        user_from_uid(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid(arg_arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-        }
-        getpwuuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid_r(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getpwnam_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuuid_r(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getpwnam_r(
+                __name: *const ::std::os::raw::c_char,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getpwnam_r(arg___name, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetpwent_r(
+    arg___stream: *mut FILE,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent_r(
+                __stream: *mut FILE,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
+            ) -> ::std::os::raw::c_int;
+        }
+        fgetpwent_r(arg___stream, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -11988,1692 +10708,761 @@ pub unsafe fn pg_srand48(arg_seed: ::std::os::raw::c_long) {
         pg_srand48(arg_seed)
     })
 }
+#[track_caller]
+pub unsafe fn fls(arg_mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        fls(arg_mask)
+    })
+}
+#[track_caller]
+pub unsafe fn getpeereid(
+    arg_sock: ::std::os::raw::c_int,
+    arg_uid: *mut uid_t,
+    arg_gid: *mut gid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeereid(
+                sock: ::std::os::raw::c_int,
+                uid: *mut uid_t,
+                gid: *mut gid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeereid(arg_sock, arg_uid, arg_gid)
+    })
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[track_caller]
-pub unsafe fn __math_errhandling() -> ::std::os::raw::c_int {
+pub unsafe fn __fpclassify(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __math_errhandling() -> ::std::os::raw::c_int;
+            pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
         }
-        __math_errhandling()
+        __fpclassify(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __signbit(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyf(arg_arg1)
+        __signbit(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyd(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyd(arg_arg1)
+        __isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyl(arg_arg1)
+        __finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosf(arg1: f32) -> f32;
+            pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosf(arg_arg1)
+        __isnan(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acos(arg_arg1: f64) -> f64 {
+pub unsafe fn __iseqsig(arg___x: f64, arg___y: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acos(arg1: f64) -> f64;
+            pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
         }
-        acos(arg_arg1)
+        __iseqsig(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn acosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __issignaling(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosl(arg1: f64) -> f64;
+            pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosl(arg_arg1)
+        __issignaling(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn asinf(arg_arg1: f32) -> f32 {
+pub unsafe fn acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinf(arg1: f32) -> f32;
+            pub fn acos(__x: f64) -> f64;
         }
-        asinf(arg_arg1)
+        acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asin(arg_arg1: f64) -> f64 {
+pub unsafe fn __acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asin(arg1: f64) -> f64;
+            pub fn __acos(__x: f64) -> f64;
         }
-        asin(arg_arg1)
+        __acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinl(arg_arg1: f64) -> f64 {
+pub unsafe fn asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinl(arg1: f64) -> f64;
+            pub fn asin(__x: f64) -> f64;
         }
-        asinl(arg_arg1)
+        asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanf(arg1: f32) -> f32;
+            pub fn __asin(__x: f64) -> f64;
         }
-        atanf(arg_arg1)
+        __asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan(arg_arg1: f64) -> f64 {
+pub unsafe fn atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan(arg1: f64) -> f64;
+            pub fn atan(__x: f64) -> f64;
         }
-        atan(arg_arg1)
+        atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanl(arg1: f64) -> f64;
+            pub fn __atan(__x: f64) -> f64;
         }
-        atanl(arg_arg1)
+        __atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2f(arg_arg1: f32, arg_arg2: f32) -> f32 {
+pub unsafe fn atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+            pub fn atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2f(arg_arg1, arg_arg2)
+        atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2(arg1: f64, arg2: f64) -> f64;
+            pub fn __atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2(arg_arg1, arg_arg2)
+        __atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2l(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+            pub fn cos(__x: f64) -> f64;
         }
-        atan2l(arg_arg1, arg_arg2)
+        cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosf(arg1: f32) -> f32;
+            pub fn __cos(__x: f64) -> f64;
         }
-        cosf(arg_arg1)
+        __cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cos(arg_arg1: f64) -> f64 {
+pub unsafe fn sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cos(arg1: f64) -> f64;
+            pub fn sin(__x: f64) -> f64;
         }
-        cos(arg_arg1)
+        sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosl(arg1: f64) -> f64;
+            pub fn __sin(__x: f64) -> f64;
         }
-        cosl(arg_arg1)
+        __sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinf(arg_arg1: f32) -> f32 {
+pub unsafe fn tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinf(arg1: f32) -> f32;
+            pub fn tan(__x: f64) -> f64;
         }
-        sinf(arg_arg1)
+        tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sin(arg_arg1: f64) -> f64 {
+pub unsafe fn __tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sin(arg1: f64) -> f64;
+            pub fn __tan(__x: f64) -> f64;
         }
-        sin(arg_arg1)
+        __tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinl(arg_arg1: f64) -> f64 {
+pub unsafe fn cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinl(arg1: f64) -> f64;
+            pub fn cosh(__x: f64) -> f64;
         }
-        sinl(arg_arg1)
+        cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanf(arg1: f32) -> f32;
+            pub fn __cosh(__x: f64) -> f64;
         }
-        tanf(arg_arg1)
+        __cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tan(arg_arg1: f64) -> f64 {
+pub unsafe fn sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tan(arg1: f64) -> f64;
+            pub fn sinh(__x: f64) -> f64;
         }
-        tan(arg_arg1)
+        sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanl(arg1: f64) -> f64;
+            pub fn __sinh(__x: f64) -> f64;
         }
-        tanl(arg_arg1)
+        __sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshf(arg_arg1: f32) -> f32 {
+pub unsafe fn tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshf(arg1: f32) -> f32;
+            pub fn tanh(__x: f64) -> f64;
         }
-        acoshf(arg_arg1)
+        tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acosh(arg_arg1: f64) -> f64 {
+pub unsafe fn __tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosh(arg1: f64) -> f64;
+            pub fn __tanh(__x: f64) -> f64;
         }
-        acosh(arg_arg1)
+        __tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshl(arg_arg1: f64) -> f64 {
+pub unsafe fn acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshl(arg1: f64) -> f64;
+            pub fn acosh(__x: f64) -> f64;
         }
-        acoshl(arg_arg1)
+        acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn __acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhf(arg1: f32) -> f32;
+            pub fn __acosh(__x: f64) -> f64;
         }
-        asinhf(arg_arg1)
+        __acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinh(arg_arg1: f64) -> f64 {
+pub unsafe fn asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinh(arg1: f64) -> f64;
+            pub fn asinh(__x: f64) -> f64;
         }
-        asinh(arg_arg1)
+        asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhl(arg1: f64) -> f64;
+            pub fn __asinh(__x: f64) -> f64;
         }
-        asinhl(arg_arg1)
+        __asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhf(arg1: f32) -> f32;
+            pub fn atanh(__x: f64) -> f64;
         }
-        atanhf(arg_arg1)
+        atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanh(arg1: f64) -> f64;
+            pub fn __atanh(__x: f64) -> f64;
         }
-        atanh(arg_arg1)
+        __atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhl(arg1: f64) -> f64;
+            pub fn exp(__x: f64) -> f64;
         }
-        atanhl(arg_arg1)
+        exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn coshf(arg_arg1: f32) -> f32 {
+pub unsafe fn __exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshf(arg1: f32) -> f32;
+            pub fn __exp(__x: f64) -> f64;
         }
-        coshf(arg_arg1)
+        __exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosh(arg_arg1: f64) -> f64 {
+pub unsafe fn frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosh(arg1: f64) -> f64;
+            pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        cosh(arg_arg1)
+        frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn coshl(arg_arg1: f64) -> f64 {
+pub unsafe fn __frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshl(arg1: f64) -> f64;
+            pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        coshl(arg_arg1)
+        __frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhf(arg1: f32) -> f32;
+            pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinhf(arg_arg1)
+        ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinh(arg_arg1: f64) -> f64 {
+pub unsafe fn __ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinh(arg1: f64) -> f64;
+            pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinh(arg_arg1)
+        __ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhl(arg1: f64) -> f64;
+            pub fn __log(__x: f64) -> f64;
         }
-        sinhl(arg_arg1)
+        __log(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhf(arg1: f32) -> f32;
+            pub fn log10(__x: f64) -> f64;
         }
-        tanhf(arg_arg1)
+        log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanh(arg1: f64) -> f64;
+            pub fn __log10(__x: f64) -> f64;
         }
-        tanh(arg_arg1)
+        __log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhl(arg1: f64) -> f64;
+            pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        tanhl(arg_arg1)
+        modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn expf(arg_arg1: f32) -> f32 {
+pub unsafe fn __modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expf(arg1: f32) -> f32;
+            pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        expf(arg_arg1)
+        __modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn exp(arg_arg1: f64) -> f64 {
+pub unsafe fn expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp(arg1: f64) -> f64;
+            pub fn expm1(__x: f64) -> f64;
         }
-        exp(arg_arg1)
+        expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expl(arg_arg1: f64) -> f64 {
+pub unsafe fn __expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expl(arg1: f64) -> f64;
+            pub fn __expm1(__x: f64) -> f64;
         }
-        expl(arg_arg1)
+        __expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2f(arg_arg1: f32) -> f32 {
+pub unsafe fn log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2f(arg1: f32) -> f32;
+            pub fn log1p(__x: f64) -> f64;
         }
-        exp2f(arg_arg1)
+        log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2(arg_arg1: f64) -> f64 {
+pub unsafe fn __log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2(arg1: f64) -> f64;
+            pub fn __log1p(__x: f64) -> f64;
         }
-        exp2(arg_arg1)
+        __log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2l(arg_arg1: f64) -> f64 {
+pub unsafe fn logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2l(arg1: f64) -> f64;
+            pub fn logb(__x: f64) -> f64;
         }
-        exp2l(arg_arg1)
+        logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1f(arg_arg1: f32) -> f32 {
+pub unsafe fn __logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1f(arg1: f32) -> f32;
+            pub fn __logb(__x: f64) -> f64;
         }
-        expm1f(arg_arg1)
+        __logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1(arg_arg1: f64) -> f64 {
+pub unsafe fn exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1(arg1: f64) -> f64;
+            pub fn exp2(__x: f64) -> f64;
         }
-        expm1(arg_arg1)
+        exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1l(arg_arg1: f64) -> f64 {
+pub unsafe fn __exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1l(arg1: f64) -> f64;
+            pub fn __exp2(__x: f64) -> f64;
         }
-        expm1l(arg_arg1)
+        __exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logf(arg_arg1: f32) -> f32 {
+pub unsafe fn log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logf(arg1: f32) -> f32;
+            pub fn log2(__x: f64) -> f64;
         }
-        logf(arg_arg1)
+        log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logl(arg1: f64) -> f64;
+            pub fn __log2(__x: f64) -> f64;
         }
-        logl(arg_arg1)
+        __log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log10f(arg_arg1: f32) -> f32 {
+pub unsafe fn pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10f(arg1: f32) -> f32;
+            pub fn pow(__x: f64, __y: f64) -> f64;
         }
-        log10f(arg_arg1)
+        pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10(arg_arg1: f64) -> f64 {
+pub unsafe fn __pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10(arg1: f64) -> f64;
+            pub fn __pow(__x: f64, __y: f64) -> f64;
         }
-        log10(arg_arg1)
+        __pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10l(arg_arg1: f64) -> f64 {
+pub unsafe fn sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10l(arg1: f64) -> f64;
+            pub fn sqrt(__x: f64) -> f64;
         }
-        log10l(arg_arg1)
+        sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2f(arg_arg1: f32) -> f32 {
+pub unsafe fn __sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2f(arg1: f32) -> f32;
+            pub fn __sqrt(__x: f64) -> f64;
         }
-        log2f(arg_arg1)
+        __sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2(arg_arg1: f64) -> f64 {
+pub unsafe fn hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2(arg1: f64) -> f64;
+            pub fn hypot(__x: f64, __y: f64) -> f64;
         }
-        log2(arg_arg1)
+        hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log2l(arg_arg1: f64) -> f64 {
+pub unsafe fn __hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2l(arg1: f64) -> f64;
+            pub fn __hypot(__x: f64, __y: f64) -> f64;
         }
-        log2l(arg_arg1)
+        __hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log1pf(arg_arg1: f32) -> f32 {
+pub unsafe fn cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pf(arg1: f32) -> f32;
+            pub fn cbrt(__x: f64) -> f64;
         }
-        log1pf(arg_arg1)
+        cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1p(arg_arg1: f64) -> f64 {
+pub unsafe fn __cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1p(arg1: f64) -> f64;
+            pub fn __cbrt(__x: f64) -> f64;
         }
-        log1p(arg_arg1)
+        __cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1pl(arg_arg1: f64) -> f64 {
+pub unsafe fn ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pl(arg1: f64) -> f64;
+            pub fn ceil(__x: f64) -> f64;
         }
-        log1pl(arg_arg1)
+        ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbf(arg_arg1: f32) -> f32 {
+pub unsafe fn __ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbf(arg1: f32) -> f32;
+            pub fn __ceil(__x: f64) -> f64;
         }
-        logbf(arg_arg1)
+        __ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logb(arg_arg1: f64) -> f64 {
+pub unsafe fn fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logb(arg1: f64) -> f64;
+            pub fn fabs(__x: f64) -> f64;
         }
-        logb(arg_arg1)
+        fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbl(arg_arg1: f64) -> f64 {
+pub unsafe fn __fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbl(arg1: f64) -> f64;
+            pub fn __fabs(__x: f64) -> f64;
         }
-        logbl(arg_arg1)
+        __fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modff(arg_arg1: f32, arg_arg2: *mut f32) -> f32 {
+pub unsafe fn floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+            pub fn floor(__x: f64) -> f64;
         }
-        modff(arg_arg1, arg_arg2)
+        floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modf(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn __floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn __floor(__x: f64) -> f64;
         }
-        modf(arg_arg1, arg_arg2)
+        __floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modfl(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn fmod(__x: f64, __y: f64) -> f64;
         }
-        modfl(arg_arg1, arg_arg2)
+        fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn __fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn __fmod(__x: f64, __y: f64) -> f64;
         }
-        ldexpf(arg_arg1, arg_arg2)
+        __fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexp(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexp(arg_arg1, arg_arg2)
+        isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexpl(arg_arg1, arg_arg2)
+        finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn frexpf(arg_arg1: f32, arg_arg2: *mut ::std::os::raw::c_int) -> f32 {
+pub unsafe fn drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+            pub fn drem(__x: f64, __y: f64) -> f64;
         }
-        frexpf(arg_arg1, arg_arg2)
+        drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexp(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn __drem(__x: f64, __y: f64) -> f64;
         }
-        frexp(arg_arg1, arg_arg2)
+        __drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexpl(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn significand(__x: f64) -> f64;
         }
-        frexpl(arg_arg1, arg_arg2)
+        significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __significand(__x: f64) -> f64;
         }
-        ilogbf(arg_arg1)
+        __significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogb(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogb(arg_arg1)
+        copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogbl(arg_arg1)
+        __copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbnf(arg_arg1, arg_arg2)
+        nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbn(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbn(arg_arg1, arg_arg2)
+        __nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        scalbnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_long) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-        }
-        scalblnf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalbln(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalbln(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalblnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsf(arg1: f32) -> f32;
-        }
-        fabsf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabs(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabs(arg1: f64) -> f64;
-        }
-        fabs(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsl(arg1: f64) -> f64;
-        }
-        fabsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtf(arg1: f32) -> f32;
-        }
-        cbrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrt(arg1: f64) -> f64;
-        }
-        cbrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtl(arg1: f64) -> f64;
-        }
-        cbrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-        }
-        hypotf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypot(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypot(arg1: f64, arg2: f64) -> f64;
-        }
-        hypot(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-        }
-        hypotl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powf(arg1: f32, arg2: f32) -> f32;
-        }
-        powf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pow(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pow(arg1: f64, arg2: f64) -> f64;
-        }
-        pow(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powl(arg1: f64, arg2: f64) -> f64;
-        }
-        powl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtf(arg1: f32) -> f32;
-        }
-        sqrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrt(arg1: f64) -> f64;
-        }
-        sqrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtl(arg1: f64) -> f64;
-        }
-        sqrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erff(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erff(arg1: f32) -> f32;
-        }
-        erff(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erf(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erf(arg1: f64) -> f64;
-        }
-        erf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfl(arg1: f64) -> f64;
-        }
-        erfl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcf(arg1: f32) -> f32;
-        }
-        erfcf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfc(arg1: f64) -> f64;
-        }
-        erfc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcl(arg1: f64) -> f64;
-        }
-        erfcl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammaf(arg1: f32) -> f32;
-        }
-        lgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgamma(arg1: f64) -> f64;
-        }
-        lgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammal(arg1: f64) -> f64;
-        }
-        lgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammaf(arg1: f32) -> f32;
-        }
-        tgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgamma(arg1: f64) -> f64;
-        }
-        tgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammal(arg1: f64) -> f64;
-        }
-        tgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceilf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceilf(arg1: f32) -> f32;
-        }
-        ceilf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceil(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceil(arg1: f64) -> f64;
-        }
-        ceil(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceill(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceill(arg1: f64) -> f64;
-        }
-        ceill(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorf(arg1: f32) -> f32;
-        }
-        floorf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floor(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floor(arg1: f64) -> f64;
-        }
-        floor(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorl(arg1: f64) -> f64;
-        }
-        floorl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintf(arg1: f32) -> f32;
-        }
-        nearbyintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyint(arg1: f64) -> f64;
-        }
-        nearbyint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintl(arg1: f64) -> f64;
-        }
-        nearbyintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintf(arg1: f32) -> f32;
-        }
-        rintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rint(arg1: f64) -> f64;
-        }
-        rint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintl(arg1: f64) -> f64;
-        }
-        rintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrint(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundf(arg1: f32) -> f32;
-        }
-        roundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn round(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn round(arg1: f64) -> f64;
-        }
-        round(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundl(arg1: f64) -> f64;
-        }
-        roundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lround(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrint(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llround(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncf(arg1: f32) -> f32;
-        }
-        truncf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn trunc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn trunc(arg1: f64) -> f64;
-        }
-        trunc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncl(arg1: f64) -> f64;
-        }
-        truncl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmodf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmod(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmod(arg1: f64, arg2: f64) -> f64;
-        }
-        fmod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmodl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-        }
-        remainderf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainder(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainder(arg1: f64, arg2: f64) -> f64;
-        }
-        remainder(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-        }
-        remainderl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remquof(arg_arg1: f32, arg_arg2: f32, arg_arg3: *mut ::std::os::raw::c_int) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-        }
-        remquof(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquo(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquo(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquol(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquol(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-        }
-        copysignf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysign(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysign(arg1: f64, arg2: f64) -> f64;
-        }
-        copysign(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-        }
-        copysignl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nanf(arg_arg1: *const ::std::os::raw::c_char) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-        }
-        nanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nan(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nan(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nanl(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nanl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-        }
-        nextafterf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafter(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafter(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafterl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttoward(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttoward(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardf(arg_arg1: f32, arg_arg2: f64) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-        }
-        nexttowardf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttowardl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdimf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-        }
-        fdimf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdim(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdim(arg1: f64, arg2: f64) -> f64;
-        }
-        fdim(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdiml(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-        }
-        fdiml(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmaxf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmax(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmax(arg1: f64, arg2: f64) -> f64;
-        }
-        fmax(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmaxl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminf(arg1: f32, arg2: f32) -> f32;
-        }
-        fminf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmin(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmin(arg1: f64, arg2: f64) -> f64;
-        }
-        fmin(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminl(arg1: f64, arg2: f64) -> f64;
-        }
-        fminl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaf(arg_arg1: f32, arg_arg2: f32, arg_arg3: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-        }
-        fmaf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fma(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fma(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fmal(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fmal(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10f(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10f(arg1: f32) -> f32;
-        }
-        __exp10f(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10(arg1: f64) -> f64;
-        }
-        __exp10(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospif(arg1: f32) -> f32;
-        }
-        __cospif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospi(arg1: f64) -> f64;
-        }
-        __cospi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpif(arg1: f32) -> f32;
-        }
-        __sinpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpi(arg1: f64) -> f64;
-        }
-        __sinpi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpif(arg1: f32) -> f32;
-        }
-        __tanpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpi(arg1: f64) -> f64;
-        }
-        __tanpi(arg_arg1)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[track_caller]
-pub unsafe fn __sincosf_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincosf_stret(arg1: f32) -> __float2;
-        }
-        __sincosf_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincos_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincos_stret(arg1: f64) -> __double2;
-        }
-        __sincos_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospif_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospif_stret(arg1: f32) -> __float2;
-        }
-        __sincospif_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospi_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospi_stret(arg1: f64) -> __double2;
-        }
-        __sincospi_stret(arg_arg1)
+        isnan(arg___value)
     })
 }
 #[track_caller]
@@ -13686,12 +11475,30 @@ pub unsafe fn j0(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __j0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0(arg1: f64) -> f64;
+        }
+        __j0(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn j1(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn j1(arg1: f64) -> f64;
         }
         j1(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1(arg1: f64) -> f64;
+        }
+        __j1(arg_arg1)
     })
 }
 #[track_caller]
@@ -13704,12 +11511,30 @@ pub unsafe fn jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+        }
+        __jn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
 pub unsafe fn y0(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn y0(arg1: f64) -> f64;
         }
         y0(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0(arg1: f64) -> f64;
+        }
+        __y0(arg_arg1)
     })
 }
 #[track_caller]
@@ -13722,6 +11547,15 @@ pub unsafe fn y1(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __y1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1(arg1: f64) -> f64;
+        }
+        __y1(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -13731,42 +11565,3155 @@ pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
-pub unsafe fn scalb(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalb(arg1: f64, arg2: f64) -> f64;
+            pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
         }
-        scalb(arg_arg1, arg_arg2)
+        __yn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erf(arg1: f64) -> f64;
+        }
+        erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erf(arg1: f64) -> f64;
+        }
+        __erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfc(arg1: f64) -> f64;
+        }
+        erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfc(arg1: f64) -> f64;
+        }
+        __erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma(arg1: f64) -> f64;
+        }
+        lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma(arg1: f64) -> f64;
+        }
+        __lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgamma(arg1: f64) -> f64;
+        }
+        tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgamma(arg1: f64) -> f64;
+        }
+        __tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gamma(arg1: f64) -> f64;
+        }
+        gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gamma(arg1: f64) -> f64;
+        }
+        __gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rint(__x: f64) -> f64;
+        }
+        rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rint(__x: f64) -> f64;
+        }
+        __rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafter(__x: f64, __y: f64) -> f64;
+        }
+        nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafter(__x: f64, __y: f64) -> f64;
+        }
+        __nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        __nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainder(__x: f64, __y: f64) -> f64;
+        }
+        remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainder(__x: f64, __y: f64) -> f64;
+        }
+        __remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        __scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        __ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        __scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyint(__x: f64) -> f64;
+        }
+        nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyint(__x: f64) -> f64;
+        }
+        __nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn round(__x: f64) -> f64;
+        }
+        round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __round(__x: f64) -> f64;
+        }
+        __round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn trunc(__x: f64) -> f64;
+        }
+        trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __trunc(__x: f64) -> f64;
+        }
+        __trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdim(__x: f64, __y: f64) -> f64;
+        }
+        fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdim(__x: f64, __y: f64) -> f64;
+        }
+        __fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmax(__x: f64, __y: f64) -> f64;
+        }
+        fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmax(__x: f64, __y: f64) -> f64;
+        }
+        __fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmin(__x: f64, __y: f64) -> f64;
+        }
+        fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmin(__x: f64, __y: f64) -> f64;
+        }
+        __fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        __fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalb(__x: f64, __n: f64) -> f64;
+        }
+        scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalb(__x: f64, __n: f64) -> f64;
+        }
+        __scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __signbitf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigf(arg___x: f32, arg___y: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+        }
+        __iseqsigf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __issignalingf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosf(__x: f32) -> f32;
+        }
+        acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosf(__x: f32) -> f32;
+        }
+        __acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinf(__x: f32) -> f32;
+        }
+        asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinf(__x: f32) -> f32;
+        }
+        __asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanf(__x: f32) -> f32;
+        }
+        atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanf(__x: f32) -> f32;
+        }
+        __atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2f(__y: f32, __x: f32) -> f32;
+        }
+        atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2f(__y: f32, __x: f32) -> f32;
+        }
+        __atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosf(__x: f32) -> f32;
+        }
+        cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosf(__x: f32) -> f32;
+        }
+        __cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinf(__x: f32) -> f32;
+        }
+        sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinf(__x: f32) -> f32;
+        }
+        __sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanf(__x: f32) -> f32;
+        }
+        tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanf(__x: f32) -> f32;
+        }
+        __tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshf(__x: f32) -> f32;
+        }
+        coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshf(__x: f32) -> f32;
+        }
+        __coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhf(__x: f32) -> f32;
+        }
+        sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhf(__x: f32) -> f32;
+        }
+        __sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhf(__x: f32) -> f32;
+        }
+        tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhf(__x: f32) -> f32;
+        }
+        __tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshf(__x: f32) -> f32;
+        }
+        acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshf(__x: f32) -> f32;
+        }
+        __acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhf(__x: f32) -> f32;
+        }
+        asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhf(__x: f32) -> f32;
+        }
+        __asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhf(__x: f32) -> f32;
+        }
+        atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhf(__x: f32) -> f32;
+        }
+        __atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expf(__x: f32) -> f32;
+        }
+        expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expf(__x: f32) -> f32;
+        }
+        __expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        __ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logf(__x: f32) -> f32;
+        }
+        logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logf(__x: f32) -> f32;
+        }
+        __logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10f(__x: f32) -> f32;
+        }
+        log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10f(__x: f32) -> f32;
+        }
+        __log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        __modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1f(__x: f32) -> f32;
+        }
+        expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1f(__x: f32) -> f32;
+        }
+        __expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pf(__x: f32) -> f32;
+        }
+        log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pf(__x: f32) -> f32;
+        }
+        __log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbf(__x: f32) -> f32;
+        }
+        logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbf(__x: f32) -> f32;
+        }
+        __logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2f(__x: f32) -> f32;
+        }
+        exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2f(__x: f32) -> f32;
+        }
+        __exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2f(__x: f32) -> f32;
+        }
+        log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2f(__x: f32) -> f32;
+        }
+        __log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powf(__x: f32, __y: f32) -> f32;
+        }
+        powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powf(__x: f32, __y: f32) -> f32;
+        }
+        __powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtf(__x: f32) -> f32;
+        }
+        sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtf(__x: f32) -> f32;
+        }
+        __sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotf(__x: f32, __y: f32) -> f32;
+        }
+        hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotf(__x: f32, __y: f32) -> f32;
+        }
+        __hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtf(__x: f32) -> f32;
+        }
+        cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtf(__x: f32) -> f32;
+        }
+        __cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceilf(__x: f32) -> f32;
+        }
+        ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceilf(__x: f32) -> f32;
+        }
+        __ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsf(__x: f32) -> f32;
+        }
+        fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsf(__x: f32) -> f32;
+        }
+        __fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorf(__x: f32) -> f32;
+        }
+        floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorf(__x: f32) -> f32;
+        }
+        __floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodf(__x: f32, __y: f32) -> f32;
+        }
+        fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodf(__x: f32, __y: f32) -> f32;
+        }
+        __fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dremf(__x: f32, __y: f32) -> f32;
+        }
+        dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dremf(__x: f32, __y: f32) -> f32;
+        }
+        __dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandf(__x: f32) -> f32;
+        }
+        significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandf(__x: f32) -> f32;
+        }
+        __significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignf(__x: f32, __y: f32) -> f32;
+        }
+        copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignf(__x: f32, __y: f32) -> f32;
+        }
+        __copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        __nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0f(arg1: f32) -> f32;
+        }
+        j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0f(arg1: f32) -> f32;
+        }
+        __j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1f(arg1: f32) -> f32;
+        }
+        j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1f(arg1: f32) -> f32;
+        }
+        __j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0f(arg1: f32) -> f32;
+        }
+        y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0f(arg1: f32) -> f32;
+        }
+        __y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1f(arg1: f32) -> f32;
+        }
+        y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1f(arg1: f32) -> f32;
+        }
+        __y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erff(arg1: f32) -> f32;
+        }
+        erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erff(arg1: f32) -> f32;
+        }
+        __erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcf(arg1: f32) -> f32;
+        }
+        erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcf(arg1: f32) -> f32;
+        }
+        __erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf(arg1: f32) -> f32;
+        }
+        lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf(arg1: f32) -> f32;
+        }
+        __lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammaf(arg1: f32) -> f32;
+        }
+        tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammaf(arg1: f32) -> f32;
+        }
+        __tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammaf(arg1: f32) -> f32;
+        }
+        gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammaf(arg1: f32) -> f32;
+        }
+        __gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintf(__x: f32) -> f32;
+        }
+        rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintf(__x: f32) -> f32;
+        }
+        __rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        __nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        __nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderf(__x: f32, __y: f32) -> f32;
+        }
+        remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderf(__x: f32, __y: f32) -> f32;
+        }
+        __remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        __scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        __ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        __scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintf(__x: f32) -> f32;
+        }
+        nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintf(__x: f32) -> f32;
+        }
+        __nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundf(__x: f32) -> f32;
+        }
+        roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundf(__x: f32) -> f32;
+        }
+        __roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncf(__x: f32) -> f32;
+        }
+        truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncf(__x: f32) -> f32;
+        }
+        __truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdimf(__x: f32, __y: f32) -> f32;
+        }
+        fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdimf(__x: f32, __y: f32) -> f32;
+        }
+        __fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        __fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminf(__x: f32, __y: f32) -> f32;
+        }
+        fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminf(__x: f32, __y: f32) -> f32;
+        }
+        __fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        __fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbf(__x: f32, __n: f32) -> f32;
+        }
+        scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbf(__x: f32, __n: f32) -> f32;
+        }
+        __scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __signbitl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigl(arg___x: u128, arg___y: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+        }
+        __iseqsigl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __issignalingl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosl(__x: u128) -> u128;
+        }
+        acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosl(__x: u128) -> u128;
+        }
+        __acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinl(__x: u128) -> u128;
+        }
+        asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinl(__x: u128) -> u128;
+        }
+        __asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanl(__x: u128) -> u128;
+        }
+        atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanl(__x: u128) -> u128;
+        }
+        __atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2l(__y: u128, __x: u128) -> u128;
+        }
+        atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2l(__y: u128, __x: u128) -> u128;
+        }
+        __atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosl(__x: u128) -> u128;
+        }
+        cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosl(__x: u128) -> u128;
+        }
+        __cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinl(__x: u128) -> u128;
+        }
+        sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinl(__x: u128) -> u128;
+        }
+        __sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanl(__x: u128) -> u128;
+        }
+        tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanl(__x: u128) -> u128;
+        }
+        __tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshl(__x: u128) -> u128;
+        }
+        coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshl(__x: u128) -> u128;
+        }
+        __coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhl(__x: u128) -> u128;
+        }
+        sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhl(__x: u128) -> u128;
+        }
+        __sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhl(__x: u128) -> u128;
+        }
+        tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhl(__x: u128) -> u128;
+        }
+        __tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshl(__x: u128) -> u128;
+        }
+        acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshl(__x: u128) -> u128;
+        }
+        __acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhl(__x: u128) -> u128;
+        }
+        asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhl(__x: u128) -> u128;
+        }
+        __asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhl(__x: u128) -> u128;
+        }
+        atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhl(__x: u128) -> u128;
+        }
+        __atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expl(__x: u128) -> u128;
+        }
+        expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expl(__x: u128) -> u128;
+        }
+        __expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        __ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logl(__x: u128) -> u128;
+        }
+        logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logl(__x: u128) -> u128;
+        }
+        __logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10l(__x: u128) -> u128;
+        }
+        log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10l(__x: u128) -> u128;
+        }
+        __log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        __modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1l(__x: u128) -> u128;
+        }
+        expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1l(__x: u128) -> u128;
+        }
+        __expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pl(__x: u128) -> u128;
+        }
+        log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pl(__x: u128) -> u128;
+        }
+        __log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbl(__x: u128) -> u128;
+        }
+        logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbl(__x: u128) -> u128;
+        }
+        __logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2l(__x: u128) -> u128;
+        }
+        exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2l(__x: u128) -> u128;
+        }
+        __exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2l(__x: u128) -> u128;
+        }
+        log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2l(__x: u128) -> u128;
+        }
+        __log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powl(__x: u128, __y: u128) -> u128;
+        }
+        powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powl(__x: u128, __y: u128) -> u128;
+        }
+        __powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtl(__x: u128) -> u128;
+        }
+        sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtl(__x: u128) -> u128;
+        }
+        __sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotl(__x: u128, __y: u128) -> u128;
+        }
+        hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotl(__x: u128, __y: u128) -> u128;
+        }
+        __hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtl(__x: u128) -> u128;
+        }
+        cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtl(__x: u128) -> u128;
+        }
+        __cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceill(__x: u128) -> u128;
+        }
+        ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceill(__x: u128) -> u128;
+        }
+        __ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsl(__x: u128) -> u128;
+        }
+        fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsl(__x: u128) -> u128;
+        }
+        __fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorl(__x: u128) -> u128;
+        }
+        floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorl(__x: u128) -> u128;
+        }
+        __floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodl(__x: u128, __y: u128) -> u128;
+        }
+        fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodl(__x: u128, __y: u128) -> u128;
+        }
+        __fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dreml(__x: u128, __y: u128) -> u128;
+        }
+        dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dreml(__x: u128, __y: u128) -> u128;
+        }
+        __dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandl(__x: u128) -> u128;
+        }
+        significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandl(__x: u128) -> u128;
+        }
+        __significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignl(__x: u128, __y: u128) -> u128;
+        }
+        copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignl(__x: u128, __y: u128) -> u128;
+        }
+        __copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        __nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0l(arg1: u128) -> u128;
+        }
+        j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0l(arg1: u128) -> u128;
+        }
+        __j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1l(arg1: u128) -> u128;
+        }
+        j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1l(arg1: u128) -> u128;
+        }
+        __j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0l(arg1: u128) -> u128;
+        }
+        y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0l(arg1: u128) -> u128;
+        }
+        __y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1l(arg1: u128) -> u128;
+        }
+        y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1l(arg1: u128) -> u128;
+        }
+        __y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfl(arg1: u128) -> u128;
+        }
+        erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfl(arg1: u128) -> u128;
+        }
+        __erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcl(arg1: u128) -> u128;
+        }
+        erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcl(arg1: u128) -> u128;
+        }
+        __erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal(arg1: u128) -> u128;
+        }
+        lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal(arg1: u128) -> u128;
+        }
+        __lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammal(arg1: u128) -> u128;
+        }
+        tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammal(arg1: u128) -> u128;
+        }
+        __tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammal(arg1: u128) -> u128;
+        }
+        gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammal(arg1: u128) -> u128;
+        }
+        __gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintl(__x: u128) -> u128;
+        }
+        rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintl(__x: u128) -> u128;
+        }
+        __rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        __nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        __nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderl(__x: u128, __y: u128) -> u128;
+        }
+        remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderl(__x: u128, __y: u128) -> u128;
+        }
+        __remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        __scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        __ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        __scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintl(__x: u128) -> u128;
+        }
+        nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintl(__x: u128) -> u128;
+        }
+        __nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundl(__x: u128) -> u128;
+        }
+        roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundl(__x: u128) -> u128;
+        }
+        __roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncl(__x: u128) -> u128;
+        }
+        truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncl(__x: u128) -> u128;
+        }
+        __truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquol(arg___x: u128, arg___y: u128, arg___quo: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquol(
+    arg___x: u128,
+    arg___y: u128,
+    arg___quo: *mut ::std::os::raw::c_int,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdiml(__x: u128, __y: u128) -> u128;
+        }
+        fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdiml(__x: u128, __y: u128) -> u128;
+        }
+        __fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        __fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminl(__x: u128, __y: u128) -> u128;
+        }
+        fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminl(__x: u128, __y: u128) -> u128;
+        }
+        __fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        __fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbl(__x: u128, __n: u128) -> u128;
+        }
+        scalbl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbl(__x: u128, __n: u128) -> u128;
+        }
+        __scalbl(arg___x, arg___n)
     })
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-impl Default for exception {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub const FP_NAN: _bindgen_ty_8 = 0;
+pub const FP_INFINITE: _bindgen_ty_8 = 1;
+pub const FP_ZERO: _bindgen_ty_8 = 2;
+pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
+pub const FP_NORMAL: _bindgen_ty_8 = 4;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn explicit_bzero(arg_buf: *mut ::std::os::raw::c_void, arg_len: usize) {
+pub unsafe fn strlcat(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn explicit_bzero(buf: *mut ::std::os::raw::c_void, len: usize);
+            pub fn strlcat(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
         }
-        explicit_bzero(arg_buf, arg_len)
+        strlcat(arg_dst, arg_src, arg_siz)
+    })
+}
+#[track_caller]
+pub unsafe fn strlcpy(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlcpy(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strlcpy(arg_dst, arg_src, arg_siz)
     })
 }
 #[track_caller]
@@ -13976,17 +14923,16 @@ pub unsafe fn wait_result_is_any_signal(
         wait_result_is_any_signal(arg_exit_status, arg_include_command_not_found)
     })
 }
-pub type jmp_buf = [::std::os::raw::c_int; 48usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 49usize];
-#[track_caller]
-pub unsafe fn longjmperror() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn longjmperror();
-        }
-        longjmperror()
-    })
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
 }
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[track_caller]
 pub unsafe fn errstart(
     arg_elevel: ::std::os::raw::c_int,
@@ -16774,390 +17720,147 @@ pub unsafe fn HeapTupleGetUpdateXid(arg_tuple: HeapTupleHeader) -> TransactionId
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
-#[track_caller]
-pub unsafe fn open(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        open(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn openat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn openat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        openat(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn creat(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: mode_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn creat(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: mode_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        creat(arg_arg1, arg_arg2)
-    })
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
 #[track_caller]
 pub unsafe fn fcntl(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fcntl(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        fcntl(arg_arg1, arg_arg2)
+        fcntl(arg___fd, arg___cmd)
     })
 }
 #[track_caller]
-pub unsafe fn openx_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: filesec_t,
+pub unsafe fn open(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openx_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: filesec_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        openx_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn open_dprotected_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open_dprotected_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn open(
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        open_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        open(arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_dprotected_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: ::std::os::raw::c_int,
+pub unsafe fn openat(
+    arg___fd: ::std::os::raw::c_int,
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_dprotected_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-                arg5: ::std::os::raw::c_int,
+            pub fn openat(
+                __fd: ::std::os::raw::c_int,
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        openat_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        openat(arg___fd, arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_authenticated_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
+pub unsafe fn creat(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___mode: mode_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_authenticated_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn creat(
+                __file: *const ::std::os::raw::c_char,
+                __mode: mode_t,
             ) -> ::std::os::raw::c_int;
         }
-        openat_authenticated_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        creat(arg___file, arg___mode)
     })
 }
 #[track_caller]
-pub unsafe fn flock(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn lockf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flock(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+            pub fn lockf(
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        flock(arg_arg1, arg_arg2)
+        lockf(arg___fd, arg___cmd, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_init() -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_init() -> filesec_t;
-        }
-        filesec_init()
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_dup(arg_arg1: filesec_t) -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-        }
-        filesec_dup(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_free(arg_arg1: filesec_t) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_free(arg1: filesec_t);
-        }
-        filesec_free(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_get_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_void,
+pub unsafe fn posix_fadvise(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
+    arg___advise: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_get_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_void,
+            pub fn posix_fadvise(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
+                __advise: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_get_property(arg_arg1, arg_arg2, arg_arg3)
+        posix_fadvise(arg___fd, arg___offset, arg___len, arg___advise)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_query_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_int,
+pub unsafe fn posix_fallocate(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_query_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_int,
+            pub fn posix_fallocate(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_query_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_set_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *const ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_set_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_set_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_unset_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_unset_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_unset_property(arg_arg1, arg_arg2)
+        posix_fallocate(arg___fd, arg___offset, arg___len)
     })
 }
 pub type XLogRecPtr = uint64;
@@ -18952,7 +19655,7 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
@@ -18963,26 +19666,11 @@ impl Default for tm {
         }
     }
 }
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[track_caller]
-pub unsafe fn asctime(arg_arg1: *const tm) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
-        }
-        asctime(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[track_caller]
 pub unsafe fn clock() -> clock_t {
@@ -18994,103 +19682,167 @@ pub unsafe fn clock() -> clock_t {
     })
 }
 #[track_caller]
-pub unsafe fn ctime(arg_arg1: *const time_t) -> *mut ::std::os::raw::c_char {
+pub unsafe fn time(arg___timer: *mut time_t) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+            pub fn time(__timer: *mut time_t) -> time_t;
         }
-        ctime(arg_arg1)
+        time(arg___timer)
     })
 }
 #[track_caller]
-pub unsafe fn difftime(arg_arg1: time_t, arg_arg2: time_t) -> f64 {
+pub unsafe fn difftime(arg___time1: time_t, arg___time0: time_t) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+            pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
         }
-        difftime(arg_arg1, arg_arg2)
+        difftime(arg___time1, arg___time0)
     })
 }
 #[track_caller]
-pub unsafe fn getdate(arg_arg1: *const ::std::os::raw::c_char) -> *mut tm {
+pub unsafe fn mktime(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+            pub fn mktime(__tp: *mut tm) -> time_t;
         }
-        getdate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gmtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gmtime(arg1: *const time_t) -> *mut tm;
-        }
-        gmtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime(arg1: *const time_t) -> *mut tm;
-        }
-        localtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mktime(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mktime(arg1: *mut tm) -> time_t;
-        }
-        mktime(arg_arg1)
+        mktime(arg___tp)
     })
 }
 #[track_caller]
 pub unsafe fn strftime(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const tm,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
 ) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strftime(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const tm,
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
             ) -> usize;
         }
-        strftime(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        strftime(arg___s, arg___maxsize, arg___format, arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn strptime(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut tm,
+pub unsafe fn strftime_l(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
+    arg___loc: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strftime_l(
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
+                __loc: locale_t,
+            ) -> usize;
+        }
+        strftime_l(arg___s, arg___maxsize, arg___format, arg___tp, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime(__timer: *const time_t) -> *mut tm;
+        }
+        gmtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime(__timer: *const time_t) -> *mut tm;
+        }
+        localtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        gmtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        localtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime(arg___tp: *const tm) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+        }
+        asctime(arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn ctime(arg___timer: *const time_t) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+        }
+        ctime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime_r(
+    arg___tp: *const tm,
+    arg___buf: *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strptime(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut tm,
+            pub fn asctime_r(
+                __tp: *const tm,
+                __buf: *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strptime(arg_arg1, arg_arg2, arg_arg3)
+        asctime_r(arg___tp, arg___buf)
     })
 }
 #[track_caller]
-pub unsafe fn time(arg_arg1: *mut time_t) -> time_t {
+pub unsafe fn ctime_r(
+    arg___timer: *const time_t,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn time(arg1: *mut time_t) -> time_t;
+            pub fn ctime_r(
+                __timer: *const time_t,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        time(arg_arg1)
+        ctime_r(arg___timer, arg___buf)
     })
+}
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[track_caller]
 pub unsafe fn tzset() {
@@ -19101,123 +19853,54 @@ pub unsafe fn tzset() {
         tzset()
     })
 }
+extern "C" {
+    pub static mut daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut timezone: ::std::os::raw::c_long;
+}
 #[track_caller]
-pub unsafe fn asctime_r(
-    arg_arg1: *const tm,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timegm(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asctime_r(
-                arg1: *const tm,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timegm(__tp: *mut tm) -> time_t;
         }
-        asctime_r(arg_arg1, arg_arg2)
+        timegm(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn ctime_r(
-    arg_arg1: *const time_t,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timelocal(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime_r(
-                arg1: *const time_t,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timelocal(__tp: *mut tm) -> time_t;
         }
-        ctime_r(arg_arg1, arg_arg2)
+        timelocal(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn gmtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
+pub unsafe fn dysize(arg___year: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+            pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        gmtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
-        }
-        localtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn posix2time(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix2time(arg1: time_t) -> time_t;
-        }
-        posix2time(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tzsetwall() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tzsetwall();
-        }
-        tzsetwall()
-    })
-}
-#[track_caller]
-pub unsafe fn time2posix(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn time2posix(arg1: time_t) -> time_t;
-        }
-        time2posix(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timelocal(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timelocal(arg1: *mut tm) -> time_t;
-        }
-        timelocal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timegm(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timegm(arg1: *mut tm) -> time_t;
-        }
-        timegm(arg_arg1)
+        dysize(arg___year)
     })
 }
 #[track_caller]
 pub unsafe fn nanosleep(
-    arg___rqtp: *const timespec,
-    arg___rmtp: *mut timespec,
+    arg___requested_time: *const timespec,
+    arg___remaining: *mut timespec,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn nanosleep(
-                __rqtp: *const timespec,
-                __rmtp: *mut timespec,
+                __requested_time: *const timespec,
+                __remaining: *mut timespec,
             ) -> ::std::os::raw::c_int;
         }
-        nanosleep(arg___rqtp, arg___rmtp)
+        nanosleep(arg___requested_time, arg___remaining)
     })
 }
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn clock_getres(
     arg___clock_id: clockid_t,
@@ -19249,15 +19932,6 @@ pub unsafe fn clock_gettime(
     })
 }
 #[track_caller]
-pub unsafe fn clock_gettime_nsec_np(arg___clock_id: clockid_t) -> __uint64_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-        }
-        clock_gettime_nsec_np(arg___clock_id)
-    })
-}
-#[track_caller]
 pub unsafe fn clock_settime(
     arg___clock_id: clockid_t,
     arg___tp: *const timespec,
@@ -19273,18 +19947,121 @@ pub unsafe fn clock_settime(
     })
 }
 #[track_caller]
+pub unsafe fn clock_nanosleep(
+    arg___clock_id: clockid_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___req: *const timespec,
+    arg___rem: *mut timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_nanosleep(
+                __clock_id: clockid_t,
+                __flags: ::std::os::raw::c_int,
+                __req: *const timespec,
+                __rem: *mut timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_nanosleep(arg___clock_id, arg___flags, arg___req, arg___rem)
+    })
+}
+#[track_caller]
+pub unsafe fn clock_getcpuclockid(
+    arg___pid: pid_t,
+    arg___clock_id: *mut clockid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_getcpuclockid(
+                __pid: pid_t,
+                __clock_id: *mut clockid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_getcpuclockid(arg___pid, arg___clock_id)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_create(
+    arg___clock_id: clockid_t,
+    arg___evp: *mut sigevent,
+    arg___timerid: *mut timer_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_create(
+                __clock_id: clockid_t,
+                __evp: *mut sigevent,
+                __timerid: *mut timer_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_create(arg___clock_id, arg___evp, arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_delete(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_delete(arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_settime(
+    arg___timerid: timer_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___value: *const itimerspec,
+    arg___ovalue: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_settime(
+                __timerid: timer_t,
+                __flags: ::std::os::raw::c_int,
+                __value: *const itimerspec,
+                __ovalue: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_settime(arg___timerid, arg___flags, arg___value, arg___ovalue)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_gettime(
+    arg___timerid: timer_t,
+    arg___value: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_gettime(
+                __timerid: timer_t,
+                __value: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_gettime(arg___timerid, arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_getoverrun(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_getoverrun(arg___timerid)
+    })
+}
+#[track_caller]
 pub unsafe fn timespec_get(
-    arg_ts: *mut timespec,
-    arg_base: ::std::os::raw::c_int,
+    arg___ts: *mut timespec,
+    arg___base: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn timespec_get(
-                ts: *mut timespec,
-                base: ::std::os::raw::c_int,
+                __ts: *mut timespec,
+                __base: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        timespec_get(arg_ts, arg_base)
+        timespec_get(arg___ts, arg___base)
     })
 }
 pub type instr_time = timespec;
@@ -21789,6 +22566,7 @@ pub struct SubPlan {
     pub args: *mut List,
     pub startup_cost: Cost,
     pub per_call_cost: Cost,
+    pub subLinkId: ::std::os::raw::c_int,
 }
 impl Default for SubPlan {
     fn default() -> Self {
@@ -23398,7 +24176,7 @@ impl Default for PlanInvalItem {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct pg_atomic_flag {
-    pub value: ::std::os::raw::c_int,
+    pub value: ::std::os::raw::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -24114,7 +24892,7 @@ pub struct proclist_mutable_iter {
     pub cur: ::std::os::raw::c_int,
     pub next: ::std::os::raw::c_int,
 }
-pub type slock_t = ::std::os::raw::c_int;
+pub type slock_t = ::std::os::raw::c_uchar;
 extern "C" {
     pub static mut dummy_spinlock: slock_t;
 }
@@ -24759,12 +25537,11 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
@@ -24775,146 +25552,119 @@ impl Default for dirent {
         }
     }
 }
+pub const DT_UNKNOWN: _bindgen_ty_9 = 0;
+pub const DT_FIFO: _bindgen_ty_9 = 1;
+pub const DT_CHR: _bindgen_ty_9 = 2;
+pub const DT_DIR: _bindgen_ty_9 = 4;
+pub const DT_BLK: _bindgen_ty_9 = 6;
+pub const DT_REG: _bindgen_ty_9 = 8;
+pub const DT_LNK: _bindgen_ty_9 = 10;
+pub const DT_SOCK: _bindgen_ty_9 = 12;
+pub const DT_WHT: _bindgen_ty_9 = 14;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type DIR = __dirstream;
 #[track_caller]
-pub unsafe fn closedir(arg_arg1: *mut DIR) -> ::std::os::raw::c_int {
+pub unsafe fn closedir(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+            pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        closedir(arg_arg1)
+        closedir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn opendir(arg_arg1: *const ::std::os::raw::c_char) -> *mut DIR {
+pub unsafe fn opendir(arg___name: *const ::std::os::raw::c_char) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+            pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
         }
-        opendir(arg_arg1)
+        opendir(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn readdir(arg_arg1: *mut DIR) -> *mut dirent {
+pub unsafe fn fdopendir(arg___fd: ::std::os::raw::c_int) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+            pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
         }
-        readdir(arg_arg1)
+        fdopendir(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn readdir(arg___dirp: *mut DIR) -> *mut dirent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+        }
+        readdir(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn readdir_r(
-    arg_arg1: *mut DIR,
-    arg_arg2: *mut dirent,
-    arg_arg3: *mut *mut dirent,
+    arg___dirp: *mut DIR,
+    arg___entry: *mut dirent,
+    arg___result: *mut *mut dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn readdir_r(
-                arg1: *mut DIR,
-                arg2: *mut dirent,
-                arg3: *mut *mut dirent,
+                __dirp: *mut DIR,
+                __entry: *mut dirent,
+                __result: *mut *mut dirent,
             ) -> ::std::os::raw::c_int;
         }
-        readdir_r(arg_arg1, arg_arg2, arg_arg3)
+        readdir_r(arg___dirp, arg___entry, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn rewinddir(arg_arg1: *mut DIR) {
+pub unsafe fn rewinddir(arg___dirp: *mut DIR) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rewinddir(arg1: *mut DIR);
+            pub fn rewinddir(__dirp: *mut DIR);
         }
-        rewinddir(arg_arg1)
+        rewinddir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn seekdir(arg_arg1: *mut DIR, arg_arg2: ::std::os::raw::c_long) {
+pub unsafe fn seekdir(arg___dirp: *mut DIR, arg___pos: ::std::os::raw::c_long) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+            pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
         }
-        seekdir(arg_arg1, arg_arg2)
+        seekdir(arg___dirp, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn telldir(arg_arg1: *mut DIR) -> ::std::os::raw::c_long {
+pub unsafe fn telldir(arg___dirp: *mut DIR) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+            pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
         }
-        telldir(arg_arg1)
+        telldir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn fdopendir(arg_arg1: ::std::os::raw::c_int) -> *mut DIR {
+pub unsafe fn dirfd(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+            pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        fdopendir(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn alphasort(
-    arg_arg1: *mut *const dirent,
-    arg_arg2: *mut *const dirent,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alphasort(
-                arg1: *mut *const dirent,
-                arg2: *mut *const dirent,
-            ) -> ::std::os::raw::c_int;
-        }
-        alphasort(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn dirfd(arg_dirp: *mut DIR) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-        }
-        dirfd(arg_dirp)
+        dirfd(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn scandir(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: ::std::option::Option<
+    arg___dir: *const ::std::os::raw::c_char,
+    arg___namelist: *mut *mut *mut dirent,
+    arg___selector: ::std::option::Option<
         unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
     >,
-    arg_arg4: ::std::option::Option<
+    arg___cmp: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut *const dirent,
             arg2: *mut *const dirent,
@@ -24924,12 +25674,12 @@ pub unsafe fn scandir(
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn scandir(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: ::std::option::Option<
+                __dir: *const ::std::os::raw::c_char,
+                __namelist: *mut *mut *mut dirent,
+                __selector: ::std::option::Option<
                     unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
                 >,
-                arg4: ::std::option::Option<
+                __cmp: ::std::option::Option<
                     unsafe extern "C" fn(
                         arg1: *mut *const dirent,
                         arg2: *mut *const dirent,
@@ -24937,61 +25687,41 @@ pub unsafe fn scandir(
                 >,
             ) -> ::std::os::raw::c_int;
         }
-        scandir(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        scandir(arg___dir, arg___namelist, arg___selector, arg___cmp)
     })
 }
 #[track_caller]
-pub unsafe fn scandir_b(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: *mut ::std::os::raw::c_void,
+pub unsafe fn alphasort(
+    arg___e1: *mut *const dirent,
+    arg___e2: *mut *const dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scandir_b(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: *mut ::std::os::raw::c_void,
+            pub fn alphasort(
+                __e1: *mut *const dirent,
+                __e2: *mut *const dirent,
             ) -> ::std::os::raw::c_int;
         }
-        scandir_b(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        alphasort(arg___e1, arg___e2)
     })
 }
 #[track_caller]
 pub unsafe fn getdirentries(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___nbytes: usize,
+    arg___basep: *mut __off_t,
+) -> __ssize_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
             pub fn getdirentries(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __nbytes: usize,
+                __basep: *mut __off_t,
+            ) -> __ssize_t;
         }
-        getdirentries(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __opendir2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut DIR {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __opendir2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut DIR;
-        }
-        __opendir2(arg_arg1, arg_arg2)
+        getdirentries(arg___fd, arg___buf, arg___nbytes, arg___basep)
     })
 }
 pub type File = ::std::os::raw::c_int;
@@ -36248,356 +36978,943 @@ pub unsafe fn extract_variadic_args(
         )
     })
 }
-extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
 }
-extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+impl Default for sigval {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const SI_ASYNCNL: _bindgen_ty_10 = -60;
+pub const SI_DETHREAD: _bindgen_ty_10 = -7;
+pub const SI_TKILL: _bindgen_ty_10 = -6;
+pub const SI_SIGIO: _bindgen_ty_10 = -5;
+pub const SI_ASYNCIO: _bindgen_ty_10 = -4;
+pub const SI_MESGQ: _bindgen_ty_10 = -3;
+pub const SI_TIMER: _bindgen_ty_10 = -2;
+pub const SI_QUEUE: _bindgen_ty_10 = -1;
+pub const SI_USER: _bindgen_ty_10 = 0;
+pub const SI_KERNEL: _bindgen_ty_10 = 128;
+pub type _bindgen_ty_10 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: _bindgen_ty_11 = 1;
+pub const ILL_ILLOPN: _bindgen_ty_11 = 2;
+pub const ILL_ILLADR: _bindgen_ty_11 = 3;
+pub const ILL_ILLTRP: _bindgen_ty_11 = 4;
+pub const ILL_PRVOPC: _bindgen_ty_11 = 5;
+pub const ILL_PRVREG: _bindgen_ty_11 = 6;
+pub const ILL_COPROC: _bindgen_ty_11 = 7;
+pub const ILL_BADSTK: _bindgen_ty_11 = 8;
+pub const ILL_BADIADDR: _bindgen_ty_11 = 9;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: _bindgen_ty_12 = 1;
+pub const FPE_INTOVF: _bindgen_ty_12 = 2;
+pub const FPE_FLTDIV: _bindgen_ty_12 = 3;
+pub const FPE_FLTOVF: _bindgen_ty_12 = 4;
+pub const FPE_FLTUND: _bindgen_ty_12 = 5;
+pub const FPE_FLTRES: _bindgen_ty_12 = 6;
+pub const FPE_FLTINV: _bindgen_ty_12 = 7;
+pub const FPE_FLTSUB: _bindgen_ty_12 = 8;
+pub const FPE_FLTUNK: _bindgen_ty_12 = 14;
+pub const FPE_CONDTRAP: _bindgen_ty_12 = 15;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: _bindgen_ty_13 = 1;
+pub const SEGV_ACCERR: _bindgen_ty_13 = 2;
+pub const SEGV_BNDERR: _bindgen_ty_13 = 3;
+pub const SEGV_PKUERR: _bindgen_ty_13 = 4;
+pub const SEGV_ACCADI: _bindgen_ty_13 = 5;
+pub const SEGV_ADIDERR: _bindgen_ty_13 = 6;
+pub const SEGV_ADIPERR: _bindgen_ty_13 = 7;
+pub const SEGV_MTEAERR: _bindgen_ty_13 = 8;
+pub const SEGV_MTESERR: _bindgen_ty_13 = 9;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: _bindgen_ty_14 = 1;
+pub const BUS_ADRERR: _bindgen_ty_14 = 2;
+pub const BUS_OBJERR: _bindgen_ty_14 = 3;
+pub const BUS_MCEERR_AR: _bindgen_ty_14 = 4;
+pub const BUS_MCEERR_AO: _bindgen_ty_14 = 5;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: _bindgen_ty_15 = 1;
+pub const CLD_KILLED: _bindgen_ty_15 = 2;
+pub const CLD_DUMPED: _bindgen_ty_15 = 3;
+pub const CLD_TRAPPED: _bindgen_ty_15 = 4;
+pub const CLD_STOPPED: _bindgen_ty_15 = 5;
+pub const CLD_CONTINUED: _bindgen_ty_15 = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub const POLL_IN: _bindgen_ty_16 = 1;
+pub const POLL_OUT: _bindgen_ty_16 = 2;
+pub const POLL_MSG: _bindgen_ty_16 = 3;
+pub const POLL_ERR: _bindgen_ty_16 = 4;
+pub const POLL_PRI: _bindgen_ty_16 = 5;
+pub const POLL_HUP: _bindgen_ty_16 = 6;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: _bindgen_ty_17 = 0;
+pub const SIGEV_NONE: _bindgen_ty_17 = 1;
+pub const SIGEV_THREAD: _bindgen_ty_17 = 2;
+pub const SIGEV_THREAD_ID: _bindgen_ty_17 = 4;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[track_caller]
-pub unsafe fn raise(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __sysv_signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __sysv_signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        raise(arg_arg1)
+        __sysv_signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn bsd_signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bsd_signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        bsd_signal(arg_arg1, arg_arg2)
+        signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn kill(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn kill(arg___pid: __pid_t, arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        kill(arg_arg1, arg_arg2)
+        kill(arg___pid, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn killpg(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        killpg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pthread_kill(
-    arg_arg1: pthread_t,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn killpg(
+    arg___pgrp: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_kill(
-                arg1: pthread_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_kill(arg_arg1, arg_arg2)
+        killpg(arg___pgrp, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn pthread_sigmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
-) -> ::std::os::raw::c_int {
+pub unsafe fn raise(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_sigmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
-            ) -> ::std::os::raw::c_int;
+            pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_sigmask(arg_arg1, arg_arg2, arg_arg3)
+        raise(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn sigaction(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigaction,
-    arg_arg3: *mut sigaction,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ssignal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigaction(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigaction,
-                arg3: *mut sigaction,
-            ) -> ::std::os::raw::c_int;
+            pub fn ssignal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        sigaction(arg_arg1, arg_arg2, arg_arg3)
+        ssignal(arg___sig, arg___handler)
+    })
+}
+#[track_caller]
+pub unsafe fn gsignal(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        gsignal(arg___sig)
+    })
+}
+#[track_caller]
+pub unsafe fn psignal(arg___sig: ::std::os::raw::c_int, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
+        }
+        psignal(arg___sig, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn psiginfo(arg___pinfo: *const siginfo_t, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
+        }
+        psiginfo(arg___pinfo, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn sigblock(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigblock(arg___mask)
+    })
+}
+#[track_caller]
+pub unsafe fn sigsetmask(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigsetmask(arg___mask)
+    })
+}
+pub type sig_t = __sighandler_t;
+#[track_caller]
+pub unsafe fn sigemptyset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigemptyset(arg___set)
+    })
+}
+#[track_caller]
+pub unsafe fn sigfillset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigfillset(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigaddset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigaddset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigaddset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigaltstack(
-    arg_arg1: *const stack_t,
-    arg_arg2: *mut stack_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
-        }
-        sigaltstack(arg_arg1, arg_arg2)
+        sigaddset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigdelset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigdelset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigdelset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigemptyset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigemptyset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigfillset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigfillset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sighold(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sighold(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigignore(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigignore(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn siginterrupt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn siginterrupt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        siginterrupt(arg_arg1, arg_arg2)
+        sigdelset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigismember(
-    arg_arg1: *const sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigismember(
-                arg1: *const sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigismember(arg_arg1, arg_arg2)
+        sigismember(arg___set, arg___signo)
     })
 }
-#[track_caller]
-pub unsafe fn sigpause(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigpause(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
 }
-#[track_caller]
-pub unsafe fn sigpending(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        sigpending(arg_arg1)
-    })
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[track_caller]
 pub unsafe fn sigprocmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
+    arg___how: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___oset: *mut sigset_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigprocmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
+                __how: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __oset: *mut sigset_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigprocmask(arg_arg1, arg_arg2, arg_arg3)
+        sigprocmask(arg___how, arg___set, arg___oset)
     })
 }
 #[track_caller]
-pub unsafe fn sigrelse(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn sigsuspend(arg___set: *const sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
         }
-        sigrelse(arg_arg1)
+        sigsuspend(arg___set)
     })
 }
 #[track_caller]
-pub unsafe fn sigset(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn sigaction(
+    arg___sig: ::std::os::raw::c_int,
+    arg___act: *const sigaction,
+    arg___oact: *mut sigaction,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigset(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn sigaction(
+                __sig: ::std::os::raw::c_int,
+                __act: *const sigaction,
+                __oact: *mut sigaction,
+            ) -> ::std::os::raw::c_int;
         }
-        sigset(arg_arg1, arg_arg2)
+        sigaction(arg___sig, arg___act, arg___oact)
     })
 }
 #[track_caller]
-pub unsafe fn sigsuspend(arg_arg1: *const sigset_t) -> ::std::os::raw::c_int {
+pub unsafe fn sigpending(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+            pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
         }
-        sigsuspend(arg_arg1)
+        sigpending(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigwait(
-    arg_arg1: *const sigset_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___sig: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigwait(
-                arg1: *const sigset_t,
-                arg2: *mut ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __sig: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigwait(arg_arg1, arg_arg2)
+        sigwait(arg___set, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn psignal(arg_arg1: ::std::os::raw::c_uint, arg_arg2: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
-        }
-        psignal(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigblock(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigblock(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigsetmask(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigsetmask(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigvec(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sigvec,
-    arg_arg3: *mut sigvec,
+pub unsafe fn sigwaitinfo(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigvec(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sigvec,
-                arg3: *mut sigvec,
+            pub fn sigwaitinfo(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigvec(arg_arg1, arg_arg2, arg_arg3)
+        sigwaitinfo(arg___set, arg___info)
+    })
+}
+#[track_caller]
+pub unsafe fn sigtimedwait(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
+    arg___timeout: *const timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigtimedwait(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
+                __timeout: *const timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigtimedwait(arg___set, arg___info, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn sigqueue(
+    arg___pid: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
+    arg___val: sigval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigqueue(
+                __pid: __pid_t,
+                __sig: ::std::os::raw::c_int,
+                __val: sigval,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigqueue(arg___pid, arg___sig, arg___val)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn siginterrupt(
+    arg___sig: ::std::os::raw::c_int,
+    arg___interrupt: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn siginterrupt(
+                __sig: ::std::os::raw::c_int,
+                __interrupt: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        siginterrupt(arg___sig, arg___interrupt)
+    })
+}
+pub const SS_ONSTACK: _bindgen_ty_18 = 1;
+pub const SS_DISABLE: _bindgen_ty_18 = 2;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[track_caller]
+pub unsafe fn sigaltstack(
+    arg___ss: *const stack_t,
+    arg___oss: *mut stack_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+        }
+        sigaltstack(arg___ss, arg___oss)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn pthread_sigmask(
+    arg___how: ::std::os::raw::c_int,
+    arg___newmask: *const __sigset_t,
+    arg___oldmask: *mut __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_sigmask(
+                __how: ::std::os::raw::c_int,
+                __newmask: *const __sigset_t,
+                __oldmask: *mut __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_sigmask(arg___how, arg___newmask, arg___oldmask)
+    })
+}
+#[track_caller]
+pub unsafe fn pthread_kill(
+    arg___threadid: pthread_t,
+    arg___signo: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_kill(
+                __threadid: pthread_t,
+                __signo: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_kill(arg___threadid, arg___signo)
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmin() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmin()
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmax() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmax()
     })
 }
 pub type pg_time_t = int64;
@@ -37651,9 +38968,8 @@ pub unsafe fn get_hash_mem() -> ::std::os::raw::c_int {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -37748,20 +39064,46 @@ pub const RmgrIds_RM_NEXT_ID: RmgrIds = 22;
 pub type RmgrIds = ::std::os::raw::c_uint;
 pub type pg_crc32c = uint32;
 #[track_caller]
-pub unsafe fn pg_comp_crc32c_armv8(
+pub unsafe fn pg_comp_crc32c_sb8(
     arg_crc: pg_crc32c,
     arg_data: *const ::std::os::raw::c_void,
     arg_len: usize,
 ) -> pg_crc32c {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pg_comp_crc32c_armv8(
+            pub fn pg_comp_crc32c_sb8(
                 crc: pg_crc32c,
                 data: *const ::std::os::raw::c_void,
                 len: usize,
             ) -> pg_crc32c;
         }
-        pg_comp_crc32c_armv8(arg_crc, arg_data, arg_len)
+        pg_comp_crc32c_sb8(arg_crc, arg_data, arg_len)
+    })
+}
+extern "C" {
+    pub static mut pg_comp_crc32c: ::std::option::Option<
+        unsafe extern "C" fn(
+            crc: pg_crc32c,
+            data: *const ::std::os::raw::c_void,
+            len: usize,
+        ) -> pg_crc32c,
+    >;
+}
+#[track_caller]
+pub unsafe fn pg_comp_crc32c_sse42(
+    arg_crc: pg_crc32c,
+    arg_data: *const ::std::os::raw::c_void,
+    arg_len: usize,
+) -> pg_crc32c {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pg_comp_crc32c_sse42(
+                crc: pg_crc32c,
+                data: *const ::std::os::raw::c_void,
+                len: usize,
+            ) -> pg_crc32c;
+        }
+        pg_comp_crc32c_sse42(arg_crc, arg_data, arg_len)
     })
 }
 pub const ForkNumber_InvalidForkNumber: ForkNumber = -1;
@@ -107010,8 +108352,29 @@ pub unsafe fn make_empty_range(arg_typcache: *mut TypeCacheEntry) -> *mut RangeT
         make_empty_range(arg_typcache)
     })
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+impl Default for __va_list_tag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AttrMissing {
@@ -107092,2466 +108455,2877 @@ pub struct RowSecurityDesc {
 pub struct SnapBuild {
     pub _address: u8,
 }
+impl pg_sys::seal::Sealed for A_ArrayExpr {}
 impl pg_sys::PgNode for A_ArrayExpr {}
 impl std::fmt::Display for A_ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Const {}
 impl pg_sys::PgNode for A_Const {}
 impl std::fmt::Display for A_Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Expr {}
 impl pg_sys::PgNode for A_Expr {}
 impl std::fmt::Display for A_Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indices {}
 impl pg_sys::PgNode for A_Indices {}
 impl std::fmt::Display for A_Indices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indirection {}
 impl pg_sys::PgNode for A_Indirection {}
 impl std::fmt::Display for A_Indirection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Star {}
 impl pg_sys::PgNode for A_Star {}
 impl std::fmt::Display for A_Star {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AccessPriv {}
 impl pg_sys::PgNode for AccessPriv {}
 impl std::fmt::Display for AccessPriv {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Agg {}
 impl pg_sys::PgNode for Agg {}
 impl std::fmt::Display for Agg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggPath {}
 impl pg_sys::PgNode for AggPath {}
 impl std::fmt::Display for AggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggState {}
 impl pg_sys::PgNode for AggState {}
 impl std::fmt::Display for AggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Aggref {}
 impl pg_sys::PgNode for Aggref {}
 impl std::fmt::Display for Aggref {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggrefExprState {}
 impl pg_sys::PgNode for AggrefExprState {}
 impl std::fmt::Display for AggrefExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Alias {}
 impl pg_sys::PgNode for Alias {}
 impl std::fmt::Display for Alias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterCollationStmt {}
 impl pg_sys::PgNode for AlterCollationStmt {}
 impl std::fmt::Display for AlterCollationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseSetStmt {}
 impl pg_sys::PgNode for AlterDatabaseSetStmt {}
 impl std::fmt::Display for AlterDatabaseSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseStmt {}
 impl pg_sys::PgNode for AlterDatabaseStmt {}
 impl std::fmt::Display for AlterDatabaseStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDefaultPrivilegesStmt {}
 impl pg_sys::PgNode for AlterDefaultPrivilegesStmt {}
 impl std::fmt::Display for AlterDefaultPrivilegesStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDomainStmt {}
 impl pg_sys::PgNode for AlterDomainStmt {}
 impl std::fmt::Display for AlterDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEnumStmt {}
 impl pg_sys::PgNode for AlterEnumStmt {}
 impl std::fmt::Display for AlterEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEventTrigStmt {}
 impl pg_sys::PgNode for AlterEventTrigStmt {}
 impl std::fmt::Display for AlterEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionContentsStmt {}
 impl pg_sys::PgNode for AlterExtensionContentsStmt {}
 impl std::fmt::Display for AlterExtensionContentsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionStmt {}
 impl pg_sys::PgNode for AlterExtensionStmt {}
 impl std::fmt::Display for AlterExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFdwStmt {}
 impl pg_sys::PgNode for AlterFdwStmt {}
 impl std::fmt::Display for AlterFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterForeignServerStmt {}
 impl pg_sys::PgNode for AlterForeignServerStmt {}
 impl std::fmt::Display for AlterForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFunctionStmt {}
 impl pg_sys::PgNode for AlterFunctionStmt {}
 impl std::fmt::Display for AlterFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectDependsStmt {}
 impl pg_sys::PgNode for AlterObjectDependsStmt {}
 impl std::fmt::Display for AlterObjectDependsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectSchemaStmt {}
 impl pg_sys::PgNode for AlterObjectSchemaStmt {}
 impl std::fmt::Display for AlterObjectSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOpFamilyStmt {}
 impl pg_sys::PgNode for AlterOpFamilyStmt {}
 impl std::fmt::Display for AlterOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOperatorStmt {}
 impl pg_sys::PgNode for AlterOperatorStmt {}
 impl std::fmt::Display for AlterOperatorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOwnerStmt {}
 impl pg_sys::PgNode for AlterOwnerStmt {}
 impl std::fmt::Display for AlterOwnerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPolicyStmt {}
 impl pg_sys::PgNode for AlterPolicyStmt {}
 impl std::fmt::Display for AlterPolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPublicationStmt {}
 impl pg_sys::PgNode for AlterPublicationStmt {}
 impl std::fmt::Display for AlterPublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleSetStmt {}
 impl pg_sys::PgNode for AlterRoleSetStmt {}
 impl std::fmt::Display for AlterRoleSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleStmt {}
 impl pg_sys::PgNode for AlterRoleStmt {}
 impl std::fmt::Display for AlterRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSeqStmt {}
 impl pg_sys::PgNode for AlterSeqStmt {}
 impl std::fmt::Display for AlterSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterStatsStmt {}
 impl pg_sys::PgNode for AlterStatsStmt {}
 impl std::fmt::Display for AlterStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSubscriptionStmt {}
 impl pg_sys::PgNode for AlterSubscriptionStmt {}
 impl std::fmt::Display for AlterSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSystemStmt {}
 impl pg_sys::PgNode for AlterSystemStmt {}
 impl std::fmt::Display for AlterSystemStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSConfigurationStmt {}
 impl pg_sys::PgNode for AlterTSConfigurationStmt {}
 impl std::fmt::Display for AlterTSConfigurationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSDictionaryStmt {}
 impl pg_sys::PgNode for AlterTSDictionaryStmt {}
 impl std::fmt::Display for AlterTSDictionaryStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableCmd {}
 impl pg_sys::PgNode for AlterTableCmd {}
 impl std::fmt::Display for AlterTableCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableMoveAllStmt {}
 impl pg_sys::PgNode for AlterTableMoveAllStmt {}
 impl std::fmt::Display for AlterTableMoveAllStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableSpaceOptionsStmt {}
 impl pg_sys::PgNode for AlterTableSpaceOptionsStmt {}
 impl std::fmt::Display for AlterTableSpaceOptionsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableStmt {}
 impl pg_sys::PgNode for AlterTableStmt {}
 impl std::fmt::Display for AlterTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTypeStmt {}
 impl pg_sys::PgNode for AlterTypeStmt {}
 impl std::fmt::Display for AlterTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterUserMappingStmt {}
 impl pg_sys::PgNode for AlterUserMappingStmt {}
 impl std::fmt::Display for AlterUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlan {}
 impl pg_sys::PgNode for AlternativeSubPlan {}
 impl std::fmt::Display for AlternativeSubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlanState {}
 impl pg_sys::PgNode for AlternativeSubPlanState {}
 impl std::fmt::Display for AlternativeSubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Append {}
 impl pg_sys::PgNode for Append {}
 impl std::fmt::Display for Append {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendPath {}
 impl pg_sys::PgNode for AppendPath {}
 impl std::fmt::Display for AppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendRelInfo {}
 impl pg_sys::PgNode for AppendRelInfo {}
 impl std::fmt::Display for AppendRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendState {}
 impl pg_sys::PgNode for AppendState {}
 impl std::fmt::Display for AppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayCoerceExpr {}
 impl pg_sys::PgNode for ArrayCoerceExpr {}
 impl std::fmt::Display for ArrayCoerceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayExpr {}
 impl pg_sys::PgNode for ArrayExpr {}
 impl std::fmt::Display for ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BaseBackupCmd {}
 impl pg_sys::PgNode for BaseBackupCmd {}
 impl std::fmt::Display for BaseBackupCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAnd {}
 impl pg_sys::PgNode for BitmapAnd {}
 impl std::fmt::Display for BitmapAnd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndPath {}
 impl pg_sys::PgNode for BitmapAndPath {}
 impl std::fmt::Display for BitmapAndPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndState {}
 impl pg_sys::PgNode for BitmapAndState {}
 impl std::fmt::Display for BitmapAndState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapPath {}
 impl pg_sys::PgNode for BitmapHeapPath {}
 impl std::fmt::Display for BitmapHeapPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScan {}
 impl pg_sys::PgNode for BitmapHeapScan {}
 impl std::fmt::Display for BitmapHeapScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScanState {}
 impl pg_sys::PgNode for BitmapHeapScanState {}
 impl std::fmt::Display for BitmapHeapScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScan {}
 impl pg_sys::PgNode for BitmapIndexScan {}
 impl std::fmt::Display for BitmapIndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScanState {}
 impl pg_sys::PgNode for BitmapIndexScanState {}
 impl std::fmt::Display for BitmapIndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOr {}
 impl pg_sys::PgNode for BitmapOr {}
 impl std::fmt::Display for BitmapOr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrPath {}
 impl pg_sys::PgNode for BitmapOrPath {}
 impl std::fmt::Display for BitmapOrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrState {}
 impl pg_sys::PgNode for BitmapOrState {}
 impl std::fmt::Display for BitmapOrState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BoolExpr {}
 impl pg_sys::PgNode for BoolExpr {}
 impl std::fmt::Display for BoolExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BooleanTest {}
 impl pg_sys::PgNode for BooleanTest {}
 impl std::fmt::Display for BooleanTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BufferHeapTupleTableSlot {}
 impl pg_sys::PgNode for BufferHeapTupleTableSlot {}
 impl std::fmt::Display for BufferHeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallContext {}
 impl pg_sys::PgNode for CallContext {}
 impl std::fmt::Display for CallContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallStmt {}
 impl pg_sys::PgNode for CallStmt {}
 impl std::fmt::Display for CallStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseExpr {}
 impl pg_sys::PgNode for CaseExpr {}
 impl std::fmt::Display for CaseExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseTestExpr {}
 impl pg_sys::PgNode for CaseTestExpr {}
 impl std::fmt::Display for CaseTestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseWhen {}
 impl pg_sys::PgNode for CaseWhen {}
 impl std::fmt::Display for CaseWhen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CheckPointStmt {}
 impl pg_sys::PgNode for CheckPointStmt {}
 impl std::fmt::Display for CheckPointStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClosePortalStmt {}
 impl pg_sys::PgNode for ClosePortalStmt {}
 impl std::fmt::Display for ClosePortalStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClusterStmt {}
 impl pg_sys::PgNode for ClusterStmt {}
 impl std::fmt::Display for ClusterStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoalesceExpr {}
 impl pg_sys::PgNode for CoalesceExpr {}
 impl std::fmt::Display for CoalesceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomain {}
 impl pg_sys::PgNode for CoerceToDomain {}
 impl std::fmt::Display for CoerceToDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomainValue {}
 impl pg_sys::PgNode for CoerceToDomainValue {}
 impl std::fmt::Display for CoerceToDomainValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceViaIO {}
 impl pg_sys::PgNode for CoerceViaIO {}
 impl std::fmt::Display for CoerceViaIO {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateClause {}
 impl pg_sys::PgNode for CollateClause {}
 impl std::fmt::Display for CollateClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateExpr {}
 impl pg_sys::PgNode for CollateExpr {}
 impl std::fmt::Display for CollateExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnDef {}
 impl pg_sys::PgNode for ColumnDef {}
 impl std::fmt::Display for ColumnDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnRef {}
 impl pg_sys::PgNode for ColumnRef {}
 impl std::fmt::Display for ColumnRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommentStmt {}
 impl pg_sys::PgNode for CommentStmt {}
 impl std::fmt::Display for CommentStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommonTableExpr {}
 impl pg_sys::PgNode for CommonTableExpr {}
 impl std::fmt::Display for CommonTableExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CompositeTypeStmt {}
 impl pg_sys::PgNode for CompositeTypeStmt {}
 impl std::fmt::Display for CompositeTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Const {}
 impl pg_sys::PgNode for Const {}
 impl std::fmt::Display for Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Constraint {}
 impl pg_sys::PgNode for Constraint {}
 impl std::fmt::Display for Constraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConstraintsSetStmt {}
 impl pg_sys::PgNode for ConstraintsSetStmt {}
 impl std::fmt::Display for ConstraintsSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConvertRowtypeExpr {}
 impl pg_sys::PgNode for ConvertRowtypeExpr {}
 impl std::fmt::Display for ConvertRowtypeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CopyStmt {}
 impl pg_sys::PgNode for CopyStmt {}
 impl std::fmt::Display for CopyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateAmStmt {}
 impl pg_sys::PgNode for CreateAmStmt {}
 impl std::fmt::Display for CreateAmStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateCastStmt {}
 impl pg_sys::PgNode for CreateCastStmt {}
 impl std::fmt::Display for CreateCastStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateConversionStmt {}
 impl pg_sys::PgNode for CreateConversionStmt {}
 impl std::fmt::Display for CreateConversionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateDomainStmt {}
 impl pg_sys::PgNode for CreateDomainStmt {}
 impl std::fmt::Display for CreateDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEnumStmt {}
 impl pg_sys::PgNode for CreateEnumStmt {}
 impl std::fmt::Display for CreateEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEventTrigStmt {}
 impl pg_sys::PgNode for CreateEventTrigStmt {}
 impl std::fmt::Display for CreateEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateExtensionStmt {}
 impl pg_sys::PgNode for CreateExtensionStmt {}
 impl std::fmt::Display for CreateExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFdwStmt {}
 impl pg_sys::PgNode for CreateFdwStmt {}
 impl std::fmt::Display for CreateFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignServerStmt {}
 impl pg_sys::PgNode for CreateForeignServerStmt {}
 impl std::fmt::Display for CreateForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignTableStmt {}
 impl pg_sys::PgNode for CreateForeignTableStmt {}
 impl std::fmt::Display for CreateForeignTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFunctionStmt {}
 impl pg_sys::PgNode for CreateFunctionStmt {}
 impl std::fmt::Display for CreateFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassItem {}
 impl pg_sys::PgNode for CreateOpClassItem {}
 impl std::fmt::Display for CreateOpClassItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassStmt {}
 impl pg_sys::PgNode for CreateOpClassStmt {}
 impl std::fmt::Display for CreateOpClassStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpFamilyStmt {}
 impl pg_sys::PgNode for CreateOpFamilyStmt {}
 impl std::fmt::Display for CreateOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePLangStmt {}
 impl pg_sys::PgNode for CreatePLangStmt {}
 impl std::fmt::Display for CreatePLangStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePolicyStmt {}
 impl pg_sys::PgNode for CreatePolicyStmt {}
 impl std::fmt::Display for CreatePolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePublicationStmt {}
 impl pg_sys::PgNode for CreatePublicationStmt {}
 impl std::fmt::Display for CreatePublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRangeStmt {}
 impl pg_sys::PgNode for CreateRangeStmt {}
 impl std::fmt::Display for CreateRangeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateReplicationSlotCmd {}
 impl pg_sys::PgNode for CreateReplicationSlotCmd {}
 impl std::fmt::Display for CreateReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRoleStmt {}
 impl pg_sys::PgNode for CreateRoleStmt {}
 impl std::fmt::Display for CreateRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSchemaStmt {}
 impl pg_sys::PgNode for CreateSchemaStmt {}
 impl std::fmt::Display for CreateSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSeqStmt {}
 impl pg_sys::PgNode for CreateSeqStmt {}
 impl std::fmt::Display for CreateSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStatsStmt {}
 impl pg_sys::PgNode for CreateStatsStmt {}
 impl std::fmt::Display for CreateStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStmt {}
 impl pg_sys::PgNode for CreateStmt {}
 impl std::fmt::Display for CreateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSubscriptionStmt {}
 impl pg_sys::PgNode for CreateSubscriptionStmt {}
 impl std::fmt::Display for CreateSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableAsStmt {}
 impl pg_sys::PgNode for CreateTableAsStmt {}
 impl std::fmt::Display for CreateTableAsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableSpaceStmt {}
 impl pg_sys::PgNode for CreateTableSpaceStmt {}
 impl std::fmt::Display for CreateTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTransformStmt {}
 impl pg_sys::PgNode for CreateTransformStmt {}
 impl std::fmt::Display for CreateTransformStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTrigStmt {}
 impl pg_sys::PgNode for CreateTrigStmt {}
 impl std::fmt::Display for CreateTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateUserMappingStmt {}
 impl pg_sys::PgNode for CreateUserMappingStmt {}
 impl std::fmt::Display for CreateUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatedbStmt {}
 impl pg_sys::PgNode for CreatedbStmt {}
 impl std::fmt::Display for CreatedbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScan {}
 impl pg_sys::PgNode for CteScan {}
 impl std::fmt::Display for CteScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScanState {}
 impl pg_sys::PgNode for CteScanState {}
 impl std::fmt::Display for CteScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CurrentOfExpr {}
 impl pg_sys::PgNode for CurrentOfExpr {}
 impl std::fmt::Display for CurrentOfExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomPath {}
 impl pg_sys::PgNode for CustomPath {}
 impl std::fmt::Display for CustomPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScan {}
 impl pg_sys::PgNode for CustomScan {}
 impl std::fmt::Display for CustomScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScanState {}
 impl pg_sys::PgNode for CustomScanState {}
 impl std::fmt::Display for CustomScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeallocateStmt {}
 impl pg_sys::PgNode for DeallocateStmt {}
 impl std::fmt::Display for DeallocateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeclareCursorStmt {}
 impl pg_sys::PgNode for DeclareCursorStmt {}
 impl std::fmt::Display for DeclareCursorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefElem {}
 impl pg_sys::PgNode for DefElem {}
 impl std::fmt::Display for DefElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefineStmt {}
 impl pg_sys::PgNode for DefineStmt {}
 impl std::fmt::Display for DefineStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeleteStmt {}
 impl pg_sys::PgNode for DeleteStmt {}
 impl std::fmt::Display for DeleteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DiscardStmt {}
 impl pg_sys::PgNode for DiscardStmt {}
 impl std::fmt::Display for DiscardStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DoStmt {}
 impl pg_sys::PgNode for DoStmt {}
 impl std::fmt::Display for DoStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DomainConstraintState {}
 impl pg_sys::PgNode for DomainConstraintState {}
 impl std::fmt::Display for DomainConstraintState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropOwnedStmt {}
 impl pg_sys::PgNode for DropOwnedStmt {}
 impl std::fmt::Display for DropOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropReplicationSlotCmd {}
 impl pg_sys::PgNode for DropReplicationSlotCmd {}
 impl std::fmt::Display for DropReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropRoleStmt {}
 impl pg_sys::PgNode for DropRoleStmt {}
 impl std::fmt::Display for DropRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropStmt {}
 impl pg_sys::PgNode for DropStmt {}
 impl std::fmt::Display for DropStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropSubscriptionStmt {}
 impl pg_sys::PgNode for DropSubscriptionStmt {}
 impl std::fmt::Display for DropSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropTableSpaceStmt {}
 impl pg_sys::PgNode for DropTableSpaceStmt {}
 impl std::fmt::Display for DropTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropUserMappingStmt {}
 impl pg_sys::PgNode for DropUserMappingStmt {}
 impl std::fmt::Display for DropUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropdbStmt {}
 impl pg_sys::PgNode for DropdbStmt {}
 impl std::fmt::Display for DropdbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EState {}
 impl pg_sys::PgNode for EState {}
 impl std::fmt::Display for EState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceClass {}
 impl pg_sys::PgNode for EquivalenceClass {}
 impl std::fmt::Display for EquivalenceClass {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceMember {}
 impl pg_sys::PgNode for EquivalenceMember {}
 impl std::fmt::Display for EquivalenceMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EventTriggerData {}
 impl pg_sys::PgNode for EventTriggerData {}
 impl std::fmt::Display for EventTriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExecuteStmt {}
 impl pg_sys::PgNode for ExecuteStmt {}
 impl std::fmt::Display for ExecuteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExplainStmt {}
 impl pg_sys::PgNode for ExplainStmt {}
 impl std::fmt::Display for ExplainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Expr {}
 impl pg_sys::PgNode for Expr {}
 impl std::fmt::Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprContext {}
 impl pg_sys::PgNode for ExprContext {}
 impl std::fmt::Display for ExprContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprState {}
 impl pg_sys::PgNode for ExprState {}
 impl std::fmt::Display for ExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExtensibleNode {}
 impl pg_sys::PgNode for ExtensibleNode {}
 impl std::fmt::Display for ExtensibleNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FdwRoutine {}
 impl pg_sys::PgNode for FdwRoutine {}
 impl std::fmt::Display for FdwRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FetchStmt {}
 impl pg_sys::PgNode for FetchStmt {}
 impl std::fmt::Display for FetchStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldSelect {}
 impl pg_sys::PgNode for FieldSelect {}
 impl std::fmt::Display for FieldSelect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldStore {}
 impl pg_sys::PgNode for FieldStore {}
 impl std::fmt::Display for FieldStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyCacheInfo {}
 impl pg_sys::PgNode for ForeignKeyCacheInfo {}
 impl std::fmt::Display for ForeignKeyCacheInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyOptInfo {}
 impl pg_sys::PgNode for ForeignKeyOptInfo {}
 impl std::fmt::Display for ForeignKeyOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignPath {}
 impl pg_sys::PgNode for ForeignPath {}
 impl std::fmt::Display for ForeignPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScan {}
 impl pg_sys::PgNode for ForeignScan {}
 impl std::fmt::Display for ForeignScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScanState {}
 impl pg_sys::PgNode for ForeignScanState {}
 impl std::fmt::Display for ForeignScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FromExpr {}
 impl pg_sys::PgNode for FromExpr {}
 impl std::fmt::Display for FromExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncCall {}
 impl pg_sys::PgNode for FuncCall {}
 impl std::fmt::Display for FuncCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncExpr {}
 impl pg_sys::PgNode for FuncExpr {}
 impl std::fmt::Display for FuncExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionParameter {}
 impl pg_sys::PgNode for FunctionParameter {}
 impl std::fmt::Display for FunctionParameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScan {}
 impl pg_sys::PgNode for FunctionScan {}
 impl std::fmt::Display for FunctionScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScanState {}
 impl pg_sys::PgNode for FunctionScanState {}
 impl std::fmt::Display for FunctionScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Gather {}
 impl pg_sys::PgNode for Gather {}
 impl std::fmt::Display for Gather {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMerge {}
 impl pg_sys::PgNode for GatherMerge {}
 impl std::fmt::Display for GatherMerge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergePath {}
 impl pg_sys::PgNode for GatherMergePath {}
 impl std::fmt::Display for GatherMergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergeState {}
 impl pg_sys::PgNode for GatherMergeState {}
 impl std::fmt::Display for GatherMergeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherPath {}
 impl pg_sys::PgNode for GatherPath {}
 impl std::fmt::Display for GatherPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherState {}
 impl pg_sys::PgNode for GatherState {}
 impl std::fmt::Display for GatherState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantRoleStmt {}
 impl pg_sys::PgNode for GrantRoleStmt {}
 impl std::fmt::Display for GrantRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantStmt {}
 impl pg_sys::PgNode for GrantStmt {}
 impl std::fmt::Display for GrantStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Group {}
 impl pg_sys::PgNode for Group {}
 impl std::fmt::Display for Group {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupPath {}
 impl pg_sys::PgNode for GroupPath {}
 impl std::fmt::Display for GroupPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupResultPath {}
 impl pg_sys::PgNode for GroupResultPath {}
 impl std::fmt::Display for GroupResultPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupState {}
 impl pg_sys::PgNode for GroupState {}
 impl std::fmt::Display for GroupState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingFunc {}
 impl pg_sys::PgNode for GroupingFunc {}
 impl std::fmt::Display for GroupingFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSet {}
 impl pg_sys::PgNode for GroupingSet {}
 impl std::fmt::Display for GroupingSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetData {}
 impl pg_sys::PgNode for GroupingSetData {}
 impl std::fmt::Display for GroupingSetData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetsPath {}
 impl pg_sys::PgNode for GroupingSetsPath {}
 impl std::fmt::Display for GroupingSetsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Hash {}
 impl pg_sys::PgNode for Hash {}
 impl std::fmt::Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoin {}
 impl pg_sys::PgNode for HashJoin {}
 impl std::fmt::Display for HashJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoinState {}
 impl pg_sys::PgNode for HashJoinState {}
 impl std::fmt::Display for HashJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashPath {}
 impl pg_sys::PgNode for HashPath {}
 impl std::fmt::Display for HashPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashState {}
 impl pg_sys::PgNode for HashState {}
 impl std::fmt::Display for HashState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HeapTupleTableSlot {}
 impl pg_sys::PgNode for HeapTupleTableSlot {}
 impl std::fmt::Display for HeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IdentifySystemCmd {}
 impl pg_sys::PgNode for IdentifySystemCmd {}
 impl std::fmt::Display for IdentifySystemCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ImportForeignSchemaStmt {}
 impl pg_sys::PgNode for ImportForeignSchemaStmt {}
 impl std::fmt::Display for ImportForeignSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSort {}
 impl pg_sys::PgNode for IncrementalSort {}
 impl std::fmt::Display for IncrementalSort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSortPath {}
 impl pg_sys::PgNode for IncrementalSortPath {}
 impl std::fmt::Display for IncrementalSortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSortState {}
 impl pg_sys::PgNode for IncrementalSortState {}
 impl std::fmt::Display for IncrementalSortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexAmRoutine {}
 impl pg_sys::PgNode for IndexAmRoutine {}
 impl std::fmt::Display for IndexAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexClause {}
 impl pg_sys::PgNode for IndexClause {}
 impl std::fmt::Display for IndexClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexElem {}
 impl pg_sys::PgNode for IndexElem {}
 impl std::fmt::Display for IndexElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexInfo {}
 impl pg_sys::PgNode for IndexInfo {}
 impl std::fmt::Display for IndexInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScan {}
 impl pg_sys::PgNode for IndexOnlyScan {}
 impl std::fmt::Display for IndexOnlyScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScanState {}
 impl pg_sys::PgNode for IndexOnlyScanState {}
 impl std::fmt::Display for IndexOnlyScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOptInfo {}
 impl pg_sys::PgNode for IndexOptInfo {}
 impl std::fmt::Display for IndexOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexPath {}
 impl pg_sys::PgNode for IndexPath {}
 impl std::fmt::Display for IndexPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScan {}
 impl pg_sys::PgNode for IndexScan {}
 impl std::fmt::Display for IndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScanState {}
 impl pg_sys::PgNode for IndexScanState {}
 impl std::fmt::Display for IndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexStmt {}
 impl pg_sys::PgNode for IndexStmt {}
 impl std::fmt::Display for IndexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferClause {}
 impl pg_sys::PgNode for InferClause {}
 impl std::fmt::Display for InferClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferenceElem {}
 impl pg_sys::PgNode for InferenceElem {}
 impl std::fmt::Display for InferenceElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InlineCodeBlock {}
 impl pg_sys::PgNode for InlineCodeBlock {}
 impl std::fmt::Display for InlineCodeBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InsertStmt {}
 impl pg_sys::PgNode for InsertStmt {}
 impl std::fmt::Display for InsertStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IntoClause {}
 impl pg_sys::PgNode for IntoClause {}
 impl std::fmt::Display for IntoClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Join {}
 impl pg_sys::PgNode for Join {}
 impl std::fmt::Display for Join {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinExpr {}
 impl pg_sys::PgNode for JoinExpr {}
 impl std::fmt::Display for JoinExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinPath {}
 impl pg_sys::PgNode for JoinPath {}
 impl std::fmt::Display for JoinPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinState {}
 impl pg_sys::PgNode for JoinState {}
 impl std::fmt::Display for JoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JunkFilter {}
 impl pg_sys::PgNode for JunkFilter {}
 impl std::fmt::Display for JunkFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Limit {}
 impl pg_sys::PgNode for Limit {}
 impl std::fmt::Display for Limit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitPath {}
 impl pg_sys::PgNode for LimitPath {}
 impl std::fmt::Display for LimitPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitState {}
 impl pg_sys::PgNode for LimitState {}
 impl std::fmt::Display for LimitState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for List {}
 impl pg_sys::PgNode for List {}
 impl std::fmt::Display for List {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ListenStmt {}
 impl pg_sys::PgNode for ListenStmt {}
 impl std::fmt::Display for ListenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LoadStmt {}
 impl pg_sys::PgNode for LoadStmt {}
 impl std::fmt::Display for LoadStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRows {}
 impl pg_sys::PgNode for LockRows {}
 impl std::fmt::Display for LockRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsPath {}
 impl pg_sys::PgNode for LockRowsPath {}
 impl std::fmt::Display for LockRowsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsState {}
 impl pg_sys::PgNode for LockRowsState {}
 impl std::fmt::Display for LockRowsState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockStmt {}
 impl pg_sys::PgNode for LockStmt {}
 impl std::fmt::Display for LockStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockingClause {}
 impl pg_sys::PgNode for LockingClause {}
 impl std::fmt::Display for LockingClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Material {}
 impl pg_sys::PgNode for Material {}
 impl std::fmt::Display for Material {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialPath {}
 impl pg_sys::PgNode for MaterialPath {}
 impl std::fmt::Display for MaterialPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialState {}
 impl pg_sys::PgNode for MaterialState {}
 impl std::fmt::Display for MaterialState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoryContextData {}
 impl pg_sys::PgNode for MemoryContextData {}
 impl std::fmt::Display for MemoryContextData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppend {}
 impl pg_sys::PgNode for MergeAppend {}
 impl std::fmt::Display for MergeAppend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendPath {}
 impl pg_sys::PgNode for MergeAppendPath {}
 impl std::fmt::Display for MergeAppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendState {}
 impl pg_sys::PgNode for MergeAppendState {}
 impl std::fmt::Display for MergeAppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoin {}
 impl pg_sys::PgNode for MergeJoin {}
 impl std::fmt::Display for MergeJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoinState {}
 impl pg_sys::PgNode for MergeJoinState {}
 impl std::fmt::Display for MergeJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergePath {}
 impl pg_sys::PgNode for MergePath {}
 impl std::fmt::Display for MergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggInfo {}
 impl pg_sys::PgNode for MinMaxAggInfo {}
 impl std::fmt::Display for MinMaxAggInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggPath {}
 impl pg_sys::PgNode for MinMaxAggPath {}
 impl std::fmt::Display for MinMaxAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxExpr {}
 impl pg_sys::PgNode for MinMaxExpr {}
 impl std::fmt::Display for MinMaxExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinimalTupleTableSlot {}
 impl pg_sys::PgNode for MinimalTupleTableSlot {}
 impl std::fmt::Display for MinimalTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTable {}
 impl pg_sys::PgNode for ModifyTable {}
 impl std::fmt::Display for ModifyTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTablePath {}
 impl pg_sys::PgNode for ModifyTablePath {}
 impl std::fmt::Display for ModifyTablePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTableState {}
 impl pg_sys::PgNode for ModifyTableState {}
 impl std::fmt::Display for ModifyTableState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MultiAssignRef {}
 impl pg_sys::PgNode for MultiAssignRef {}
 impl std::fmt::Display for MultiAssignRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedArgExpr {}
 impl pg_sys::PgNode for NamedArgExpr {}
 impl std::fmt::Display for NamedArgExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScan {}
 impl pg_sys::PgNode for NamedTuplestoreScan {}
 impl std::fmt::Display for NamedTuplestoreScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScanState {}
 impl pg_sys::PgNode for NamedTuplestoreScanState {}
 impl std::fmt::Display for NamedTuplestoreScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoop {}
 impl pg_sys::PgNode for NestLoop {}
 impl std::fmt::Display for NestLoop {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopParam {}
 impl pg_sys::PgNode for NestLoopParam {}
 impl std::fmt::Display for NestLoopParam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopState {}
 impl pg_sys::PgNode for NestLoopState {}
 impl std::fmt::Display for NestLoopState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NextValueExpr {}
 impl pg_sys::PgNode for NextValueExpr {}
 impl std::fmt::Display for NextValueExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Node {}
 impl pg_sys::PgNode for Node {}
 impl std::fmt::Display for Node {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NotifyStmt {}
 impl pg_sys::PgNode for NotifyStmt {}
 impl std::fmt::Display for NotifyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NullTest {}
 impl pg_sys::PgNode for NullTest {}
 impl std::fmt::Display for NullTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ObjectWithArgs {}
 impl pg_sys::PgNode for ObjectWithArgs {}
 impl std::fmt::Display for ObjectWithArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictClause {}
 impl pg_sys::PgNode for OnConflictClause {}
 impl std::fmt::Display for OnConflictClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictExpr {}
 impl pg_sys::PgNode for OnConflictExpr {}
 impl std::fmt::Display for OnConflictExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictSetState {}
 impl pg_sys::PgNode for OnConflictSetState {}
 impl std::fmt::Display for OnConflictSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OpExpr {}
 impl pg_sys::PgNode for OpExpr {}
 impl std::fmt::Display for OpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Param {}
 impl pg_sys::PgNode for Param {}
 impl std::fmt::Display for Param {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamPathInfo {}
 impl pg_sys::PgNode for ParamPathInfo {}
 impl std::fmt::Display for ParamPathInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamRef {}
 impl pg_sys::PgNode for ParamRef {}
 impl std::fmt::Display for ParamRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionBoundSpec {}
 impl pg_sys::PgNode for PartitionBoundSpec {}
 impl std::fmt::Display for PartitionBoundSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionCmd {}
 impl pg_sys::PgNode for PartitionCmd {}
 impl std::fmt::Display for PartitionCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionElem {}
 impl pg_sys::PgNode for PartitionElem {}
 impl std::fmt::Display for PartitionElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneInfo {}
 impl pg_sys::PgNode for PartitionPruneInfo {}
 impl std::fmt::Display for PartitionPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStep {}
 impl pg_sys::PgNode for PartitionPruneStep {}
 impl std::fmt::Display for PartitionPruneStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepCombine {}
 impl pg_sys::PgNode for PartitionPruneStepCombine {}
 impl std::fmt::Display for PartitionPruneStepCombine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepOp {}
 impl pg_sys::PgNode for PartitionPruneStepOp {}
 impl std::fmt::Display for PartitionPruneStepOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionRangeDatum {}
 impl pg_sys::PgNode for PartitionRangeDatum {}
 impl std::fmt::Display for PartitionRangeDatum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionSpec {}
 impl pg_sys::PgNode for PartitionSpec {}
 impl std::fmt::Display for PartitionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionedRelPruneInfo {}
 impl pg_sys::PgNode for PartitionedRelPruneInfo {}
 impl std::fmt::Display for PartitionedRelPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Path {}
 impl pg_sys::PgNode for Path {}
 impl std::fmt::Display for Path {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathKey {}
 impl pg_sys::PgNode for PathKey {}
 impl std::fmt::Display for PathKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathTarget {}
 impl pg_sys::PgNode for PathTarget {}
 impl std::fmt::Display for PathTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderInfo {}
 impl pg_sys::PgNode for PlaceHolderInfo {}
 impl std::fmt::Display for PlaceHolderInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderVar {}
 impl pg_sys::PgNode for PlaceHolderVar {}
 impl std::fmt::Display for PlaceHolderVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Plan {}
 impl pg_sys::PgNode for Plan {}
 impl std::fmt::Display for Plan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanInvalItem {}
 impl pg_sys::PgNode for PlanInvalItem {}
 impl std::fmt::Display for PlanInvalItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanRowMark {}
 impl pg_sys::PgNode for PlanRowMark {}
 impl std::fmt::Display for PlanRowMark {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanState {}
 impl pg_sys::PgNode for PlanState {}
 impl std::fmt::Display for PlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannedStmt {}
 impl pg_sys::PgNode for PlannedStmt {}
 impl std::fmt::Display for PlannedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerGlobal {}
 impl pg_sys::PgNode for PlannerGlobal {}
 impl std::fmt::Display for PlannerGlobal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerInfo {}
 impl pg_sys::PgNode for PlannerInfo {}
 impl std::fmt::Display for PlannerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerParamItem {}
 impl pg_sys::PgNode for PlannerParamItem {}
 impl std::fmt::Display for PlannerParamItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PrepareStmt {}
 impl pg_sys::PgNode for PrepareStmt {}
 impl std::fmt::Display for PrepareStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSet {}
 impl pg_sys::PgNode for ProjectSet {}
 impl std::fmt::Display for ProjectSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetPath {}
 impl pg_sys::PgNode for ProjectSetPath {}
 impl std::fmt::Display for ProjectSetPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetState {}
 impl pg_sys::PgNode for ProjectSetState {}
 impl std::fmt::Display for ProjectSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionInfo {}
 impl pg_sys::PgNode for ProjectionInfo {}
 impl std::fmt::Display for ProjectionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionPath {}
 impl pg_sys::PgNode for ProjectionPath {}
 impl std::fmt::Display for ProjectionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Query {}
 impl pg_sys::PgNode for Query {}
 impl std::fmt::Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeFunction {}
 impl pg_sys::PgNode for RangeFunction {}
 impl std::fmt::Display for RangeFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeSubselect {}
 impl pg_sys::PgNode for RangeSubselect {}
 impl std::fmt::Display for RangeSubselect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFunc {}
 impl pg_sys::PgNode for RangeTableFunc {}
 impl std::fmt::Display for RangeTableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFuncCol {}
 impl pg_sys::PgNode for RangeTableFuncCol {}
 impl std::fmt::Display for RangeTableFuncCol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableSample {}
 impl pg_sys::PgNode for RangeTableSample {}
 impl std::fmt::Display for RangeTableSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblEntry {}
 impl pg_sys::PgNode for RangeTblEntry {}
 impl std::fmt::Display for RangeTblEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblFunction {}
 impl pg_sys::PgNode for RangeTblFunction {}
 impl std::fmt::Display for RangeTblFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblRef {}
 impl pg_sys::PgNode for RangeTblRef {}
 impl std::fmt::Display for RangeTblRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeVar {}
 impl pg_sys::PgNode for RangeVar {}
 impl std::fmt::Display for RangeVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RawStmt {}
 impl pg_sys::PgNode for RawStmt {}
 impl std::fmt::Display for RawStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReassignOwnedStmt {}
 impl pg_sys::PgNode for ReassignOwnedStmt {}
 impl std::fmt::Display for ReassignOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnion {}
 impl pg_sys::PgNode for RecursiveUnion {}
 impl std::fmt::Display for RecursiveUnion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionPath {}
 impl pg_sys::PgNode for RecursiveUnionPath {}
 impl std::fmt::Display for RecursiveUnionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionState {}
 impl pg_sys::PgNode for RecursiveUnionState {}
 impl std::fmt::Display for RecursiveUnionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RefreshMatViewStmt {}
 impl pg_sys::PgNode for RefreshMatViewStmt {}
 impl std::fmt::Display for RefreshMatViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReindexStmt {}
 impl pg_sys::PgNode for ReindexStmt {}
 impl std::fmt::Display for ReindexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelOptInfo {}
 impl pg_sys::PgNode for RelOptInfo {}
 impl std::fmt::Display for RelOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelabelType {}
 impl pg_sys::PgNode for RelabelType {}
 impl std::fmt::Display for RelabelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RenameStmt {}
 impl pg_sys::PgNode for RenameStmt {}
 impl std::fmt::Display for RenameStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReplicaIdentityStmt {}
 impl pg_sys::PgNode for ReplicaIdentityStmt {}
 impl std::fmt::Display for ReplicaIdentityStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResTarget {}
 impl pg_sys::PgNode for ResTarget {}
 impl std::fmt::Display for ResTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RestrictInfo {}
 impl pg_sys::PgNode for RestrictInfo {}
 impl std::fmt::Display for RestrictInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Result {}
 impl pg_sys::PgNode for Result {}
 impl std::fmt::Display for Result {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultRelInfo {}
 impl pg_sys::PgNode for ResultRelInfo {}
 impl std::fmt::Display for ResultRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultState {}
 impl pg_sys::PgNode for ResultState {}
 impl std::fmt::Display for ResultState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReturnSetInfo {}
 impl pg_sys::PgNode for ReturnSetInfo {}
 impl std::fmt::Display for ReturnSetInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RoleSpec {}
 impl pg_sys::PgNode for RoleSpec {}
 impl std::fmt::Display for RoleSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RollupData {}
 impl pg_sys::PgNode for RollupData {}
 impl std::fmt::Display for RollupData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowCompareExpr {}
 impl pg_sys::PgNode for RowCompareExpr {}
 impl std::fmt::Display for RowCompareExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowExpr {}
 impl pg_sys::PgNode for RowExpr {}
 impl std::fmt::Display for RowExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowMarkClause {}
 impl pg_sys::PgNode for RowMarkClause {}
 impl std::fmt::Display for RowMarkClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RuleStmt {}
 impl pg_sys::PgNode for RuleStmt {}
 impl std::fmt::Display for RuleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLCmd {}
 impl pg_sys::PgNode for SQLCmd {}
 impl std::fmt::Display for SQLCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLValueFunction {}
 impl pg_sys::PgNode for SQLValueFunction {}
 impl std::fmt::Display for SQLValueFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScan {}
 impl pg_sys::PgNode for SampleScan {}
 impl std::fmt::Display for SampleScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScanState {}
 impl pg_sys::PgNode for SampleScanState {}
 impl std::fmt::Display for SampleScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScalarArrayOpExpr {}
 impl pg_sys::PgNode for ScalarArrayOpExpr {}
 impl std::fmt::Display for ScalarArrayOpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Scan {}
 impl pg_sys::PgNode for Scan {}
 impl std::fmt::Display for Scan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScanState {}
 impl pg_sys::PgNode for ScanState {}
 impl std::fmt::Display for ScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SecLabelStmt {}
 impl pg_sys::PgNode for SecLabelStmt {}
 impl std::fmt::Display for SecLabelStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SelectStmt {}
 impl pg_sys::PgNode for SelectStmt {}
 impl std::fmt::Display for SelectStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SeqScanState {}
 impl pg_sys::PgNode for SeqScanState {}
 impl std::fmt::Display for SeqScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetExprState {}
 impl pg_sys::PgNode for SetExprState {}
 impl std::fmt::Display for SetExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOp {}
 impl pg_sys::PgNode for SetOp {}
 impl std::fmt::Display for SetOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpPath {}
 impl pg_sys::PgNode for SetOpPath {}
 impl std::fmt::Display for SetOpPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpState {}
 impl pg_sys::PgNode for SetOpState {}
 impl std::fmt::Display for SetOpState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOperationStmt {}
 impl pg_sys::PgNode for SetOperationStmt {}
 impl std::fmt::Display for SetOperationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetToDefault {}
 impl pg_sys::PgNode for SetToDefault {}
 impl std::fmt::Display for SetToDefault {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Sort {}
 impl pg_sys::PgNode for Sort {}
 impl std::fmt::Display for Sort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortBy {}
 impl pg_sys::PgNode for SortBy {}
 impl std::fmt::Display for SortBy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortGroupClause {}
 impl pg_sys::PgNode for SortGroupClause {}
 impl std::fmt::Display for SortGroupClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortPath {}
 impl pg_sys::PgNode for SortPath {}
 impl std::fmt::Display for SortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortState {}
 impl pg_sys::PgNode for SortState {}
 impl std::fmt::Display for SortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SpecialJoinInfo {}
 impl pg_sys::PgNode for SpecialJoinInfo {}
 impl std::fmt::Display for SpecialJoinInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StartReplicationCmd {}
 impl pg_sys::PgNode for StartReplicationCmd {}
 impl std::fmt::Display for StartReplicationCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StatisticExtInfo {}
 impl pg_sys::PgNode for StatisticExtInfo {}
 impl std::fmt::Display for StatisticExtInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubLink {}
 impl pg_sys::PgNode for SubLink {}
 impl std::fmt::Display for SubLink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlan {}
 impl pg_sys::PgNode for SubPlan {}
 impl std::fmt::Display for SubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlanState {}
 impl pg_sys::PgNode for SubPlanState {}
 impl std::fmt::Display for SubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScan {}
 impl pg_sys::PgNode for SubqueryScan {}
 impl std::fmt::Display for SubqueryScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanPath {}
 impl pg_sys::PgNode for SubqueryScanPath {}
 impl std::fmt::Display for SubqueryScanPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanState {}
 impl pg_sys::PgNode for SubqueryScanState {}
 impl std::fmt::Display for SubqueryScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubscriptingRef {}
 impl pg_sys::PgNode for SubscriptingRef {}
 impl std::fmt::Display for SubscriptingRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestCost {}
 impl pg_sys::PgNode for SupportRequestCost {}
 impl std::fmt::Display for SupportRequestCost {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestIndexCondition {}
 impl pg_sys::PgNode for SupportRequestIndexCondition {}
 impl std::fmt::Display for SupportRequestIndexCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestRows {}
 impl pg_sys::PgNode for SupportRequestRows {}
 impl std::fmt::Display for SupportRequestRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSelectivity {}
 impl pg_sys::PgNode for SupportRequestSelectivity {}
 impl std::fmt::Display for SupportRequestSelectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSimplify {}
 impl pg_sys::PgNode for SupportRequestSimplify {}
 impl std::fmt::Display for SupportRequestSimplify {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableAmRoutine {}
 impl pg_sys::PgNode for TableAmRoutine {}
 impl std::fmt::Display for TableAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFunc {}
 impl pg_sys::PgNode for TableFunc {}
 impl std::fmt::Display for TableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScan {}
 impl pg_sys::PgNode for TableFuncScan {}
 impl std::fmt::Display for TableFuncScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScanState {}
 impl pg_sys::PgNode for TableFuncScanState {}
 impl std::fmt::Display for TableFuncScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableLikeClause {}
 impl pg_sys::PgNode for TableLikeClause {}
 impl std::fmt::Display for TableLikeClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableSampleClause {}
 impl pg_sys::PgNode for TableSampleClause {}
 impl std::fmt::Display for TableSampleClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TargetEntry {}
 impl pg_sys::PgNode for TargetEntry {}
 impl std::fmt::Display for TargetEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidPath {}
 impl pg_sys::PgNode for TidPath {}
 impl std::fmt::Display for TidPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScan {}
 impl pg_sys::PgNode for TidScan {}
 impl std::fmt::Display for TidScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScanState {}
 impl pg_sys::PgNode for TidScanState {}
 impl std::fmt::Display for TidScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TimeLineHistoryCmd {}
 impl pg_sys::PgNode for TimeLineHistoryCmd {}
 impl std::fmt::Display for TimeLineHistoryCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TransactionStmt {}
 impl pg_sys::PgNode for TransactionStmt {}
 impl std::fmt::Display for TransactionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerData {}
 impl pg_sys::PgNode for TriggerData {}
 impl std::fmt::Display for TriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerTransition {}
 impl pg_sys::PgNode for TriggerTransition {}
 impl std::fmt::Display for TriggerTransition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TruncateStmt {}
 impl pg_sys::PgNode for TruncateStmt {}
 impl std::fmt::Display for TruncateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TupleTableSlot {}
 impl pg_sys::PgNode for TupleTableSlot {}
 impl std::fmt::Display for TupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeCast {}
 impl pg_sys::PgNode for TypeCast {}
 impl std::fmt::Display for TypeCast {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeName {}
 impl pg_sys::PgNode for TypeName {}
 impl std::fmt::Display for TypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Unique {}
 impl pg_sys::PgNode for Unique {}
 impl std::fmt::Display for Unique {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniquePath {}
 impl pg_sys::PgNode for UniquePath {}
 impl std::fmt::Display for UniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniqueState {}
 impl pg_sys::PgNode for UniqueState {}
 impl std::fmt::Display for UniqueState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UnlistenStmt {}
 impl pg_sys::PgNode for UnlistenStmt {}
 impl std::fmt::Display for UnlistenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpdateStmt {}
 impl pg_sys::PgNode for UpdateStmt {}
 impl std::fmt::Display for UpdateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpperUniquePath {}
 impl pg_sys::PgNode for UpperUniquePath {}
 impl std::fmt::Display for UpperUniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumRelation {}
 impl pg_sys::PgNode for VacuumRelation {}
 impl std::fmt::Display for VacuumRelation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumStmt {}
 impl pg_sys::PgNode for VacuumStmt {}
 impl std::fmt::Display for VacuumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Value {}
 impl pg_sys::PgNode for Value {}
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScan {}
 impl pg_sys::PgNode for ValuesScan {}
 impl std::fmt::Display for ValuesScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScanState {}
 impl pg_sys::PgNode for ValuesScanState {}
 impl std::fmt::Display for ValuesScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Var {}
 impl pg_sys::PgNode for Var {}
 impl std::fmt::Display for Var {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableSetStmt {}
 impl pg_sys::PgNode for VariableSetStmt {}
 impl std::fmt::Display for VariableSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableShowStmt {}
 impl pg_sys::PgNode for VariableShowStmt {}
 impl std::fmt::Display for VariableShowStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ViewStmt {}
 impl pg_sys::PgNode for ViewStmt {}
 impl std::fmt::Display for ViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VirtualTupleTableSlot {}
 impl pg_sys::PgNode for VirtualTupleTableSlot {}
 impl std::fmt::Display for VirtualTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAgg {}
 impl pg_sys::PgNode for WindowAgg {}
 impl std::fmt::Display for WindowAgg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggPath {}
 impl pg_sys::PgNode for WindowAggPath {}
 impl std::fmt::Display for WindowAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggState {}
 impl pg_sys::PgNode for WindowAggState {}
 impl std::fmt::Display for WindowAggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowClause {}
 impl pg_sys::PgNode for WindowClause {}
 impl std::fmt::Display for WindowClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowDef {}
 impl pg_sys::PgNode for WindowDef {}
 impl std::fmt::Display for WindowDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFunc {}
 impl pg_sys::PgNode for WindowFunc {}
 impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFuncExprState {}
 impl pg_sys::PgNode for WindowFuncExprState {}
 impl std::fmt::Display for WindowFuncExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithCheckOption {}
 impl pg_sys::PgNode for WithCheckOption {}
 impl std::fmt::Display for WithCheckOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithClause {}
 impl pg_sys::PgNode for WithClause {}
 impl std::fmt::Display for WithClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScan {}
 impl pg_sys::PgNode for WorkTableScan {}
 impl std::fmt::Display for WorkTableScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScanState {}
 impl pg_sys::PgNode for WorkTableScanState {}
 impl std::fmt::Display for WorkTableScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlExpr {}
 impl pg_sys::PgNode for XmlExpr {}
 impl std::fmt::Display for XmlExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlSerialize {}
 impl pg_sys::PgNode for XmlSerialize {}
 impl std::fmt::Display for XmlSerialize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -164,32 +164,31 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 107usize] = b" '--prefix=/Users/e_ridge/.pgx/14.5/pgx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 106usize] = b" '--prefix=/home/atelier/.pgx/14.6/pgx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28814;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28814\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_BACKTRACE_SYMBOLS: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
-pub const HAVE_COPYFILE: u32 = 1;
-pub const HAVE_COPYFILE_H: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_PREADV: u32 = 1;
 pub const HAVE_DECL_PWRITEV: u32 = 1;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_EXECINFO_H: u32 = 1;
+pub const HAVE_EXPLICIT_BZERO: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -199,11 +198,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -212,10 +211,8 @@ pub const HAVE_IFADDRS_H: u32 = 1;
 pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
-pub const HAVE_KQUEUE: u32 = 1;
 pub const HAVE_LANGINFO_H: u32 = 1;
 pub const HAVE_LIBM: u32 = 1;
 pub const HAVE_LIBREADLINE: u32 = 1;
@@ -223,17 +220,18 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LINK: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
-pub const HAVE_MEMSET_S: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
 pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
+pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
+pub const HAVE_PTHREAD_BARRIER_WAIT: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_RANDOM: u32 = 1;
@@ -243,7 +241,11 @@ pub const HAVE_READLINK: u32 = 1;
 pub const HAVE_READV: u32 = 1;
 pub const HAVE_RL_COMPLETION_APPEND_CHARACTER: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
+pub const HAVE_RL_COMPLETION_SUPPRESS_QUOTE: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTE_CHARACTERS: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTING_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_SETENV: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
 pub const HAVE_SHM_OPEN: u32 = 1;
@@ -252,11 +254,10 @@ pub const HAVE_SRANDOM: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
+pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -264,35 +265,34 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_UN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNCFS: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EVENT_H: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
+pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
+pub const HAVE_SYS_SIGNALFD_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UIO_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
 pub const HAVE_USELOCALE: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE_WRITEV: u32 = 1;
+pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP16: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP32: u32 = 1;
@@ -305,25 +305,26 @@ pub const HAVE__BUILTIN_OP_OVERFLOW: u32 = 1;
 pub const HAVE__BUILTIN_POPCOUNT: u32 = 1;
 pub const HAVE__BUILTIN_TYPES_COMPATIBLE_P: u32 = 1;
 pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
+pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &[u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 14.5\0";
+pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 14.6\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28usize] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5usize] = b"14.5\0";
+pub const PACKAGE_VERSION: &[u8; 5usize] = b"14.6\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"14\0";
 pub const PG_MAJORVERSION_NUM: u32 = 14;
-pub const PG_MINORVERSION_NUM: u32 = 5;
+pub const PG_MINORVERSION_NUM: u32 = 6;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5usize] = b"14.5\0";
-pub const PG_VERSION_NUM: u32 = 140005;
-pub const PG_VERSION_STR : & [u8 ; 116usize] = b"PostgreSQL 14.5 on aarch64-apple-darwin22.1.0, compiled by Apple clang version 14.0.0 (clang-1400.0.29.202), 64-bit\0" ;
+pub const PG_VERSION: &[u8; 5usize] = b"14.6\0";
+pub const PG_VERSION_NUM: u32 = 140006;
+pub const PG_VERSION_STR: &[u8; 77usize] =
+    b"PostgreSQL 14.6 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -331,12 +332,10 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
-pub const USE_ARMV8_CRC32C: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
+pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -352,566 +351,214 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &[u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &[u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_13_0: u32 = 130000;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 130000;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 36;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
+pub const P_tmpdir: &[u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -922,7 +569,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -946,92 +593,151 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4usize] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4usize] = b"%lu\0";
 pub const HAVE_INT128: u32 = 1;
@@ -1055,376 +761,366 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &[u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &[u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &[u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_PRIMARY_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const SO_RESOLVER_SIGNATURE: u32 = 4401;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _CTYPE_H: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MCTP: u32 = 45;
+pub const PF_MAX: u32 = 46;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MCTP: u32 = 45;
+pub const AF_MAX: u32 = 46;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_NETNS_COOKIE: u32 = 71;
+pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_RECVERR_RFC4884: u32 = 26;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_RECVERR_RFC4884: u32 = 31;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -1436,285 +1132,68 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &[u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_ULA_USETEMPADDR: u32 = 51;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &[u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &[u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &[u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &[u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &[u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &[u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const _PATH_PWD: &[u8; 5usize] = b"/etc\0";
-pub const _PATH_PASSWD: &[u8; 12usize] = b"/etc/passwd\0";
-pub const _PASSWD: &[u8; 7usize] = b"passwd\0";
-pub const _PATH_MASTERPASSWD: &[u8; 19usize] = b"/etc/master.passwd\0";
-pub const _PATH_MASTERPASSWD_LOCK: &[u8; 10usize] = b"/etc/ptmp\0";
-pub const _MASTERPASSWD: &[u8; 14usize] = b"master.passwd\0";
-pub const _PATH_MP_DB: &[u8; 12usize] = b"/etc/pwd.db\0";
-pub const _MP_DB: &[u8; 7usize] = b"pwd.db\0";
-pub const _PATH_SMP_DB: &[u8; 13usize] = b"/etc/spwd.db\0";
-pub const _SMP_DB: &[u8; 8usize] = b"spwd.db\0";
-pub const _PATH_PWD_MKDB: &[u8; 19usize] = b"/usr/sbin/pwd_mkdb\0";
-pub const _PW_KEYBYNAME: u8 = 49u8;
-pub const _PW_KEYBYNUM: u8 = 50u8;
-pub const _PW_KEYBYUID: u8 = 51u8;
-pub const _PASSWORD_EFMT1: u8 = 95u8;
-pub const _PASSWORD_LEN: u32 = 128;
-pub const _PASSWORD_NOUID: u32 = 1;
-pub const _PASSWORD_NOGID: u32 = 2;
-pub const _PASSWORD_NOCHG: u32 = 4;
-pub const _PASSWORD_NOEXP: u32 = 8;
-pub const _PASSWORD_WARNDAYS: u32 = 14;
-pub const _PASSWORD_CHGNOW: i32 = -1;
+pub const _PWD_H: u32 = 1;
+pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 14.5\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 14.6\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1728,13 +1207,9 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 48;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
+pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1812,162 +1287,136 @@ pub const LP_DEAD: u32 = 3;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const O_EXEC: u32 = 1073741824;
-pub const O_SEARCH: u32 = 1074790400;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const AT_SYMLINK_NOFOLLOW_ANY: u32 = 2048;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const O_DP_AUTHENTICATE: u32 = 4;
-pub const AUTH_OPEN_NOAUTHFD: i32 = -1;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const F_SETLEASE: u32 = 106;
-pub const F_GETLEASE: u32 = 107;
-pub const F_TRANSFEREXTENTS: u32 = 110;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_ALLOCATEPERSIST: u32 = 8;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
 pub const PG_O_DIRECT: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstBootstrapObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -2293,7 +1742,24 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ISNULL: u32 = 4;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ARGS: u32 = 6;
 pub const PG_MAGIC_FUNCTION_NAME_STRING: &[u8; 14usize] = b"Pg_magic_func\0";
@@ -2345,121 +1811,84 @@ pub const INDEX_VAR: u32 = 65002;
 pub const ROWID_VAR: u32 = 65003;
 pub const PRS2_OLD_VARNO: u32 = 1;
 pub const PRS2_NEW_VARNO: u32 = 2;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
 pub const DSM_IMPL_WINDOWS: u32 = 3;
@@ -2490,25 +1919,9 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
 pub const PG_TEMP_FILES_DIR: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const SHARED_TUPLESTORE_SINGLE_PASS: u32 = 1;
@@ -2623,7 +2036,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 256;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 512;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 1024;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 2048;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const MaxAllocHugeSize: u32 = 0;
 pub const ALLOCSET_DEFAULT_MINSIZE: u32 = 0;
 pub const ALLOCSET_DEFAULT_INITSIZE: u32 = 8192;
@@ -2640,6 +2052,85 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2662,13 +2153,7 @@ pub const MIN_XFN_CHARS: u32 = 16;
 pub const MAX_XFN_CHARS: u32 = 40;
 pub const VALID_XFN_CHARS: &[u8; 40usize] = b"0123456789ABCDEF.history.backup.partial\0";
 pub const PGSTAT_NUM_PROGRESS_PARAM: u32 = 20;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const MAX_STARTUP_PACKET_LENGTH: u32 = 10000;
 pub const AUTH_REQ_OK: u32 = 0;
 pub const AUTH_REQ_KRB4: u32 = 1;
@@ -2839,7 +2324,6 @@ pub const XACT_COMPLETION_FORCE_SYNC_COMMIT: u32 = 2147483648;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const MAXDIM: u32 = 6;
 pub const EA_MAGIC: u32 = 689375833;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3848,22 +3332,95 @@ pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
@@ -3874,45 +3431,13 @@ impl Default for __mbstate_t {
         }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
 }
-impl Default for __darwin_pthread_handler_rec {
+impl Default for _G_fpos_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3921,13 +3446,14 @@ impl Default for __darwin_pthread_handler_rec {
         }
     }
 }
+pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
 }
-impl Default for _opaque_pthread_attr_t {
+impl Default for _G_fpos64_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3936,241 +3462,59 @@ impl Default for _opaque_pthread_attr_t {
         }
     }
 }
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[track_caller]
-pub unsafe fn renameat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameat(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn renamex_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renamex_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renamex_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn renameatx_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameatx_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameatx_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -4179,327 +3523,24 @@ impl Default for __sFILE {
         }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
-}
-extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stdout: *mut FILE;
+}
+extern "C" {
+    pub static mut stderr: *mut FILE;
 }
 #[track_caller]
-pub unsafe fn clearerr(arg_arg1: *mut FILE) {
+pub unsafe fn remove(arg___filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn clearerr(arg1: *mut FILE);
+            pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        clearerr(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn feof(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        feof(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ferror(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        ferror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fflush(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fflush(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fgetc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetpos(arg_arg1: *mut FILE, arg_arg2: *mut fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-        }
-        fgetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fgets(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut FILE,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgets(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut FILE,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fgets(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fopen(
-    arg___filename: *const ::std::os::raw::c_char,
-    arg___mode: *const ::std::os::raw::c_char,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fopen(
-                __filename: *const ::std::os::raw::c_char,
-                __mode: *const ::std::os::raw::c_char,
-            ) -> *mut FILE;
-        }
-        fopen(arg___filename, arg___mode)
-    })
-}
-#[track_caller]
-pub unsafe fn fprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fputc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputs(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputs(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut FILE,
-            ) -> ::std::os::raw::c_int;
-        }
-        fputs(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fread(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fread(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fread(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn freopen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut FILE,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freopen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut FILE,
-            ) -> *mut FILE;
-        }
-        freopen(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fscanf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fseek(
-    arg_arg1: *mut FILE,
-    arg_arg2: ::std::os::raw::c_long,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fseek(
-                arg1: *mut FILE,
-                arg2: ::std::os::raw::c_long,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        fseek(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fsetpos(arg_arg1: *mut FILE, arg_arg2: *const fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-        }
-        fsetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn ftell(arg_arg1: *mut FILE) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-        }
-        ftell(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fwrite(
-    arg___ptr: *const ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fwrite(
-                __ptr: *const ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fwrite(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn getc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        getc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getchar() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getchar() -> ::std::os::raw::c_int;
-        }
-        getchar()
-    })
-}
-#[track_caller]
-pub unsafe fn perror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn perror(arg1: *const ::std::os::raw::c_char);
-        }
-        perror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn printf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        printf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn putc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        putc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn putchar(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        putchar(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn puts(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        puts(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn remove(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        remove(arg_arg1)
+        remove(arg___filename)
     })
 }
 #[track_caller]
@@ -4518,81 +3559,31 @@ pub unsafe fn rename(
     })
 }
 #[track_caller]
-pub unsafe fn rewind(arg_arg1: *mut FILE) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rewind(arg1: *mut FILE);
-        }
-        rewind(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn scanf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        scanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuf(arg_arg1: *mut FILE, arg_arg2: *mut ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-        }
-        setbuf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setvbuf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
+pub unsafe fn renameat(
+    arg___oldfd: ::std::os::raw::c_int,
+    arg___old: *const ::std::os::raw::c_char,
+    arg___newfd: ::std::os::raw::c_int,
+    arg___new: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setvbuf(
-                arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
+            pub fn renameat(
+                __oldfd: ::std::os::raw::c_int,
+                __old: *const ::std::os::raw::c_char,
+                __newfd: ::std::os::raw::c_int,
+                __new: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        setvbuf(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        renameat(arg___oldfd, arg___old, arg___newfd, arg___new)
     })
 }
 #[track_caller]
-pub unsafe fn sprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        sprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sscanf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sscanf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        sscanf(arg_arg1, arg_arg2)
+        fclose(arg___stream)
     })
 }
 #[track_caller]
@@ -4605,195 +3596,540 @@ pub unsafe fn tmpfile() -> *mut FILE {
     })
 }
 #[track_caller]
-pub unsafe fn ungetc(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ungetc(arg_arg1, arg_arg2)
+        fflush(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vfprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vfprintf(arg_arg1, arg_arg2, arg_arg3)
+        fflush_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vprintf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vprintf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+            ) -> *mut FILE;
         }
-        vprintf(arg_arg1, arg_arg2)
+        fopen(arg___filename, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn vsprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn freopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn freopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> *mut FILE;
         }
-        vsprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ctermid(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        ctermid(arg_arg1)
+        freopen(arg___filename, arg___modes, arg___stream)
     })
 }
 #[track_caller]
 pub unsafe fn fdopen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
+    arg___fd: ::std::os::raw::c_int,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fdopen(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
+                __fd: ::std::os::raw::c_int,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fdopen(arg_arg1, arg_arg2)
+        fdopen(arg___fd, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn fileno(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fileno(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn pclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        pclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn popen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
+pub unsafe fn fmemopen(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___len: usize,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn popen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
+            pub fn fmemopen(
+                __s: *mut ::std::os::raw::c_void,
+                __len: usize,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        popen(arg_arg1, arg_arg2)
+        fmemopen(arg___s, arg___len, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn __srget(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn open_memstream(
+    arg___bufloc: *mut *mut ::std::os::raw::c_char,
+    arg___sizeloc: *mut usize,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn open_memstream(
+                __bufloc: *mut *mut ::std::os::raw::c_char,
+                __sizeloc: *mut usize,
+            ) -> *mut FILE;
         }
-        __srget(arg_arg1)
+        open_memstream(arg___bufloc, arg___sizeloc)
     })
 }
 #[track_caller]
-pub unsafe fn __svfscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
+pub unsafe fn setbuf(arg___stream: *mut FILE, arg___buf: *mut ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+        }
+        setbuf(arg___stream, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setvbuf(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___modes: ::std::os::raw::c_int,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __svfscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
+            pub fn setvbuf(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __modes: ::std::os::raw::c_int,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        __svfscanf(arg_arg1, arg_arg2, arg_arg3)
+        setvbuf(arg___stream, arg___buf, arg___modes, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn __swbuf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+pub unsafe fn setbuffer(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___size: usize,
+) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuffer(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __size: usize,
+            );
+        }
+        setbuffer(arg___stream, arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn setlinebuf(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlinebuf(__stream: *mut FILE);
+        }
+        setlinebuf(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fprintf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fprintf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        __swbuf(arg_arg1, arg_arg2)
+        fprintf(arg___stream, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn flockfile(arg_arg1: *mut FILE) {
+pub unsafe fn printf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flockfile(arg1: *mut FILE);
+            pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
         }
-        flockfile(arg_arg1)
+        printf(arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn ftrylockfile(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn sprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn sprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        ftrylockfile(arg_arg1)
+        sprintf(arg___s, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn funlockfile(arg_arg1: *mut FILE) {
+pub unsafe fn vfprintf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn funlockfile(arg1: *mut FILE);
+            pub fn vfprintf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        funlockfile(arg_arg1)
+        vfprintf(arg___s, arg___format, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn getc_unlocked(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn vprintf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn vprintf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        getc_unlocked(arg_arg1)
+        vprintf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsprintf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn snprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn snprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        snprintf(arg___s, arg___maxlen, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vsnprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsnprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsnprintf(arg___s, arg___maxlen, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vdprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vdprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vdprintf(arg___fd, arg___fmt, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn dprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        dprintf(arg___fd, arg___fmt)
+    })
+}
+#[track_caller]
+pub unsafe fn fscanf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fscanf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf(arg___s, arg___format)
+    })
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[track_caller]
+pub unsafe fn fscanf1(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_fscanf"]
+            pub fn fscanf1(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf1(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf1(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_scanf"]
+            pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf1(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_sscanf"]
+            pub fn sscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf1(arg___s, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vfscanf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vscanf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf1(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vfscanf"]
+            pub fn vfscanf1(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf1(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vscanf"]
+            pub fn vscanf1(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf1(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vsscanf"]
+            pub fn vsscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getchar() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getchar() -> ::std::os::raw::c_int;
+        }
+        getchar()
+    })
+}
+#[track_caller]
+pub unsafe fn getc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc_unlocked(arg___stream)
     })
 }
 #[track_caller]
@@ -4806,1508 +4142,537 @@ pub unsafe fn getchar_unlocked() -> ::std::os::raw::c_int {
     })
 }
 #[track_caller]
+pub unsafe fn fgetc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fputc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putchar(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        putchar(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc_unlocked(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc_unlocked(
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputc_unlocked(arg___c, arg___stream)
+    })
+}
+#[track_caller]
 pub unsafe fn putc_unlocked(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn putc_unlocked(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut FILE,
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
             ) -> ::std::os::raw::c_int;
         }
-        putc_unlocked(arg_arg1, arg_arg2)
+        putc_unlocked(arg___c, arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putchar_unlocked(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn putchar_unlocked(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        putchar_unlocked(arg_arg1)
+        putchar_unlocked(arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn getw(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn getw(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getw(arg_arg1)
+        getw(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putw(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn putw(
+    arg___w: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        putw(arg_arg1, arg_arg2)
+        putw(arg___w, arg___stream)
     })
 }
-pub type off_t = __darwin_off_t;
+#[track_caller]
+pub unsafe fn fgets(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgets(
+                __s: *mut ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fgets(arg___s, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn __getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        __getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getline(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getline(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getline(arg___lineptr, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputs(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputs(
+                __s: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputs(arg___s, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn puts(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        puts(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn ungetc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+                -> ::std::os::raw::c_int;
+        }
+        ungetc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fread(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fread(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___s: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __s: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fwrite(arg___ptr, arg___size, arg___n, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn fread_unlocked(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread_unlocked(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fread_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite_unlocked(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite_unlocked(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fwrite_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fseek(
+    arg___stream: *mut FILE,
+    arg___off: ::std::os::raw::c_long,
+    arg___whence: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fseek(
+                __stream: *mut FILE,
+                __off: ::std::os::raw::c_long,
+                __whence: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        fseek(arg___stream, arg___off, arg___whence)
+    })
+}
+#[track_caller]
+pub unsafe fn ftell(arg___stream: *mut FILE) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+        }
+        ftell(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn rewind(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rewind(__stream: *mut FILE);
+        }
+        rewind(arg___stream)
+    })
+}
 #[track_caller]
 pub unsafe fn fseeko(
     arg___stream: *mut FILE,
-    arg___offset: off_t,
+    arg___off: __off_t,
     arg___whence: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fseeko(
                 __stream: *mut FILE,
-                __offset: off_t,
+                __off: __off_t,
                 __whence: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        fseeko(arg___stream, arg___offset, arg___whence)
+        fseeko(arg___stream, arg___off, arg___whence)
     })
 }
 #[track_caller]
-pub unsafe fn ftello(arg___stream: *mut FILE) -> off_t {
+pub unsafe fn ftello(arg___stream: *mut FILE) -> __off_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftello(__stream: *mut FILE) -> off_t;
+            pub fn ftello(__stream: *mut FILE) -> __off_t;
         }
         ftello(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn snprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fgetpos(arg___stream: *mut FILE, arg___pos: *mut fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn snprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
         }
-        snprintf(arg___str, arg___size, arg___format)
+        fgetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vfscanf(
-    arg___stream: *mut FILE,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fsetpos(arg___stream: *mut FILE, arg___pos: *const fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfscanf(
-                __stream: *mut FILE,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
         }
-        vfscanf(arg___stream, arg___format, arg_arg1)
+        fsetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vscanf(
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vscanf(
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr(__stream: *mut FILE);
         }
-        vscanf(arg___format, arg_arg1)
+        clearerr(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsnprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsnprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsnprintf(arg___str, arg___size, arg___format, arg_arg1)
+        feof(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsscanf(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ferror(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsscanf(
-                __str: *const ::std::os::raw::c_char,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsscanf(arg___str, arg___format, arg_arg1)
+        ferror(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn dprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr_unlocked(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn dprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr_unlocked(__stream: *mut FILE);
         }
-        dprintf(arg_arg1, arg_arg2)
+        clearerr_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vdprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vdprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vdprintf(arg_arg1, arg_arg2, arg_arg3)
+        feof_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getdelim(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___delimiter: ::std::os::raw::c_int,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn ferror_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdelim(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __delimiter: ::std::os::raw::c_int,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getdelim(arg___linep, arg___linecapp, arg___delimiter, arg___stream)
+        ferror_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getline(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn perror(arg___s: *const ::std::os::raw::c_char) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getline(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn perror(__s: *const ::std::os::raw::c_char);
         }
-        getline(arg___linep, arg___linecapp, arg___stream)
+        perror(arg___s)
     })
 }
 #[track_caller]
-pub unsafe fn fmemopen(
-    arg___buf: *mut ::std::os::raw::c_void,
-    arg___size: usize,
-    arg___mode: *const ::std::os::raw::c_char,
+pub unsafe fn fileno(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fileno_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn pclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        pclose(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn popen(
+    arg___command: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmemopen(
-                __buf: *mut ::std::os::raw::c_void,
-                __size: usize,
-                __mode: *const ::std::os::raw::c_char,
+            pub fn popen(
+                __command: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fmemopen(arg___buf, arg___size, arg___mode)
+        popen(arg___command, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn open_memstream(
-    arg___bufp: *mut *mut ::std::os::raw::c_char,
-    arg___sizep: *mut usize,
-) -> *mut FILE {
+pub unsafe fn ctermid(arg___s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn open_memstream(
-                __bufp: *mut *mut ::std::os::raw::c_char,
-                __sizep: *mut usize,
-            ) -> *mut FILE;
+            pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
         }
-        open_memstream(arg___bufp, arg___sizep)
+        ctermid(arg___s)
     })
 }
-extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
-}
 #[track_caller]
-pub unsafe fn asprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn flockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn flockfile(__stream: *mut FILE);
         }
-        asprintf(arg_arg1, arg_arg2)
+        flockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn ctermid_r(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ftrylockfile(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ctermid_r(arg_arg1)
+        ftrylockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fgetln(arg_arg1: *mut FILE, arg_arg2: *mut usize) -> *mut ::std::os::raw::c_char {
+pub unsafe fn funlockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+            pub fn funlockfile(__stream: *mut FILE);
         }
-        fgetln(arg_arg1, arg_arg2)
+        funlockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fmtcheck(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *const ::std::os::raw::c_char {
+pub unsafe fn __uflow(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmtcheck(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *const ::std::os::raw::c_char;
+            pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
         }
-        fmtcheck(arg_arg1, arg_arg2)
+        __uflow(arg_arg1)
     })
 }
 #[track_caller]
-pub unsafe fn fpurge(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fpurge(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuffer(
+pub unsafe fn __overflow(
     arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) {
+    arg_arg2: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setbuffer(
+            pub fn __overflow(
                 arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            );
-        }
-        setbuffer(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setlinebuf(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        setlinebuf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn vasprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn vasprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        vasprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn funopen(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg3: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg4: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    arg_arg5: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn funopen(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *mut ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg3: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg4: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: fpos_t,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> fpos_t,
-                >,
-                arg5: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> *mut FILE;
-        }
-        funopen(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __sprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __sprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __snprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __snprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __snprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsnprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-    arg_arg6: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsnprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                arg6: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsnprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
-}
-impl Default for __darwin_arm_vfp_state {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
-        }
-        signal(arg_arg1, arg_arg2)
-    })
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_reserved: [u64; 14usize],
-}
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[track_caller]
-pub unsafe fn getpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-        }
-        getpriority(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getiopolicy_np(
-                arg1: ::std::os::raw::c_int,
                 arg2: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getiopolicy_np(arg_arg1, arg_arg2)
+        __overflow(arg_arg1, arg_arg2)
     })
 }
-#[track_caller]
-pub unsafe fn getrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getrusage(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rusage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrusage(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rusage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrusage(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpriority(
-                arg1: ::std::os::raw::c_int,
-                arg2: id_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setpriority(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setiopolicy_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setiopolicy_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        setrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn wait(arg_arg1: *mut ::std::os::raw::c_int) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-        }
-        wait(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn waitpid(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitpid(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> pid_t;
-        }
-        waitpid(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn waitid(
-    arg_arg1: idtype_t,
-    arg_arg2: id_t,
-    arg_arg3: *mut siginfo_t,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitid(
-                arg1: idtype_t,
-                arg2: id_t,
-                arg3: *mut siginfo_t,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        waitid(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn wait3(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait3(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut rusage,
-            ) -> pid_t;
-        }
-        wait3(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn wait4(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait4(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut rusage,
-            ) -> pid_t;
-        }
-        wait4(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn alloca(arg_arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-        }
-        alloca(arg_arg1)
-    })
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6326,8 +4691,1000 @@ pub struct lldiv_t {
     pub quot: ::std::os::raw::c_longlong,
     pub rem: ::std::os::raw::c_longlong,
 }
-extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+#[track_caller]
+pub unsafe fn __ctype_get_mb_cur_max() -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ctype_get_mb_cur_max() -> usize;
+        }
+        __ctype_get_mb_cur_max()
+    })
+}
+#[track_caller]
+pub unsafe fn atof(arg___nptr: *const ::std::os::raw::c_char) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+        }
+        atof(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoi(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        atoi(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atol(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        atol(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoll(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+        }
+        atoll(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtod(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtod(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f64;
+        }
+        strtod(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtof(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtof(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f32;
+        }
+        strtof(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtold(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtold(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> u128;
+        }
+        strtold(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtol(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtol(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_long;
+        }
+        strtol(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoul(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoul(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strtoul(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtouq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtouq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtouq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoll(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoll(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoll(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoull(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoull(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtoull(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn l64a(arg___n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+        }
+        l64a(arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn a64l(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        a64l(arg___s)
+    })
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[track_caller]
+pub unsafe fn select(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *mut timeval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn select(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *mut timeval,
+            ) -> ::std::os::raw::c_int;
+        }
+        select(arg___nfds, arg___readfds, arg___writefds, arg___exceptfds, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn pselect(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *const timespec,
+    arg___sigmask: *const __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pselect(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *const timespec,
+                __sigmask: *const __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pselect(
+            arg___nfds,
+            arg___readfds,
+            arg___writefds,
+            arg___exceptfds,
+            arg___timeout,
+            arg___sigmask,
+        )
+    })
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __atomic_wide_counter {
+    pub __value64: ::std::os::raw::c_ulonglong,
+    pub __value32: __atomic_wide_counter__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __atomic_wide_counter__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __atomic_wide_counter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __wseq: __atomic_wide_counter,
+    pub __g1_start: __atomic_wide_counter,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random() -> ::std::os::raw::c_long;
+        }
+        random()
+    })
+}
+#[track_caller]
+pub unsafe fn srandom(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom(__seed: ::std::os::raw::c_uint);
+        }
+        srandom(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        initstate(arg___seed, arg___statebuf, arg___statelen)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate(arg___statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate(__statebuf: *mut ::std::os::raw::c_char)
+                -> *mut ::std::os::raw::c_char;
+        }
+        setstate(arg___statebuf)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random_r(
+    arg___buf: *mut random_data,
+    arg___result: *mut i32,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+        }
+        random_r(arg___buf, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srandom_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom_r(
+                __seed: ::std::os::raw::c_uint,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srandom_r(arg___seed, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate_r(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        initstate_r(arg___seed, arg___statebuf, arg___statelen, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate_r(
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate_r(
+                __statebuf: *mut ::std::os::raw::c_char,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        setstate_r(arg___statebuf, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn rand() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand() -> ::std::os::raw::c_int;
+        }
+        rand()
+    })
+}
+#[track_caller]
+pub unsafe fn srand(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand(__seed: ::std::os::raw::c_uint);
+        }
+        srand(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn rand_r(arg___seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+        }
+        rand_r(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn drand48() -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48() -> f64;
+        }
+        drand48()
+    })
+}
+#[track_caller]
+pub unsafe fn erand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+        }
+        erand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48() -> ::std::os::raw::c_long;
+        }
+        lrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        nrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48() -> ::std::os::raw::c_long;
+        }
+        mrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        jrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48(arg___seedval: ::std::os::raw::c_long) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48(__seedval: ::std::os::raw::c_long);
+        }
+        srand48(arg___seedval)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+) -> *mut ::std::os::raw::c_ushort {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+            ) -> *mut ::std::os::raw::c_ushort;
+        }
+        seed48(arg___seed16v)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48(arg___param: *mut ::std::os::raw::c_ushort) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+        }
+        lcong48(arg___param)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[track_caller]
+pub unsafe fn drand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        drand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn erand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        erand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        lrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        nrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        mrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        jrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48_r(
+    arg___seedval: ::std::os::raw::c_long,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48_r(
+                __seedval: ::std::os::raw::c_long,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srand48_r(arg___seedval, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48_r(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48_r(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        seed48_r(arg___seed16v, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48_r(
+    arg___param: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48_r(
+                __param: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        lcong48_r(arg___param, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random() -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random() -> __uint32_t;
+        }
+        arc4random()
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___size: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+        }
+        arc4random_buf(arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_uniform(arg___upper_bound: __uint32_t) -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+        }
+        arc4random_uniform(arg___upper_bound)
+    })
 }
 #[track_caller]
 pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
@@ -6340,26 +5697,17 @@ pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw
 }
 #[track_caller]
 pub unsafe fn calloc(
-    arg___count: ::std::os::raw::c_ulong,
+    arg___nmemb: ::std::os::raw::c_ulong,
     arg___size: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn calloc(
-                __count: ::std::os::raw::c_ulong,
+                __nmemb: ::std::os::raw::c_ulong,
                 __size: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        calloc(arg___count, arg___size)
-    })
-}
-#[track_caller]
-pub unsafe fn free(arg_arg1: *mut ::std::os::raw::c_void) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn free(arg1: *mut ::std::os::raw::c_void);
-        }
-        free(arg_arg1)
+        calloc(arg___nmemb, arg___size)
     })
 }
 #[track_caller]
@@ -6378,27 +5726,47 @@ pub unsafe fn realloc(
     })
 }
 #[track_caller]
-pub unsafe fn valloc(arg_arg1: usize) -> *mut ::std::os::raw::c_void {
+pub unsafe fn free(arg___ptr: *mut ::std::os::raw::c_void) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+            pub fn free(__ptr: *mut ::std::os::raw::c_void);
         }
-        valloc(arg_arg1)
+        free(arg___ptr)
     })
 }
 #[track_caller]
-pub unsafe fn aligned_alloc(
-    arg___alignment: ::std::os::raw::c_ulong,
-    arg___size: ::std::os::raw::c_ulong,
+pub unsafe fn reallocarray(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn aligned_alloc(
-                __alignment: ::std::os::raw::c_ulong,
-                __size: ::std::os::raw::c_ulong,
+            pub fn reallocarray(
+                __ptr: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
             ) -> *mut ::std::os::raw::c_void;
         }
-        aligned_alloc(arg___alignment, arg___size)
+        reallocarray(arg___ptr, arg___nmemb, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn alloca(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+        }
+        alloca(arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn valloc(arg___size: usize) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+        }
+        valloc(arg___size)
     })
 }
 #[track_caller]
@@ -6419,6 +5787,21 @@ pub unsafe fn posix_memalign(
     })
 }
 #[track_caller]
+pub unsafe fn aligned_alloc(
+    arg___alignment: ::std::os::raw::c_ulong,
+    arg___size: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn aligned_alloc(
+                __alignment: ::std::os::raw::c_ulong,
+                __size: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        aligned_alloc(arg___alignment, arg___size)
+    })
+}
+#[track_caller]
 pub unsafe fn abort() {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -6428,161 +5811,500 @@ pub unsafe fn abort() {
     })
 }
 #[track_caller]
-pub unsafe fn abs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        abs(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn atexit(
-    arg_arg1: ::std::option::Option<unsafe extern "C" fn()>,
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn atexit(
-                arg1: ::std::option::Option<unsafe extern "C" fn()>,
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
             ) -> ::std::os::raw::c_int;
         }
-        atexit(arg_arg1)
+        atexit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atof(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
+pub unsafe fn at_quick_exit(
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+            pub fn at_quick_exit(
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
+            ) -> ::std::os::raw::c_int;
         }
-        atof(arg_arg1)
+        at_quick_exit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atoi(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+pub unsafe fn on_exit(
+    arg___func: ::std::option::Option<
+        unsafe extern "C" fn(__status: ::std::os::raw::c_int, __arg: *mut ::std::os::raw::c_void),
+    >,
+    arg___arg: *mut ::std::os::raw::c_void,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+            pub fn on_exit(
+                __func: ::std::option::Option<
+                    unsafe extern "C" fn(
+                        __status: ::std::os::raw::c_int,
+                        __arg: *mut ::std::os::raw::c_void,
+                    ),
+                >,
+                __arg: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int;
         }
-        atoi(arg_arg1)
+        on_exit(arg___func, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn atol(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn exit(__status: ::std::os::raw::c_int);
         }
-        atol(arg_arg1)
+        exit(arg___status)
     })
 }
 #[track_caller]
-pub unsafe fn atoll(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+pub unsafe fn quick_exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+            pub fn quick_exit(__status: ::std::os::raw::c_int);
         }
-        atoll(arg_arg1)
+        quick_exit(arg___status)
     })
 }
+#[track_caller]
+pub unsafe fn _Exit(arg___status: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _Exit(__status: ::std::os::raw::c_int);
+        }
+        _Exit(arg___status)
+    })
+}
+#[track_caller]
+pub unsafe fn getenv(arg___name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        getenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn putenv(arg___string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        putenv(arg___string)
+    })
+}
+#[track_caller]
+pub unsafe fn setenv(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___value: *const ::std::os::raw::c_char,
+    arg___replace: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setenv(
+                __name: *const ::std::os::raw::c_char,
+                __value: *const ::std::os::raw::c_char,
+                __replace: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        setenv(arg___name, arg___value, arg___replace)
+    })
+}
+#[track_caller]
+pub unsafe fn unsetenv(arg___name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        unsetenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn clearenv() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clearenv() -> ::std::os::raw::c_int;
+        }
+        clearenv()
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemp(arg___template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        mkstemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemps(
+    arg___template: *mut ::std::os::raw::c_char,
+    arg___suffixlen: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemps(
+                __template: *mut ::std::os::raw::c_char,
+                __suffixlen: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        mkstemps(arg___template, arg___suffixlen)
+    })
+}
+#[track_caller]
+pub unsafe fn mkdtemp(arg___template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        mkdtemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn system(arg___command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        system(arg___command)
+    })
+}
+#[track_caller]
+pub unsafe fn realpath(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resolved: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn realpath(
+                __name: *const ::std::os::raw::c_char,
+                __resolved: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        realpath(arg___name, arg___resolved)
+    })
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[track_caller]
 pub unsafe fn bsearch(
     arg___key: *const ::std::os::raw::c_void,
     arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bsearch(
                 __key: *const ::std::os::raw::c_void,
                 __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
             ) -> *mut ::std::os::raw::c_void;
         }
-        bsearch(arg___key, arg___base, arg___nel, arg___width, arg___compar)
+        bsearch(arg___key, arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn div(arg_arg1: ::std::os::raw::c_int, arg_arg2: ::std::os::raw::c_int) -> div_t {
+pub unsafe fn qsort(
+    arg___base: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+            pub fn qsort(
+                __base: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
+            );
         }
-        div(arg_arg1, arg_arg2)
+        qsort(arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn abs(arg___x: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exit(arg1: ::std::os::raw::c_int);
+            pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        exit(arg_arg1)
+        abs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn getenv(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn labs(arg___x: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
         }
-        getenv(arg_arg1)
+        labs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn labs(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
+pub unsafe fn llabs(arg___x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+            pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
         }
-        labs(arg_arg1)
+        llabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ldiv(arg_arg1: ::std::os::raw::c_long, arg_arg2: ::std::os::raw::c_long) -> ldiv_t {
+pub unsafe fn div(arg___numer: ::std::os::raw::c_int, arg___denom: ::std::os::raw::c_int) -> div_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+            pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
         }
-        ldiv(arg_arg1, arg_arg2)
+        div(arg___numer, arg___denom)
     })
 }
 #[track_caller]
-pub unsafe fn llabs(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
+pub unsafe fn ldiv(
+    arg___numer: ::std::os::raw::c_long,
+    arg___denom: ::std::os::raw::c_long,
+) -> ldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+            pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long)
+                -> ldiv_t;
         }
-        llabs(arg_arg1)
+        ldiv(arg___numer, arg___denom)
     })
 }
 #[track_caller]
 pub unsafe fn lldiv(
-    arg_arg1: ::std::os::raw::c_longlong,
-    arg_arg2: ::std::os::raw::c_longlong,
+    arg___numer: ::std::os::raw::c_longlong,
+    arg___denom: ::std::os::raw::c_longlong,
 ) -> lldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn lldiv(
-                arg1: ::std::os::raw::c_longlong,
-                arg2: ::std::os::raw::c_longlong,
+                __numer: ::std::os::raw::c_longlong,
+                __denom: ::std::os::raw::c_longlong,
             ) -> lldiv_t;
         }
-        lldiv(arg_arg1, arg_arg2)
+        lldiv(arg___numer, arg___denom)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        ecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn gcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        gcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qfcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qgcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qgcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qgcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        ecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        fcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qfcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
     })
 }
 #[track_caller]
@@ -6598,1295 +6320,180 @@ pub unsafe fn mblen(
     })
 }
 #[track_caller]
-pub unsafe fn mbstowcs(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mbstowcs(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> usize;
-        }
-        mbstowcs(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
 pub unsafe fn mbtowc(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
+    arg___pwc: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn mbtowc(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
+                __pwc: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        mbtowc(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn rand() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand() -> ::std::os::raw::c_int;
-        }
-        rand()
-    })
-}
-#[track_caller]
-pub unsafe fn srand(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand(arg1: ::std::os::raw::c_uint);
-        }
-        srand(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn strtod(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtod(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtof(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtof(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f32;
-        }
-        strtof(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtol(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtol(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_long;
-        }
-        strtol(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtold(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtold(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtold(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoll(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoll(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoll(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoul(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoul(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strtoul(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoull(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoull(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtoull(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn system(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        system(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn wcstombs(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const wchar_t,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wcstombs(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const wchar_t,
-                arg3: usize,
-            ) -> usize;
-        }
-        wcstombs(arg_arg1, arg_arg2, arg_arg3)
+        mbtowc(arg___pwc, arg___s, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn wctomb(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: wchar_t,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___wchar: wchar_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn wctomb(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: wchar_t,
+                __s: *mut ::std::os::raw::c_char,
+                __wchar: wchar_t,
             ) -> ::std::os::raw::c_int;
         }
-        wctomb(arg_arg1, arg_arg2)
+        wctomb(arg___s, arg___wchar)
     })
 }
 #[track_caller]
-pub unsafe fn _Exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn mbstowcs(
+    arg___pwcs: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn _Exit(arg1: ::std::os::raw::c_int);
+            pub fn mbstowcs(
+                __pwcs: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> usize;
         }
-        _Exit(arg_arg1)
+        mbstowcs(arg___pwcs, arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn a64l(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn wcstombs(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___pwcs: *const wchar_t,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn wcstombs(
+                __s: *mut ::std::os::raw::c_char,
+                __pwcs: *const wchar_t,
+                __n: usize,
+            ) -> usize;
         }
-        a64l(arg_arg1)
+        wcstombs(arg___s, arg___pwcs, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn drand48() -> f64 {
+pub unsafe fn rpmatch(arg___response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn drand48() -> f64;
+            pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        drand48()
-    })
-}
-#[track_caller]
-pub unsafe fn ecvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ecvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        ecvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn erand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-        }
-        erand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fcvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        gcvt(arg_arg1, arg_arg2, arg_arg3)
+        rpmatch(arg___response)
     })
 }
 #[track_caller]
 pub unsafe fn getsubopt(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+    arg___optionp: *mut *mut ::std::os::raw::c_char,
+    arg___tokens: *const *mut ::std::os::raw::c_char,
+    arg___valuep: *mut *mut ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn getsubopt(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+                __optionp: *mut *mut ::std::os::raw::c_char,
+                __tokens: *const *mut ::std::os::raw::c_char,
+                __valuep: *mut *mut ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        getsubopt(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn grantpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        grantpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn initstate(
-    arg_arg1: ::std::os::raw::c_uint,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn initstate(
-                arg1: ::std::os::raw::c_uint,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        initstate(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn jrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        jrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn l64a(arg_arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-        }
-        l64a(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lcong48(arg_arg1: *mut ::std::os::raw::c_ushort) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-        }
-        lcong48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrand48() -> ::std::os::raw::c_long;
-        }
-        lrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn mkstemp(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        mkstemp(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mrand48() -> ::std::os::raw::c_long;
-        }
-        mrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn nrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        nrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn posix_openpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        posix_openpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname(arg_arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        ptsname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname_r(
-    arg_fildes: ::std::os::raw::c_int,
-    arg_buffer: *mut ::std::os::raw::c_char,
-    arg_buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname_r(
-                fildes: ::std::os::raw::c_int,
-                buffer: *mut ::std::os::raw::c_char,
-                buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        ptsname_r(arg_fildes, arg_buffer, arg_buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn putenv(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        putenv(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn random() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn random() -> ::std::os::raw::c_long;
-        }
-        random()
-    })
-}
-#[track_caller]
-pub unsafe fn rand_r(arg_arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-        }
-        rand_r(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn realpath(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-            pub fn realpath(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        realpath(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn seed48(arg_arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-        }
-        seed48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setenv(
-    arg___name: *const ::std::os::raw::c_char,
-    arg___value: *const ::std::os::raw::c_char,
-    arg___overwrite: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setenv(
-                __name: *const ::std::os::raw::c_char,
-                __value: *const ::std::os::raw::c_char,
-                __overwrite: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setenv(arg___name, arg___value, arg___overwrite)
-    })
-}
-#[track_caller]
-pub unsafe fn setkey(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setkey(arg1: *const ::std::os::raw::c_char);
-        }
-        setkey(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setstate(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        setstate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srand48(arg_arg1: ::std::os::raw::c_long) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand48(arg1: ::std::os::raw::c_long);
-        }
-        srand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srandom(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandom(arg1: ::std::os::raw::c_uint);
-        }
-        srandom(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unlockpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        unlockpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unsetenv(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        unsetenv(arg_arg1)
-    })
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[track_caller]
-pub unsafe fn arc4random() -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random() -> u32;
-        }
-        arc4random()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_addrandom(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: ::std::os::raw::c_int,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_addrandom(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: ::std::os::raw::c_int,
-            );
-        }
-        arc4random_addrandom(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___nbytes: usize) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-        }
-        arc4random_buf(arg___buf, arg___nbytes)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_stir() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_stir();
-        }
-        arc4random_stir()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_uniform(arg___upper_bound: u32) -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-        }
-        arc4random_uniform(arg___upper_bound)
-    })
-}
-#[track_caller]
-pub unsafe fn atexit_b(arg_arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-        }
-        atexit_b(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn bsearch_b(
-    arg___key: *const ::std::os::raw::c_void,
-    arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bsearch_b(
-                __key: *const ::std::os::raw::c_void,
-                __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        bsearch_b(arg___key, arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetcap(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetcap(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        cgetcap(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetclose() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetclose() -> ::std::os::raw::c_int;
-        }
-        cgetclose()
-    })
-}
-#[track_caller]
-pub unsafe fn cgetent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetent(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetfirst(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetfirst(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetfirst(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetmatch(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetmatch(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetmatch(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnext(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnext(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnext(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnum(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnum(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnum(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetset(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        cgetset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetstr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetstr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetstr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetustr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetustr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetustr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn daemon(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn daemon(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        daemon(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname(arg_arg1: dev_t, arg_arg2: mode_t) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-        }
-        devname(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname_r(
-    arg_arg1: dev_t,
-    arg_arg2: mode_t,
-    arg_buf: *mut ::std::os::raw::c_char,
-    arg_len: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname_r(
-                arg1: dev_t,
-                arg2: mode_t,
-                buf: *mut ::std::os::raw::c_char,
-                len: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        devname_r(arg_arg1, arg_arg2, arg_buf, arg_len)
-    })
-}
-#[track_caller]
-pub unsafe fn getbsize(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_long,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getbsize(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_long,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        getbsize(arg_arg1, arg_arg2)
+        getsubopt(arg___optionp, arg___tokens, arg___valuep)
     })
 }
 #[track_caller]
 pub unsafe fn getloadavg(
-    arg_arg1: *mut f64,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___loadavg: *mut f64,
+    arg___nelem: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int)
-                -> ::std::os::raw::c_int;
-        }
-        getloadavg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getprogname() -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprogname() -> *const ::std::os::raw::c_char;
-        }
-        getprogname()
-    })
-}
-#[track_caller]
-pub unsafe fn setprogname(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-        }
-        setprogname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn heapsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+            pub fn getloadavg(
+                __loadavg: *mut f64,
+                __nelem: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        heapsort(arg___base, arg___nel, arg___width, arg___compar)
+        getloadavg(arg___loadavg, arg___nelem)
     })
 }
 #[track_caller]
-pub unsafe fn heapsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        heapsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        psort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        qsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn radixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn radixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        radixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn rpmatch(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        rpmatch(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sradixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sradixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        sradixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn sranddev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sranddev();
-        }
-        sranddev()
-    })
-}
-#[track_caller]
-pub unsafe fn srandomdev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandomdev();
-        }
-        srandomdev()
-    })
-}
-#[track_caller]
-pub unsafe fn reallocf(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: usize,
+pub unsafe fn memcpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn reallocf(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: usize,
+            pub fn memcpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        reallocf(arg___ptr, arg___size)
+        memcpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtonum(
-    arg___numstr: *const ::std::os::raw::c_char,
-    arg___minval: ::std::os::raw::c_longlong,
-    arg___maxval: ::std::os::raw::c_longlong,
-    arg___errstrp: *mut *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_longlong {
+pub unsafe fn memmove(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strtonum(
-                __numstr: *const ::std::os::raw::c_char,
-                __minval: ::std::os::raw::c_longlong,
-                __maxval: ::std::os::raw::c_longlong,
-                __errstrp: *mut *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_longlong;
+            pub fn memmove(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
         }
-        strtonum(arg___numstr, arg___minval, arg___maxval, arg___errstrp)
+        memmove(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtoq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoq(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtouq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtouq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtouq(arg___str, arg___endptr, arg___base)
-    })
-}
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[track_caller]
-pub unsafe fn memchr(
-    arg___s: *const ::std::os::raw::c_void,
+pub unsafe fn memccpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
     arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memchr(
-                __s: *const ::std::os::raw::c_void,
+            pub fn memccpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
                 __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memchr(arg___s, arg___c, arg___n)
+        memccpy(arg___dest, arg___src, arg___c, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memset(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn memset(
+                __s: *mut ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        memset(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
@@ -7907,84 +6514,101 @@ pub unsafe fn memcmp(
     })
 }
 #[track_caller]
-pub unsafe fn memcpy(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
+pub unsafe fn __memcmpeq(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __memcmpeq(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        __memcmpeq(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memchr(
+    arg___s: *const ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memcpy(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
+            pub fn memchr(
+                __s: *const ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memcpy(arg___dst, arg___src, arg___n)
+        memchr(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn memmove(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memmove(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memmove(arg___dst, arg___src, arg___len)
+        strcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn memset(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset(
-                __b: *mut ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset(arg___b, arg___c, arg___len)
+        strncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn strcat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strcat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcat(arg___s1, arg___s2)
+        strcat(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn strchr(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___c: ::std::os::raw::c_int,
+pub unsafe fn strncat(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strchr(
-                __s: *const ::std::os::raw::c_char,
-                __c: ::std::os::raw::c_int,
+            pub fn strncat(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strchr(arg___s, arg___c)
+        strncat(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
@@ -8000,86 +6624,6 @@ pub unsafe fn strcmp(
             ) -> ::std::os::raw::c_int;
         }
         strcmp(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcoll(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcoll(
-                __s1: *const ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        strcoll(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strcpy(arg___dst, arg___src)
-    })
-}
-#[track_caller]
-pub unsafe fn strcspn(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcspn(
-                __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strcspn(arg___s, arg___charset)
-    })
-}
-#[track_caller]
-pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strerror(arg___errnum)
-    })
-}
-#[track_caller]
-pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-        }
-        strlen(arg___s)
-    })
-}
-#[track_caller]
-pub unsafe fn strncat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strncat(arg___s1, arg___s2, arg___n)
     })
 }
 #[track_caller]
@@ -8100,35 +6644,130 @@ pub unsafe fn strncmp(
     })
 }
 #[track_caller]
-pub unsafe fn strncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
+pub unsafe fn strcoll(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm(
+    arg___dest: *mut ::std::os::raw::c_char,
     arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strxfrm(arg___dest, arg___src, arg___n)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[track_caller]
+pub unsafe fn strcoll_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __l: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll_l(arg___s1, arg___s2, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm_l(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___l: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm_l(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+                __l: locale_t,
+            ) -> usize;
+        }
+        strxfrm_l(arg___dest, arg___src, arg___n, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strdup(arg___s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        strdup(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strndup(
+    arg___string: *const ::std::os::raw::c_char,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
+            pub fn strndup(
+                __string: *const ::std::os::raw::c_char,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strncpy(arg___dst, arg___src, arg___n)
+        strndup(arg___string, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strpbrk(
+pub unsafe fn strchr(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strpbrk(
+            pub fn strchr(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strpbrk(arg___s, arg___charset)
+        strchr(arg___s, arg___c)
     })
 }
 #[track_caller]
@@ -8147,358 +6786,349 @@ pub unsafe fn strrchr(
     })
 }
 #[track_caller]
+pub unsafe fn strcspn(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___reject: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcspn(
+                __s: *const ::std::os::raw::c_char,
+                __reject: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strcspn(arg___s, arg___reject)
+    })
+}
+#[track_caller]
 pub unsafe fn strspn(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strspn(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_ulong;
         }
-        strspn(arg___s, arg___charset)
+        strspn(arg___s, arg___accept)
+    })
+}
+#[track_caller]
+pub unsafe fn strpbrk(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strpbrk(
+                __s: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        strpbrk(arg___s, arg___accept)
     })
 }
 #[track_caller]
 pub unsafe fn strstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+    arg___haystack: *const ::std::os::raw::c_char,
+    arg___needle: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+                __haystack: *const ::std::os::raw::c_char,
+                __needle: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strstr(arg___big, arg___little)
+        strstr(arg___haystack, arg___needle)
     })
 }
 #[track_caller]
 pub unsafe fn strtok(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok(arg___str, arg___sep)
+        strtok(arg___s, arg___delim)
     })
 }
 #[track_caller]
-pub unsafe fn strxfrm(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn __strtok_r(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strxfrm(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn __strtok_r(
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strxfrm(arg___s1, arg___s2, arg___n)
+        __strtok_r(arg___s, arg___delim, arg___save_ptr)
     })
 }
 #[track_caller]
 pub unsafe fn strtok_r(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
-    arg___lasts: *mut *mut ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok_r(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
-                __lasts: *mut *mut ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok_r(arg___str, arg___sep, arg___lasts)
+        strtok_r(arg___s, arg___delim, arg___save_ptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+        }
+        strlen(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strnlen(arg___string: *const ::std::os::raw::c_char, arg___maxlen: usize) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+        }
+        strnlen(arg___string, arg___maxlen)
+    })
+}
+#[track_caller]
+pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+        }
+        strerror(arg___errnum)
     })
 }
 #[track_caller]
 pub unsafe fn strerror_r(
     arg___errnum: ::std::os::raw::c_int,
-    arg___strerrbuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut ::std::os::raw::c_char,
     arg___buflen: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
+            #[link_name = "\u{1}__xpg_strerror_r"]
             pub fn strerror_r(
                 __errnum: ::std::os::raw::c_int,
-                __strerrbuf: *mut ::std::os::raw::c_char,
+                __buf: *mut ::std::os::raw::c_char,
                 __buflen: usize,
             ) -> ::std::os::raw::c_int;
         }
-        strerror_r(arg___errnum, arg___strerrbuf, arg___buflen)
+        strerror_r(arg___errnum, arg___buf, arg___buflen)
     })
 }
 #[track_caller]
-pub unsafe fn strdup(arg___s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn strerror_l(
+    arg___errnum: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn strerror_l(
+                __errnum: ::std::os::raw::c_int,
+                __l: locale_t,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strdup(arg___s1)
+        strerror_l(arg___errnum, arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn memccpy(
-    arg___dst: *mut ::std::os::raw::c_void,
+pub unsafe fn bcmp(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn bcmp(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        bcmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn bcopy(
     arg___src: *const ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memccpy(
-                __dst: *mut ::std::os::raw::c_void,
+            pub fn bcopy(
                 __src: *const ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+                __dest: *mut ::std::os::raw::c_void,
+                __n: usize,
+            );
         }
-        memccpy(arg___dst, arg___src, arg___c, arg___n)
+        bcopy(arg___src, arg___dest, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: ::std::os::raw::c_ulong) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn stpcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
         }
-        stpcpy(arg___dst, arg___src)
+        bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn stpncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        stpncpy(arg___dst, arg___src, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strndup(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strndup(
-                __s1: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strndup(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strnlen(arg___s1: *const ::std::os::raw::c_char, arg___n: usize) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
-        }
-        strnlen(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strsignal(arg___sig)
-    })
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[track_caller]
-pub unsafe fn memset_s(
-    arg___s: *mut ::std::os::raw::c_void,
-    arg___smax: rsize_t,
+pub unsafe fn index(
+    arg___s: *const ::std::os::raw::c_char,
     arg___c: ::std::os::raw::c_int,
-    arg___n: rsize_t,
-) -> errno_t {
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset_s(
-                __s: *mut ::std::os::raw::c_void,
-                __smax: rsize_t,
+            pub fn index(
+                __s: *const ::std::os::raw::c_char,
                 __c: ::std::os::raw::c_int,
-                __n: rsize_t,
-            ) -> errno_t;
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset_s(arg___s, arg___smax, arg___c, arg___n)
+        index(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn memmem(
-    arg___big: *const ::std::os::raw::c_void,
-    arg___big_len: usize,
-    arg___little: *const ::std::os::raw::c_void,
-    arg___little_len: usize,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memmem(
-                __big: *const ::std::os::raw::c_void,
-                __big_len: usize,
-                __little: *const ::std::os::raw::c_void,
-                __little_len: usize,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        memmem(arg___big, arg___big_len, arg___little, arg___little_len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern4(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern4: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern4(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern4: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern4(arg___b, arg___pattern4, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern8(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern8: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern8(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern8: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern8(arg___b, arg___pattern8, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern16(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern16: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern16(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern16: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern16(arg___b, arg___pattern16, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strcasestr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+pub unsafe fn rindex(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasestr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+            pub fn rindex(
+                __s: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcasestr(arg___big, arg___little)
+        rindex(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn strnstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
-    arg___len: usize,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ffs(arg___i: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strnstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
-                __len: usize,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        strnstr(arg___big, arg___little, arg___len)
+        ffs(arg___i)
     })
 }
 #[track_caller]
-pub unsafe fn strlcat(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsl(arg___l: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcat(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
         }
-        strlcat(arg___dst, arg___source, arg___size)
+        ffsl(arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn strlcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsll(arg___ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
         }
-        strlcpy(arg___dst, arg___source, arg___size)
+        ffsll(arg___ll)
     })
 }
 #[track_caller]
-pub unsafe fn strmode(arg___mode: ::std::os::raw::c_int, arg___bp: *mut ::std::os::raw::c_char) {
+pub unsafe fn strcasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+            pub fn strcasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        strmode(arg___mode, arg___bp)
+        strcasecmp(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn strcasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcasecmp_l(arg___s1, arg___s2, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: usize,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp_l(arg___s1, arg___s2, arg___n, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn explicit_bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+        }
+        explicit_bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
@@ -8517,285 +7147,111 @@ pub unsafe fn strsep(
     })
 }
 #[track_caller]
-pub unsafe fn swab(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: isize,
-) {
+pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn swab(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: isize,
-            );
+            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
         }
-        swab(arg_arg1, arg_arg2, arg_arg3)
+        strsignal(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn timingsafe_bcmp(
-    arg___b1: *const ::std::os::raw::c_void,
-    arg___b2: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timingsafe_bcmp(
-                __b1: *const ::std::os::raw::c_void,
-                __b2: *const ::std::os::raw::c_void,
-                __len: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        timingsafe_bcmp(arg___b1, arg___b2, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal_r(
-    arg___sig: ::std::os::raw::c_int,
-    arg___strsignalbuf: *mut ::std::os::raw::c_char,
-    arg___buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal_r(
-                __sig: ::std::os::raw::c_int,
-                __strsignalbuf: *mut ::std::os::raw::c_char,
-                __buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        strsignal_r(arg___sig, arg___strsignalbuf, arg___buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn bcmp(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcmp(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        bcmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bcopy(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcopy(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-            );
-        }
-        bcopy(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bzero(arg_arg1: *mut ::std::os::raw::c_void, arg_arg2: ::std::os::raw::c_ulong) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-        }
-        bzero(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn index(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn __stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn index(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn __stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        index(arg_arg1, arg_arg2)
+        __stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn rindex(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rindex(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        rindex(arg_arg1, arg_arg2)
+        stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn ffs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        ffs(arg_arg1)
+        __stpncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strcasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
+            pub fn stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strcasecmp(arg_arg1, arg_arg2)
+        stpncpy(arg___dest, arg___src, arg___n)
     })
 }
-#[track_caller]
-pub unsafe fn strncasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        strncasecmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        ffsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        ffsll(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fls(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        fls(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        flsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        flsll(arg_arg1)
-    })
-}
-pub type max_align_t = f64;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[track_caller]
-pub unsafe fn __darwin_check_fd_set_overflow(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn __errno_location() -> *mut ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __darwin_check_fd_set_overflow(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn __errno_location() -> *mut ::std::os::raw::c_int;
         }
-        __darwin_check_fd_set_overflow(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[track_caller]
-pub unsafe fn __error() -> *mut ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __error() -> *mut ::std::os::raw::c_int;
-        }
-        __error()
+        __errno_location()
     })
 }
 #[repr(C)]
@@ -8820,8 +7276,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -8836,6 +7292,21 @@ impl Default for lconv {
     }
 }
 #[track_caller]
+pub unsafe fn setlocale(
+    arg___category: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlocale(
+                __category: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        setlocale(arg___category, arg___locale)
+    })
+}
+#[track_caller]
 pub unsafe fn localeconv() -> *mut lconv {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -8845,18 +7316,47 @@ pub unsafe fn localeconv() -> *mut lconv {
     })
 }
 #[track_caller]
-pub unsafe fn setlocale(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn newlocale(
+    arg___category_mask: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+    arg___base: locale_t,
+) -> locale_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setlocale(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn newlocale(
+                __category_mask: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+                __base: locale_t,
+            ) -> locale_t;
         }
-        setlocale(arg_arg1, arg_arg2)
+        newlocale(arg___category_mask, arg___locale, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn duplocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn duplocale(__dataset: locale_t) -> locale_t;
+        }
+        duplocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn freelocale(arg___dataset: locale_t) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freelocale(__dataset: locale_t);
+        }
+        freelocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn uselocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn uselocale(__dataset: locale_t) -> locale_t;
+        }
+        uselocale(arg___dataset)
     })
 }
 pub type pg_funcptr_t = ::std::option::Option<unsafe extern "C" fn()>;
@@ -8986,163 +7486,401 @@ impl Default for PGAlignedXLogBlock {
         }
     }
 }
+pub const _ISupper: _bindgen_ty_1 = 256;
+pub const _ISlower: _bindgen_ty_1 = 512;
+pub const _ISalpha: _bindgen_ty_1 = 1024;
+pub const _ISdigit: _bindgen_ty_1 = 2048;
+pub const _ISxdigit: _bindgen_ty_1 = 4096;
+pub const _ISspace: _bindgen_ty_1 = 8192;
+pub const _ISprint: _bindgen_ty_1 = 16384;
+pub const _ISgraph: _bindgen_ty_1 = 32768;
+pub const _ISblank: _bindgen_ty_1 = 1;
+pub const _IScntrl: _bindgen_ty_1 = 2;
+pub const _ISpunct: _bindgen_ty_1 = 4;
+pub const _ISalnum: _bindgen_ty_1 = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn fdatasync(arg_fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
         }
-        fdatasync(arg_fildes)
-    })
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
-}
-extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
-}
-#[track_caller]
-pub unsafe fn ___runetype(arg_arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
-        }
-        ___runetype(arg_arg1)
+        __ctype_b_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_tolower_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
         }
-        ___tolower(arg_arg1)
+        __ctype_tolower_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_toupper_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
         }
-        ___toupper(arg_arg1)
+        __ctype_toupper_loc()
     })
 }
 #[track_caller]
-pub unsafe fn __maskrune(
-    arg_arg1: __darwin_ct_rune_t,
-    arg_arg2: ::std::os::raw::c_ulong,
+pub unsafe fn isalnum(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalnum(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalpha(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalpha(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn iscntrl(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        iscntrl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn islower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        islower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isgraph(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isprint(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        ispunct(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isspace(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isxdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        tolower(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toupper(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isblank(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn _toupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _toupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn _tolower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _tolower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalnum_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __maskrune(
-                arg1: __darwin_ct_rune_t,
-                arg2: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
+            pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __maskrune(arg_arg1, arg_arg2)
+        isalnum_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn isalpha_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __toupper(arg_arg1)
+        isalpha_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn iscntrl_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __tolower(arg_arg1)
+        iscntrl_l(arg_arg1, arg_arg2)
     })
 }
-pub type socklen_t = __darwin_socklen_t;
-pub type sa_family_t = __uint8_t;
+#[track_caller]
+pub unsafe fn isdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn islower_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        islower_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isgraph_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isprint_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        ispunct_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isspace_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isupper_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t)
+                -> ::std::os::raw::c_int;
+        }
+        isxdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isblank_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn __toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __toupper_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        toupper_l(arg___c, arg___l)
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -9158,68 +7896,30 @@ impl Default for iovec {
         }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-pub type sockaddr_ref_t = *mut sockaddr;
-pub type sockaddr_ref_ref_t = *mut *mut sockaddr;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sockaddr_header {
-    pub sa_len: __uint8_t,
-    pub sa_family: sa_family_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
@@ -9230,17 +7930,37 @@ impl Default for sockaddr_storage {
         }
     }
 }
-pub type sockaddr_storage_ref_t = *mut sockaddr_storage;
-pub type sockaddr_storage_ref_ref_t = *mut *mut sockaddr_storage;
+pub const MSG_OOB: _bindgen_ty_2 = 1;
+pub const MSG_PEEK: _bindgen_ty_2 = 2;
+pub const MSG_DONTROUTE: _bindgen_ty_2 = 4;
+pub const MSG_CTRUNC: _bindgen_ty_2 = 8;
+pub const MSG_PROXY: _bindgen_ty_2 = 16;
+pub const MSG_TRUNC: _bindgen_ty_2 = 32;
+pub const MSG_DONTWAIT: _bindgen_ty_2 = 64;
+pub const MSG_EOR: _bindgen_ty_2 = 128;
+pub const MSG_WAITALL: _bindgen_ty_2 = 256;
+pub const MSG_FIN: _bindgen_ty_2 = 512;
+pub const MSG_SYN: _bindgen_ty_2 = 1024;
+pub const MSG_CONFIRM: _bindgen_ty_2 = 2048;
+pub const MSG_RST: _bindgen_ty_2 = 4096;
+pub const MSG_ERRQUEUE: _bindgen_ty_2 = 8192;
+pub const MSG_NOSIGNAL: _bindgen_ty_2 = 16384;
+pub const MSG_MORE: _bindgen_ty_2 = 32768;
+pub const MSG_WAITFORONE: _bindgen_ty_2 = 65536;
+pub const MSG_BATCH: _bindgen_ty_2 = 262144;
+pub const MSG_ZEROCOPY: _bindgen_ty_2 = 67108864;
+pub const MSG_FASTOPEN: _bindgen_ty_2 = 536870912;
+pub const MSG_CMSG_CLOEXEC: _bindgen_ty_2 = 1073741824;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -9253,438 +7973,423 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[track_caller]
+pub unsafe fn __cmsg_nxthdr(arg___mhdr: *mut msghdr, arg___cmsg: *mut cmsghdr) -> *mut cmsghdr {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+        }
+        __cmsg_nxthdr(arg___mhdr, arg___cmsg)
+    })
+}
+pub const SCM_RIGHTS: _bindgen_ty_3 = 1;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn accept(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn accept(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        accept(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bind(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bind(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        bind(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn connect(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn connect(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        connect(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getpeername(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpeername(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getpeername(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockname(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockname(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockname(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_void,
-    arg_arg5: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_void,
-                arg5: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn listen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn listen(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        listen(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn recv(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recv(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recv(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn recvfrom(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *mut sockaddr,
-    arg_arg6: *mut socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvfrom(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *mut sockaddr,
-                arg6: *mut socklen_t,
-            ) -> isize;
-        }
-        recvfrom(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn recvmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recvmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn send(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn send(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        send(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn sendmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        sendmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn sendto(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *const sockaddr,
-    arg_arg6: socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendto(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const sockaddr,
-                arg6: socklen_t,
-            ) -> isize;
-        }
-        sendto(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_void,
-    arg_arg5: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_void,
-                arg5: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn shutdown(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn shutdown(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        shutdown(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sockatmark(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sockatmark(arg_arg1)
-    })
-}
+pub const SHUT_RD: _bindgen_ty_4 = 0;
+pub const SHUT_WR: _bindgen_ty_4 = 1;
+pub const SHUT_RDWR: _bindgen_ty_4 = 2;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn socket(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socket(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socket(arg_arg1, arg_arg2, arg_arg3)
+        socket(arg___domain, arg___type, arg___protocol)
     })
 }
 #[track_caller]
 pub unsafe fn socketpair(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
+    arg___fds: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socketpair(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
+                __fds: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socketpair(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        socketpair(arg___domain, arg___type, arg___protocol, arg___fds)
     })
 }
 #[track_caller]
-pub unsafe fn sendfile(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: off_t,
-    arg_arg4: *mut off_t,
-    arg_arg5: *mut sf_hdtr,
-    arg_arg6: ::std::os::raw::c_int,
+pub unsafe fn bind(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sendfile(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: off_t,
-                arg4: *mut off_t,
-                arg5: *mut sf_hdtr,
-                arg6: ::std::os::raw::c_int,
+            pub fn bind(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        sendfile(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
+        bind(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn pfctlinput(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut sockaddr) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-        }
-        pfctlinput(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn connectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sa_endpoints_t,
-    arg_arg3: sae_associd_t,
-    arg_arg4: ::std::os::raw::c_uint,
-    arg_arg5: *const iovec,
-    arg_arg6: ::std::os::raw::c_uint,
-    arg_arg7: *mut usize,
-    arg_arg8: *mut sae_connid_t,
+pub unsafe fn getsockname(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn connectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sa_endpoints_t,
-                arg3: sae_associd_t,
-                arg4: ::std::os::raw::c_uint,
-                arg5: *const iovec,
-                arg6: ::std::os::raw::c_uint,
-                arg7: *mut usize,
-                arg8: *mut sae_connid_t,
+            pub fn getsockname(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        connectx(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7, arg_arg8)
+        getsockname(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn disconnectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: sae_associd_t,
-    arg_arg3: sae_connid_t,
+pub unsafe fn connect(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn disconnectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: sae_associd_t,
-                arg3: sae_connid_t,
+            pub fn connect(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        disconnectx(arg_arg1, arg_arg2, arg_arg3)
+        connect(arg___fd, arg___addr, arg___len)
     })
 }
+#[track_caller]
+pub unsafe fn getpeername(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeername(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeername(arg___fd, arg___addr, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn send(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn send(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        send(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recv(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recv(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recv(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn sendto(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___addr_len: socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendto(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __addr_len: socklen_t,
+            ) -> isize;
+        }
+        sendto(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn recvfrom(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvfrom(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> isize;
+        }
+        recvfrom(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn sendmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *const msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *const msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        sendmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recvmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *mut msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *mut msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recvmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn getsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *mut ::std::os::raw::c_void,
+    arg___optlen: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *mut ::std::os::raw::c_void,
+                __optlen: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn setsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *const ::std::os::raw::c_void,
+    arg___optlen: socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *const ::std::os::raw::c_void,
+                __optlen: socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        setsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn listen(
+    arg___fd: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn listen(
+                __fd: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        listen(arg___fd, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn accept(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn accept(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        accept(arg___fd, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn shutdown(
+    arg___fd: ::std::os::raw::c_int,
+    arg___how: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn shutdown(
+                __fd: ::std::os::raw::c_int,
+                __how: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        shutdown(arg___fd, arg___how)
+    })
+}
+#[track_caller]
+pub unsafe fn sockatmark(arg___fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sockatmark(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn isfdtype(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fdtype: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isfdtype(
+                __fd: ::std::os::raw::c_int,
+                __fdtype: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        isfdtype(arg___fd, arg___fdtype)
+    })
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9703,12 +8408,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -9716,175 +8415,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn setipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: u32,
-    arg_arg5: u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: u32,
-                arg5: u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        setipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn getipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: *mut u32,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: *mut u32,
-                arg5: *mut u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        getipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: u32,
-    arg_arg6: u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: u32,
-                arg6: u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: *mut u32,
-                arg6: *mut u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: _bindgen_ty_5 = 0;
+pub const IPPROTO_ICMP: _bindgen_ty_5 = 1;
+pub const IPPROTO_IGMP: _bindgen_ty_5 = 2;
+pub const IPPROTO_IPIP: _bindgen_ty_5 = 4;
+pub const IPPROTO_TCP: _bindgen_ty_5 = 6;
+pub const IPPROTO_EGP: _bindgen_ty_5 = 8;
+pub const IPPROTO_PUP: _bindgen_ty_5 = 12;
+pub const IPPROTO_UDP: _bindgen_ty_5 = 17;
+pub const IPPROTO_IDP: _bindgen_ty_5 = 22;
+pub const IPPROTO_TP: _bindgen_ty_5 = 29;
+pub const IPPROTO_DCCP: _bindgen_ty_5 = 33;
+pub const IPPROTO_IPV6: _bindgen_ty_5 = 41;
+pub const IPPROTO_RSVP: _bindgen_ty_5 = 46;
+pub const IPPROTO_GRE: _bindgen_ty_5 = 47;
+pub const IPPROTO_ESP: _bindgen_ty_5 = 50;
+pub const IPPROTO_AH: _bindgen_ty_5 = 51;
+pub const IPPROTO_MTP: _bindgen_ty_5 = 92;
+pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
+pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
+pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
+pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
+pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
+pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
+pub const IPPROTO_ETHERNET: _bindgen_ty_5 = 143;
+pub const IPPROTO_RAW: _bindgen_ty_5 = 255;
+pub const IPPROTO_MPTCP: _bindgen_ty_5 = 262;
+pub const IPPROTO_MAX: _bindgen_ty_5 = 263;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: _bindgen_ty_6 = 0;
+pub const IPPROTO_ROUTING: _bindgen_ty_6 = 43;
+pub const IPPROTO_FRAGMENT: _bindgen_ty_6 = 44;
+pub const IPPROTO_ICMPV6: _bindgen_ty_6 = 58;
+pub const IPPROTO_NONE: _bindgen_ty_6 = 59;
+pub const IPPROTO_DSTOPTS: _bindgen_ty_6 = 60;
+pub const IPPROTO_MH: _bindgen_ty_6 = 135;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: _bindgen_ty_7 = 7;
+pub const IPPORT_DISCARD: _bindgen_ty_7 = 9;
+pub const IPPORT_SYSTAT: _bindgen_ty_7 = 11;
+pub const IPPORT_DAYTIME: _bindgen_ty_7 = 13;
+pub const IPPORT_NETSTAT: _bindgen_ty_7 = 15;
+pub const IPPORT_FTP: _bindgen_ty_7 = 21;
+pub const IPPORT_TELNET: _bindgen_ty_7 = 23;
+pub const IPPORT_SMTP: _bindgen_ty_7 = 25;
+pub const IPPORT_TIMESERVER: _bindgen_ty_7 = 37;
+pub const IPPORT_NAMESERVER: _bindgen_ty_7 = 42;
+pub const IPPORT_WHOIS: _bindgen_ty_7 = 43;
+pub const IPPORT_MTP: _bindgen_ty_7 = 57;
+pub const IPPORT_TFTP: _bindgen_ty_7 = 69;
+pub const IPPORT_RJE: _bindgen_ty_7 = 77;
+pub const IPPORT_FINGER: _bindgen_ty_7 = 79;
+pub const IPPORT_TTYLINK: _bindgen_ty_7 = 87;
+pub const IPPORT_SUPDUP: _bindgen_ty_7 = 95;
+pub const IPPORT_EXECSERVER: _bindgen_ty_7 = 512;
+pub const IPPORT_LOGINSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_CMDSERVER: _bindgen_ty_7 = 514;
+pub const IPPORT_EFSSERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_BIFFUDP: _bindgen_ty_7 = 512;
+pub const IPPORT_WHOSERVER: _bindgen_ty_7 = 513;
+pub const IPPORT_ROUTESERVER: _bindgen_ty_7 = 520;
+pub const IPPORT_RESERVED: _bindgen_ty_7 = 1024;
+pub const IPPORT_USERRESERVED: _bindgen_ty_7 = 5000;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -9904,16 +8515,28 @@ impl Default for in6_addr {
         }
     }
 }
-pub type in6_addr_t = in6_addr;
+extern "C" {
+    pub static in6addr_any: in6_addr;
+}
+extern "C" {
+    pub static in6addr_loopback: in6_addr;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
     pub sin6_family: sa_family_t,
     pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
+    pub sin6_flowinfo: u32,
     pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
+    pub sin6_scope_id: u32,
 }
 impl Default for sockaddr_in6 {
     fn default() -> Self {
@@ -9924,23 +8547,18 @@ impl Default for sockaddr_in6 {
         }
     }
 }
-extern "C" {
-    pub static in6addr_any: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
 }
-extern "C" {
-    pub static in6addr_loopback: in6_addr;
-}
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -9958,12 +8576,12 @@ impl Default for ipv6_mreq {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+#[derive(Debug, Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9973,12 +8591,40 @@ impl Default for in6_pktinfo {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+#[derive(Debug, Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -9988,464 +8634,236 @@ impl Default for ip6_mtuinfo {
     }
 }
 #[track_caller]
-pub unsafe fn inet6_option_space(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn ntohl(arg___netlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn ntohl(__netlong: u32) -> u32;
         }
-        inet6_option_space(arg_arg1)
+        ntohl(arg___netlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *mut *mut cmsghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ntohs(arg___netshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut *mut cmsghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn ntohs(__netshort: u16) -> u16;
         }
-        inet6_option_init(arg_arg1, arg_arg2, arg_arg3)
+        ntohs(arg___netshort)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_append(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn htonl(arg___hostlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_append(
-                arg1: *mut cmsghdr,
-                arg2: *const __uint8_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn htonl(__hostlong: u32) -> u32;
         }
-        inet6_option_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        htonl(arg___hostlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_alloc(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut __uint8_t {
+pub unsafe fn htons(arg___hostshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_alloc(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut __uint8_t;
+            pub fn htons(__hostshort: u16) -> u16;
         }
-        inet6_option_alloc(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_next(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_next(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_next(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_find(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_find(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_find(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> usize;
-        }
-        inet6_rthdr_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut cmsghdr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut cmsghdr;
-        }
-        inet6_rthdr_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_add(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const in6_addr,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_add(
-                arg1: *mut cmsghdr,
-                arg2: *const in6_addr,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_add(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_lasthop(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_lasthop(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_lasthop(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_segments(arg_arg1: *const cmsghdr) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getaddr(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getaddr(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rthdr_getaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getflags(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getflags(
-                arg1: *const cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_getflags(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_append(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: socklen_t,
-    arg_arg6: __uint8_t,
-    arg_arg7: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_append(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: socklen_t,
-                arg6: __uint8_t,
-                arg7: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_finish(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_finish(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_finish(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_set_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_set_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_set_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_next(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_next(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_next(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_find(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_find(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_find(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_get_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_get_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_get_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> socklen_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> socklen_t;
-        }
-        inet6_rth_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        inet6_rth_init(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_add(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *const in6_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_add(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const in6_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_add(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_reverse(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_reverse(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_reverse(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_segments(arg_arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void)
-                -> ::std::os::raw::c_int;
-        }
-        inet6_rth_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_getaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_getaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rth_getaddr(arg_arg1, arg_arg2)
+        htons(arg___hostshort)
     })
 }
 #[track_caller]
 pub unsafe fn bindresvport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr_in,
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bindresvport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr_in,
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport(arg_arg1, arg_arg2)
+        bindresvport(arg___sockfd, arg___sock_in)
     })
 }
 #[track_caller]
-pub unsafe fn bindresvport_sa(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
+pub unsafe fn bindresvport6(
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in6,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bindresvport_sa(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
+            pub fn bindresvport6(
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in6,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport_sa(arg_arg1, arg_arg2)
+        bindresvport6(arg___sockfd, arg___sock_in)
     })
 }
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn setrpcent(arg___stayopen: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
+        }
+        setrpcent(arg___stayopen)
+    })
+}
+#[track_caller]
+pub unsafe fn endrpcent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endrpcent();
+        }
+        endrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname(arg___name: *const ::std::os::raw::c_char) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
+        }
+        getrpcbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber(arg___number: ::std::os::raw::c_int) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
+        }
+        getrpcbynumber(arg___number)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent() -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent() -> *mut rpcent;
+        }
+        getrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbyname_r(arg___name, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber_r(
+    arg___number: ::std::os::raw::c_int,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber_r(
+                __number: ::std::os::raw::c_int,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbynumber_r(arg___number, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent_r(
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent_r(
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcent_r(arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn __h_errno_location() -> *mut ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+        }
+        __h_errno_location()
+    })
+}
+#[track_caller]
+pub unsafe fn herror(arg___str: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn herror(__str: *const ::std::os::raw::c_char);
+        }
+        herror(arg___str)
+    })
+}
+#[track_caller]
+pub unsafe fn hstrerror(arg___err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        hstrerror(arg___err_num)
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10465,22 +8883,322 @@ impl Default for hostent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
+#[track_caller]
+pub unsafe fn sethostent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sethostent(__stay_open: ::std::os::raw::c_int);
         }
-    }
+        sethostent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endhostent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endhostent();
+        }
+        endhostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent() -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent() -> *mut hostent;
+        }
+        gethostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyaddr(arg___addr, arg___len, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname(arg___name: *const ::std::os::raw::c_char) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+        }
+        gethostbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyname2(arg___name, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent_r(
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent_r(
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr_r(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr_r(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyaddr_r(
+            arg___addr,
+            arg___len,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2_r(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname2_r(
+            arg___name,
+            arg___af,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn setnetent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+        }
+        setnetent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endnetent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endnetent();
+        }
+        endnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent() -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent() -> *mut netent;
+        }
+        getnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr(arg___net: u32, arg___type: ::std::os::raw::c_int) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+        }
+        getnetbyaddr(arg___net, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname(arg___name: *const ::std::os::raw::c_char) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+        }
+        getnetbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent_r(
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent_r(
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr_r(
+    arg___net: u32,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr_r(
+                __net: u32,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyaddr_r(
+            arg___net,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10499,6 +9217,142 @@ impl Default for servent {
         }
     }
 }
+#[track_caller]
+pub unsafe fn setservent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setservent(__stay_open: ::std::os::raw::c_int);
+        }
+        setservent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endservent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endservent();
+        }
+        endservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservent() -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent() -> *mut servent;
+        }
+        getservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyname(arg___name, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyport(arg___port, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservent_r(
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent_r(
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyname_r(
+            arg___name,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport_r(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport_r(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyport_r(
+            arg___port,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -10515,59 +9369,13 @@ impl Default for protoent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
 #[track_caller]
-pub unsafe fn endhostent() {
+pub unsafe fn setprotoent(arg___stay_open: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn endhostent();
+            pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
         }
-        endhostent()
-    })
-}
-#[track_caller]
-pub unsafe fn endnetent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endnetent();
-        }
-        endnetent()
+        setprotoent(arg___stay_open)
     })
 }
 #[track_caller]
@@ -10580,157 +9388,6 @@ pub unsafe fn endprotoent() {
     })
 }
 #[track_caller]
-pub unsafe fn endservent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endservent();
-        }
-        endservent()
-    })
-}
-#[track_caller]
-pub unsafe fn freeaddrinfo(arg_arg1: *mut addrinfo) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freeaddrinfo(arg1: *mut addrinfo);
-        }
-        freeaddrinfo(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gai_strerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        gai_strerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getaddrinfo(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const addrinfo,
-    arg_arg4: *mut *mut addrinfo,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getaddrinfo(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const addrinfo,
-                arg4: *mut *mut addrinfo,
-            ) -> ::std::os::raw::c_int;
-        }
-        getaddrinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyaddr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-        }
-        gethostbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostent() -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostent() -> *mut hostent;
-        }
-        gethostent()
-    })
-}
-#[track_caller]
-pub unsafe fn getnameinfo(
-    arg_arg1: *const sockaddr,
-    arg_arg2: socklen_t,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut ::std::os::raw::c_char,
-    arg_arg6: socklen_t,
-    arg_arg7: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnameinfo(
-                arg1: *const sockaddr,
-                arg2: socklen_t,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: socklen_t,
-                arg5: *mut ::std::os::raw::c_char,
-                arg6: socklen_t,
-                arg7: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        getnameinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyaddr(arg_arg1: u32, arg_arg2: ::std::os::raw::c_int) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-        }
-        getnetbyaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-        }
-        getnetbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetent() -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetent() -> *mut netent;
-        }
-        getnetent()
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-        }
-        getprotobyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobynumber(arg_arg1: ::std::os::raw::c_int) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-        }
-        getprotobynumber(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn getprotoent() -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -10740,239 +9397,91 @@ pub unsafe fn getprotoent() -> *mut protoent {
     })
 }
 #[track_caller]
-pub unsafe fn getservbyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobyname(arg___name: *const ::std::os::raw::c_char) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
         }
-        getservbyname(arg_arg1, arg_arg2)
+        getprotobyname(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn getservbyport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobynumber(arg___proto: ::std::os::raw::c_int) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
         }
-        getservbyport(arg_arg1, arg_arg2)
+        getprotobynumber(arg___proto)
     })
 }
 #[track_caller]
-pub unsafe fn getservent() -> *mut servent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getservent() -> *mut servent;
-        }
-        getservent()
-    })
-}
-#[track_caller]
-pub unsafe fn sethostent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sethostent(arg1: ::std::os::raw::c_int);
-        }
-        sethostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setnetent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setnetent(arg1: ::std::os::raw::c_int);
-        }
-        setnetent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setprotoent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprotoent(arg1: ::std::os::raw::c_int);
-        }
-        setprotoent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setservent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setservent(arg1: ::std::os::raw::c_int);
-        }
-        setservent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn freehostent(arg_arg1: *mut hostent) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freehostent(arg1: *mut hostent);
-        }
-        freehostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyname2(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyaddr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyname(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbyname(arg_name: *const ::std::os::raw::c_char) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-        }
-        getrpcbyname(arg_name)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbynumber(arg_number: ::std::os::raw::c_int) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-        }
-        getrpcbynumber(arg_number)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcent() -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcent() -> *mut rpcent;
-        }
-        getrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn setrpcent(arg_stayopen: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrpcent(stayopen: ::std::os::raw::c_int);
-        }
-        setrpcent(arg_stayopen)
-    })
-}
-#[track_caller]
-pub unsafe fn endrpcent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endrpcent();
-        }
-        endrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn herror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn herror(arg1: *const ::std::os::raw::c_char);
-        }
-        herror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hstrerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        hstrerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn innetgr(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const ::std::os::raw::c_char,
+pub unsafe fn getprotoent_r(
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn innetgr(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const ::std::os::raw::c_char,
+            pub fn getprotoent_r(
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        innetgr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        getprotoent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn getnetgrent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+pub unsafe fn getprotobyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getnetgrent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+            pub fn getprotobyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        getnetgrent(arg_arg1, arg_arg2, arg_arg3)
+        getprotobyname_r(arg___name, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getprotobynumber_r(
+    arg___proto: ::std::os::raw::c_int,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getprotobynumber_r(
+                __proto: ::std::os::raw::c_int,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getprotobynumber_r(arg___proto, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn setnetgrent(arg___netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        setnetgrent(arg___netgroup)
     })
 }
 #[track_caller]
@@ -10985,29 +9494,283 @@ pub unsafe fn endnetgrent() {
     })
 }
 #[track_caller]
-pub unsafe fn setnetgrent(arg_arg1: *const ::std::os::raw::c_char) {
+pub unsafe fn getnetgrent(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+            pub fn getnetgrent(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        setnetgrent(arg_arg1)
+        getnetgrent(arg___hostp, arg___userp, arg___domainp)
+    })
+}
+#[track_caller]
+pub unsafe fn innetgr(
+    arg___netgroup: *const ::std::os::raw::c_char,
+    arg___host: *const ::std::os::raw::c_char,
+    arg___user: *const ::std::os::raw::c_char,
+    arg___domain: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn innetgr(
+                __netgroup: *const ::std::os::raw::c_char,
+                __host: *const ::std::os::raw::c_char,
+                __user: *const ::std::os::raw::c_char,
+                __domain: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        innetgr(arg___netgroup, arg___host, arg___user, arg___domain)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetgrent_r(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetgrent_r(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetgrent_r(arg___hostp, arg___userp, arg___domainp, arg___buffer, arg___buflen)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd(arg___ahost, arg___rport, arg___locuser, arg___remuser, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd_af(
+            arg___ahost,
+            arg___rport,
+            arg___locuser,
+            arg___remuser,
+            arg___cmd,
+            arg___fd2p,
+            arg___af,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn rexec(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rexec_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec_af(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok(arg___rhost, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok_af(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok_af(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok_af(arg___rhost, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok(
+    arg___raddr: u32,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok(
+                __raddr: u32,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok(arg___raddr, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok_af(
+    arg___raddr: *const ::std::os::raw::c_void,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok_af(
+                __raddr: *const ::std::os::raw::c_void,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok_af(arg___raddr, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport(arg___alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        rresvport(arg___alport)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport_af(
+    arg___alport: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport_af(
+                __alport: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rresvport_af(arg___alport, arg___af)
     })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct passwd {
-    pub pw_name: *mut ::std::os::raw::c_char,
-    pub pw_passwd: *mut ::std::os::raw::c_char,
-    pub pw_uid: uid_t,
-    pub pw_gid: gid_t,
-    pub pw_change: __darwin_time_t,
-    pub pw_class: *mut ::std::os::raw::c_char,
-    pub pw_gecos: *mut ::std::os::raw::c_char,
-    pub pw_dir: *mut ::std::os::raw::c_char,
-    pub pw_shell: *mut ::std::os::raw::c_char,
-    pub pw_expire: __darwin_time_t,
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
 }
-impl Default for passwd {
+impl Default for addrinfo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -11017,73 +9780,94 @@ impl Default for passwd {
     }
 }
 #[track_caller]
-pub unsafe fn getpwuid(arg_arg1: uid_t) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuid(arg1: uid_t) -> *mut passwd;
-        }
-        getpwuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwnam(arg_arg1: *const ::std::os::raw::c_char) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwnam(arg1: *const ::std::os::raw::c_char) -> *mut passwd;
-        }
-        getpwnam(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuid_r(
-    arg_arg1: uid_t,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getaddrinfo(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___service: *const ::std::os::raw::c_char,
+    arg___req: *const addrinfo,
+    arg___pai: *mut *mut addrinfo,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuid_r(
-                arg1: uid_t,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getaddrinfo(
+                __name: *const ::std::os::raw::c_char,
+                __service: *const ::std::os::raw::c_char,
+                __req: *const addrinfo,
+                __pai: *mut *mut addrinfo,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getaddrinfo(arg___name, arg___service, arg___req, arg___pai)
     })
 }
 #[track_caller]
-pub unsafe fn getpwnam_r(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn freeaddrinfo(arg___ai: *mut addrinfo) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freeaddrinfo(__ai: *mut addrinfo);
+        }
+        freeaddrinfo(arg___ai)
+    })
+}
+#[track_caller]
+pub unsafe fn gai_strerror(arg___ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        gai_strerror(arg___ecode)
+    })
+}
+#[track_caller]
+pub unsafe fn getnameinfo(
+    arg___sa: *const sockaddr,
+    arg___salen: socklen_t,
+    arg___host: *mut ::std::os::raw::c_char,
+    arg___hostlen: socklen_t,
+    arg___serv: *mut ::std::os::raw::c_char,
+    arg___servlen: socklen_t,
+    arg___flags: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwnam_r(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getnameinfo(
+                __sa: *const sockaddr,
+                __salen: socklen_t,
+                __host: *mut ::std::os::raw::c_char,
+                __hostlen: socklen_t,
+                __serv: *mut ::std::os::raw::c_char,
+                __servlen: socklen_t,
+                __flags: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getpwnam_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getnameinfo(
+            arg___sa,
+            arg___salen,
+            arg___host,
+            arg___hostlen,
+            arg___serv,
+            arg___servlen,
+            arg___flags,
+        )
     })
 }
-#[track_caller]
-pub unsafe fn getpwent() -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwent() -> *mut passwd;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct passwd {
+    pub pw_name: *mut ::std::os::raw::c_char,
+    pub pw_passwd: *mut ::std::os::raw::c_char,
+    pub pw_uid: __uid_t,
+    pub pw_gid: __gid_t,
+    pub pw_gecos: *mut ::std::os::raw::c_char,
+    pub pw_dir: *mut ::std::os::raw::c_char,
+    pub pw_shell: *mut ::std::os::raw::c_char,
+}
+impl Default for passwd {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        getpwent()
-    })
+    }
 }
 #[track_caller]
 pub unsafe fn setpwent() {
@@ -11103,192 +9887,131 @@ pub unsafe fn endpwent() {
         endpwent()
     })
 }
-pub type uuid_t = __darwin_uuid_t;
-pub type uuid_string_t = __darwin_uuid_string_t;
-extern "C" {
-    pub static UUID_NULL: uuid_t;
-}
 #[track_caller]
-pub unsafe fn uuid_clear(arg_uu: *mut ::std::os::raw::c_uchar) {
+pub unsafe fn getpwent() -> *mut passwd {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_clear(uu: *mut ::std::os::raw::c_uchar);
+            pub fn getpwent() -> *mut passwd;
         }
-        uuid_clear(arg_uu)
+        getpwent()
     })
 }
 #[track_caller]
-pub unsafe fn uuid_compare(
-    arg_uu1: *mut ::std::os::raw::c_uchar,
-    arg_uu2: *mut ::std::os::raw::c_uchar,
+pub unsafe fn fgetpwent(arg___stream: *mut FILE) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent(__stream: *mut FILE) -> *mut passwd;
+        }
+        fgetpwent(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putpwent(arg___p: *const passwd, arg___f: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putpwent(__p: *const passwd, __f: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putpwent(arg___p, arg___f)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwuid(arg___uid: __uid_t) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwuid(__uid: __uid_t) -> *mut passwd;
+        }
+        getpwuid(arg___uid)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwnam(arg___name: *const ::std::os::raw::c_char) -> *mut passwd {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpwnam(__name: *const ::std::os::raw::c_char) -> *mut passwd;
+        }
+        getpwnam(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getpwent_r(
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_compare(
-                uu1: *mut ::std::os::raw::c_uchar,
-                uu2: *mut ::std::os::raw::c_uchar,
+            pub fn getpwent_r(
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_compare(arg_uu1, arg_uu2)
+        getpwent_r(arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_copy(
-    arg_dst: *mut ::std::os::raw::c_uchar,
-    arg_src: *mut ::std::os::raw::c_uchar,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_copy(dst: *mut ::std::os::raw::c_uchar, src: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_copy(arg_dst, arg_src)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_random(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_random(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_random(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_generate_time(arg_out: *mut ::std::os::raw::c_uchar) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_generate_time(out: *mut ::std::os::raw::c_uchar);
-        }
-        uuid_generate_time(arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_is_null(arg_uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_is_null(uu: *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
-        }
-        uuid_is_null(arg_uu)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_parse(
-    arg_in_: *mut ::std::os::raw::c_char,
-    arg_uu: *mut ::std::os::raw::c_uchar,
+pub unsafe fn getpwuid_r(
+    arg___uid: __uid_t,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn uuid_parse(
-                in_: *mut ::std::os::raw::c_char,
-                uu: *mut ::std::os::raw::c_uchar,
+            pub fn getpwuid_r(
+                __uid: __uid_t,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        uuid_parse(arg_in_, arg_uu)
+        getpwuid_r(arg___uid, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn uuid_unparse(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse(uu: *mut ::std::os::raw::c_uchar, out: *mut ::std::os::raw::c_char);
-        }
-        uuid_unparse(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_lower(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_lower(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_lower(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn uuid_unparse_upper(
-    arg_uu: *mut ::std::os::raw::c_uchar,
-    arg_out: *mut ::std::os::raw::c_char,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn uuid_unparse_upper(
-                uu: *mut ::std::os::raw::c_uchar,
-                out: *mut ::std::os::raw::c_char,
-            );
-        }
-        uuid_unparse_upper(arg_uu, arg_out)
-    })
-}
-#[track_caller]
-pub unsafe fn setpassent(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpassent(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        setpassent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn user_from_uid(
-    arg_arg1: uid_t,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn user_from_uid(
-                arg1: uid_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        user_from_uid(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid(arg_arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpwuuid(arg1: *mut ::std::os::raw::c_uchar) -> *mut passwd;
-        }
-        getpwuuid(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getpwuuid_r(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: *mut passwd,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: usize,
-    arg_arg5: *mut *mut passwd,
+pub unsafe fn getpwnam_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getpwuuid_r(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: *mut passwd,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: usize,
-                arg5: *mut *mut passwd,
+            pub fn getpwnam_r(
+                __name: *const ::std::os::raw::c_char,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
             ) -> ::std::os::raw::c_int;
         }
-        getpwuuid_r(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        getpwnam_r(arg___name, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetpwent_r(
+    arg___stream: *mut FILE,
+    arg___resultbuf: *mut passwd,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut passwd,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetpwent_r(
+                __stream: *mut FILE,
+                __resultbuf: *mut passwd,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut passwd,
+            ) -> ::std::os::raw::c_int;
+        }
+        fgetpwent_r(arg___stream, arg___resultbuf, arg___buffer, arg___buflen, arg___result)
     })
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -11985,1692 +10708,761 @@ pub unsafe fn pg_srand48(arg_seed: ::std::os::raw::c_long) {
         pg_srand48(arg_seed)
     })
 }
+#[track_caller]
+pub unsafe fn fls(arg_mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        fls(arg_mask)
+    })
+}
+#[track_caller]
+pub unsafe fn getpeereid(
+    arg_sock: ::std::os::raw::c_int,
+    arg_uid: *mut uid_t,
+    arg_gid: *mut gid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeereid(
+                sock: ::std::os::raw::c_int,
+                uid: *mut uid_t,
+                gid: *mut gid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeereid(arg_sock, arg_uid, arg_gid)
+    })
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[track_caller]
-pub unsafe fn __math_errhandling() -> ::std::os::raw::c_int {
+pub unsafe fn __fpclassify(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __math_errhandling() -> ::std::os::raw::c_int;
+            pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
         }
-        __math_errhandling()
+        __fpclassify(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __signbit(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyf(arg_arg1)
+        __signbit(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyd(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyd(arg_arg1)
+        __isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyl(arg_arg1)
+        __finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosf(arg1: f32) -> f32;
+            pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosf(arg_arg1)
+        __isnan(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acos(arg_arg1: f64) -> f64 {
+pub unsafe fn __iseqsig(arg___x: f64, arg___y: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acos(arg1: f64) -> f64;
+            pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
         }
-        acos(arg_arg1)
+        __iseqsig(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn acosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __issignaling(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosl(arg1: f64) -> f64;
+            pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosl(arg_arg1)
+        __issignaling(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn asinf(arg_arg1: f32) -> f32 {
+pub unsafe fn acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinf(arg1: f32) -> f32;
+            pub fn acos(__x: f64) -> f64;
         }
-        asinf(arg_arg1)
+        acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asin(arg_arg1: f64) -> f64 {
+pub unsafe fn __acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asin(arg1: f64) -> f64;
+            pub fn __acos(__x: f64) -> f64;
         }
-        asin(arg_arg1)
+        __acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinl(arg_arg1: f64) -> f64 {
+pub unsafe fn asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinl(arg1: f64) -> f64;
+            pub fn asin(__x: f64) -> f64;
         }
-        asinl(arg_arg1)
+        asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanf(arg1: f32) -> f32;
+            pub fn __asin(__x: f64) -> f64;
         }
-        atanf(arg_arg1)
+        __asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan(arg_arg1: f64) -> f64 {
+pub unsafe fn atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan(arg1: f64) -> f64;
+            pub fn atan(__x: f64) -> f64;
         }
-        atan(arg_arg1)
+        atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanl(arg1: f64) -> f64;
+            pub fn __atan(__x: f64) -> f64;
         }
-        atanl(arg_arg1)
+        __atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2f(arg_arg1: f32, arg_arg2: f32) -> f32 {
+pub unsafe fn atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+            pub fn atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2f(arg_arg1, arg_arg2)
+        atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2(arg1: f64, arg2: f64) -> f64;
+            pub fn __atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2(arg_arg1, arg_arg2)
+        __atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2l(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+            pub fn cos(__x: f64) -> f64;
         }
-        atan2l(arg_arg1, arg_arg2)
+        cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosf(arg1: f32) -> f32;
+            pub fn __cos(__x: f64) -> f64;
         }
-        cosf(arg_arg1)
+        __cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cos(arg_arg1: f64) -> f64 {
+pub unsafe fn sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cos(arg1: f64) -> f64;
+            pub fn sin(__x: f64) -> f64;
         }
-        cos(arg_arg1)
+        sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosl(arg1: f64) -> f64;
+            pub fn __sin(__x: f64) -> f64;
         }
-        cosl(arg_arg1)
+        __sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinf(arg_arg1: f32) -> f32 {
+pub unsafe fn tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinf(arg1: f32) -> f32;
+            pub fn tan(__x: f64) -> f64;
         }
-        sinf(arg_arg1)
+        tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sin(arg_arg1: f64) -> f64 {
+pub unsafe fn __tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sin(arg1: f64) -> f64;
+            pub fn __tan(__x: f64) -> f64;
         }
-        sin(arg_arg1)
+        __tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinl(arg_arg1: f64) -> f64 {
+pub unsafe fn cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinl(arg1: f64) -> f64;
+            pub fn cosh(__x: f64) -> f64;
         }
-        sinl(arg_arg1)
+        cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanf(arg1: f32) -> f32;
+            pub fn __cosh(__x: f64) -> f64;
         }
-        tanf(arg_arg1)
+        __cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tan(arg_arg1: f64) -> f64 {
+pub unsafe fn sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tan(arg1: f64) -> f64;
+            pub fn sinh(__x: f64) -> f64;
         }
-        tan(arg_arg1)
+        sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanl(arg1: f64) -> f64;
+            pub fn __sinh(__x: f64) -> f64;
         }
-        tanl(arg_arg1)
+        __sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshf(arg_arg1: f32) -> f32 {
+pub unsafe fn tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshf(arg1: f32) -> f32;
+            pub fn tanh(__x: f64) -> f64;
         }
-        acoshf(arg_arg1)
+        tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acosh(arg_arg1: f64) -> f64 {
+pub unsafe fn __tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosh(arg1: f64) -> f64;
+            pub fn __tanh(__x: f64) -> f64;
         }
-        acosh(arg_arg1)
+        __tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshl(arg_arg1: f64) -> f64 {
+pub unsafe fn acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshl(arg1: f64) -> f64;
+            pub fn acosh(__x: f64) -> f64;
         }
-        acoshl(arg_arg1)
+        acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn __acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhf(arg1: f32) -> f32;
+            pub fn __acosh(__x: f64) -> f64;
         }
-        asinhf(arg_arg1)
+        __acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinh(arg_arg1: f64) -> f64 {
+pub unsafe fn asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinh(arg1: f64) -> f64;
+            pub fn asinh(__x: f64) -> f64;
         }
-        asinh(arg_arg1)
+        asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhl(arg1: f64) -> f64;
+            pub fn __asinh(__x: f64) -> f64;
         }
-        asinhl(arg_arg1)
+        __asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhf(arg1: f32) -> f32;
+            pub fn atanh(__x: f64) -> f64;
         }
-        atanhf(arg_arg1)
+        atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanh(arg1: f64) -> f64;
+            pub fn __atanh(__x: f64) -> f64;
         }
-        atanh(arg_arg1)
+        __atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhl(arg1: f64) -> f64;
+            pub fn exp(__x: f64) -> f64;
         }
-        atanhl(arg_arg1)
+        exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn coshf(arg_arg1: f32) -> f32 {
+pub unsafe fn __exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshf(arg1: f32) -> f32;
+            pub fn __exp(__x: f64) -> f64;
         }
-        coshf(arg_arg1)
+        __exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosh(arg_arg1: f64) -> f64 {
+pub unsafe fn frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosh(arg1: f64) -> f64;
+            pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        cosh(arg_arg1)
+        frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn coshl(arg_arg1: f64) -> f64 {
+pub unsafe fn __frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshl(arg1: f64) -> f64;
+            pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        coshl(arg_arg1)
+        __frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhf(arg1: f32) -> f32;
+            pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinhf(arg_arg1)
+        ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinh(arg_arg1: f64) -> f64 {
+pub unsafe fn __ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinh(arg1: f64) -> f64;
+            pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinh(arg_arg1)
+        __ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhl(arg1: f64) -> f64;
+            pub fn __log(__x: f64) -> f64;
         }
-        sinhl(arg_arg1)
+        __log(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhf(arg1: f32) -> f32;
+            pub fn log10(__x: f64) -> f64;
         }
-        tanhf(arg_arg1)
+        log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanh(arg1: f64) -> f64;
+            pub fn __log10(__x: f64) -> f64;
         }
-        tanh(arg_arg1)
+        __log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhl(arg1: f64) -> f64;
+            pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        tanhl(arg_arg1)
+        modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn expf(arg_arg1: f32) -> f32 {
+pub unsafe fn __modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expf(arg1: f32) -> f32;
+            pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        expf(arg_arg1)
+        __modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn exp(arg_arg1: f64) -> f64 {
+pub unsafe fn expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp(arg1: f64) -> f64;
+            pub fn expm1(__x: f64) -> f64;
         }
-        exp(arg_arg1)
+        expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expl(arg_arg1: f64) -> f64 {
+pub unsafe fn __expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expl(arg1: f64) -> f64;
+            pub fn __expm1(__x: f64) -> f64;
         }
-        expl(arg_arg1)
+        __expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2f(arg_arg1: f32) -> f32 {
+pub unsafe fn log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2f(arg1: f32) -> f32;
+            pub fn log1p(__x: f64) -> f64;
         }
-        exp2f(arg_arg1)
+        log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2(arg_arg1: f64) -> f64 {
+pub unsafe fn __log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2(arg1: f64) -> f64;
+            pub fn __log1p(__x: f64) -> f64;
         }
-        exp2(arg_arg1)
+        __log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2l(arg_arg1: f64) -> f64 {
+pub unsafe fn logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2l(arg1: f64) -> f64;
+            pub fn logb(__x: f64) -> f64;
         }
-        exp2l(arg_arg1)
+        logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1f(arg_arg1: f32) -> f32 {
+pub unsafe fn __logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1f(arg1: f32) -> f32;
+            pub fn __logb(__x: f64) -> f64;
         }
-        expm1f(arg_arg1)
+        __logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1(arg_arg1: f64) -> f64 {
+pub unsafe fn exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1(arg1: f64) -> f64;
+            pub fn exp2(__x: f64) -> f64;
         }
-        expm1(arg_arg1)
+        exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1l(arg_arg1: f64) -> f64 {
+pub unsafe fn __exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1l(arg1: f64) -> f64;
+            pub fn __exp2(__x: f64) -> f64;
         }
-        expm1l(arg_arg1)
+        __exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logf(arg_arg1: f32) -> f32 {
+pub unsafe fn log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logf(arg1: f32) -> f32;
+            pub fn log2(__x: f64) -> f64;
         }
-        logf(arg_arg1)
+        log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logl(arg1: f64) -> f64;
+            pub fn __log2(__x: f64) -> f64;
         }
-        logl(arg_arg1)
+        __log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log10f(arg_arg1: f32) -> f32 {
+pub unsafe fn pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10f(arg1: f32) -> f32;
+            pub fn pow(__x: f64, __y: f64) -> f64;
         }
-        log10f(arg_arg1)
+        pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10(arg_arg1: f64) -> f64 {
+pub unsafe fn __pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10(arg1: f64) -> f64;
+            pub fn __pow(__x: f64, __y: f64) -> f64;
         }
-        log10(arg_arg1)
+        __pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10l(arg_arg1: f64) -> f64 {
+pub unsafe fn sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10l(arg1: f64) -> f64;
+            pub fn sqrt(__x: f64) -> f64;
         }
-        log10l(arg_arg1)
+        sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2f(arg_arg1: f32) -> f32 {
+pub unsafe fn __sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2f(arg1: f32) -> f32;
+            pub fn __sqrt(__x: f64) -> f64;
         }
-        log2f(arg_arg1)
+        __sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2(arg_arg1: f64) -> f64 {
+pub unsafe fn hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2(arg1: f64) -> f64;
+            pub fn hypot(__x: f64, __y: f64) -> f64;
         }
-        log2(arg_arg1)
+        hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log2l(arg_arg1: f64) -> f64 {
+pub unsafe fn __hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2l(arg1: f64) -> f64;
+            pub fn __hypot(__x: f64, __y: f64) -> f64;
         }
-        log2l(arg_arg1)
+        __hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log1pf(arg_arg1: f32) -> f32 {
+pub unsafe fn cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pf(arg1: f32) -> f32;
+            pub fn cbrt(__x: f64) -> f64;
         }
-        log1pf(arg_arg1)
+        cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1p(arg_arg1: f64) -> f64 {
+pub unsafe fn __cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1p(arg1: f64) -> f64;
+            pub fn __cbrt(__x: f64) -> f64;
         }
-        log1p(arg_arg1)
+        __cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1pl(arg_arg1: f64) -> f64 {
+pub unsafe fn ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pl(arg1: f64) -> f64;
+            pub fn ceil(__x: f64) -> f64;
         }
-        log1pl(arg_arg1)
+        ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbf(arg_arg1: f32) -> f32 {
+pub unsafe fn __ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbf(arg1: f32) -> f32;
+            pub fn __ceil(__x: f64) -> f64;
         }
-        logbf(arg_arg1)
+        __ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logb(arg_arg1: f64) -> f64 {
+pub unsafe fn fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logb(arg1: f64) -> f64;
+            pub fn fabs(__x: f64) -> f64;
         }
-        logb(arg_arg1)
+        fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbl(arg_arg1: f64) -> f64 {
+pub unsafe fn __fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbl(arg1: f64) -> f64;
+            pub fn __fabs(__x: f64) -> f64;
         }
-        logbl(arg_arg1)
+        __fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modff(arg_arg1: f32, arg_arg2: *mut f32) -> f32 {
+pub unsafe fn floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+            pub fn floor(__x: f64) -> f64;
         }
-        modff(arg_arg1, arg_arg2)
+        floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modf(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn __floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn __floor(__x: f64) -> f64;
         }
-        modf(arg_arg1, arg_arg2)
+        __floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modfl(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn fmod(__x: f64, __y: f64) -> f64;
         }
-        modfl(arg_arg1, arg_arg2)
+        fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn __fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn __fmod(__x: f64, __y: f64) -> f64;
         }
-        ldexpf(arg_arg1, arg_arg2)
+        __fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexp(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexp(arg_arg1, arg_arg2)
+        isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexpl(arg_arg1, arg_arg2)
+        finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn frexpf(arg_arg1: f32, arg_arg2: *mut ::std::os::raw::c_int) -> f32 {
+pub unsafe fn drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+            pub fn drem(__x: f64, __y: f64) -> f64;
         }
-        frexpf(arg_arg1, arg_arg2)
+        drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexp(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn __drem(__x: f64, __y: f64) -> f64;
         }
-        frexp(arg_arg1, arg_arg2)
+        __drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexpl(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn significand(__x: f64) -> f64;
         }
-        frexpl(arg_arg1, arg_arg2)
+        significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __significand(__x: f64) -> f64;
         }
-        ilogbf(arg_arg1)
+        __significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogb(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogb(arg_arg1)
+        copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogbl(arg_arg1)
+        __copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbnf(arg_arg1, arg_arg2)
+        nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbn(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbn(arg_arg1, arg_arg2)
+        __nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        scalbnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_long) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-        }
-        scalblnf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalbln(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalbln(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalblnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsf(arg1: f32) -> f32;
-        }
-        fabsf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabs(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabs(arg1: f64) -> f64;
-        }
-        fabs(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsl(arg1: f64) -> f64;
-        }
-        fabsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtf(arg1: f32) -> f32;
-        }
-        cbrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrt(arg1: f64) -> f64;
-        }
-        cbrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtl(arg1: f64) -> f64;
-        }
-        cbrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-        }
-        hypotf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypot(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypot(arg1: f64, arg2: f64) -> f64;
-        }
-        hypot(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-        }
-        hypotl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powf(arg1: f32, arg2: f32) -> f32;
-        }
-        powf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pow(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pow(arg1: f64, arg2: f64) -> f64;
-        }
-        pow(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powl(arg1: f64, arg2: f64) -> f64;
-        }
-        powl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtf(arg1: f32) -> f32;
-        }
-        sqrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrt(arg1: f64) -> f64;
-        }
-        sqrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtl(arg1: f64) -> f64;
-        }
-        sqrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erff(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erff(arg1: f32) -> f32;
-        }
-        erff(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erf(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erf(arg1: f64) -> f64;
-        }
-        erf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfl(arg1: f64) -> f64;
-        }
-        erfl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcf(arg1: f32) -> f32;
-        }
-        erfcf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfc(arg1: f64) -> f64;
-        }
-        erfc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcl(arg1: f64) -> f64;
-        }
-        erfcl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammaf(arg1: f32) -> f32;
-        }
-        lgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgamma(arg1: f64) -> f64;
-        }
-        lgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammal(arg1: f64) -> f64;
-        }
-        lgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammaf(arg1: f32) -> f32;
-        }
-        tgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgamma(arg1: f64) -> f64;
-        }
-        tgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammal(arg1: f64) -> f64;
-        }
-        tgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceilf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceilf(arg1: f32) -> f32;
-        }
-        ceilf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceil(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceil(arg1: f64) -> f64;
-        }
-        ceil(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceill(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceill(arg1: f64) -> f64;
-        }
-        ceill(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorf(arg1: f32) -> f32;
-        }
-        floorf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floor(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floor(arg1: f64) -> f64;
-        }
-        floor(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorl(arg1: f64) -> f64;
-        }
-        floorl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintf(arg1: f32) -> f32;
-        }
-        nearbyintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyint(arg1: f64) -> f64;
-        }
-        nearbyint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintl(arg1: f64) -> f64;
-        }
-        nearbyintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintf(arg1: f32) -> f32;
-        }
-        rintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rint(arg1: f64) -> f64;
-        }
-        rint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintl(arg1: f64) -> f64;
-        }
-        rintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrint(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundf(arg1: f32) -> f32;
-        }
-        roundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn round(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn round(arg1: f64) -> f64;
-        }
-        round(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundl(arg1: f64) -> f64;
-        }
-        roundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lround(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrint(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llround(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncf(arg1: f32) -> f32;
-        }
-        truncf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn trunc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn trunc(arg1: f64) -> f64;
-        }
-        trunc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncl(arg1: f64) -> f64;
-        }
-        truncl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmodf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmod(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmod(arg1: f64, arg2: f64) -> f64;
-        }
-        fmod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmodl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-        }
-        remainderf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainder(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainder(arg1: f64, arg2: f64) -> f64;
-        }
-        remainder(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-        }
-        remainderl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remquof(arg_arg1: f32, arg_arg2: f32, arg_arg3: *mut ::std::os::raw::c_int) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-        }
-        remquof(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquo(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquo(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquol(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquol(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-        }
-        copysignf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysign(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysign(arg1: f64, arg2: f64) -> f64;
-        }
-        copysign(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-        }
-        copysignl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nanf(arg_arg1: *const ::std::os::raw::c_char) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-        }
-        nanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nan(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nan(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nanl(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nanl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-        }
-        nextafterf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafter(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafter(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafterl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttoward(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttoward(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardf(arg_arg1: f32, arg_arg2: f64) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-        }
-        nexttowardf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttowardl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdimf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-        }
-        fdimf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdim(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdim(arg1: f64, arg2: f64) -> f64;
-        }
-        fdim(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdiml(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-        }
-        fdiml(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmaxf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmax(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmax(arg1: f64, arg2: f64) -> f64;
-        }
-        fmax(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmaxl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminf(arg1: f32, arg2: f32) -> f32;
-        }
-        fminf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmin(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmin(arg1: f64, arg2: f64) -> f64;
-        }
-        fmin(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminl(arg1: f64, arg2: f64) -> f64;
-        }
-        fminl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaf(arg_arg1: f32, arg_arg2: f32, arg_arg3: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-        }
-        fmaf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fma(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fma(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fmal(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fmal(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10f(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10f(arg1: f32) -> f32;
-        }
-        __exp10f(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10(arg1: f64) -> f64;
-        }
-        __exp10(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospif(arg1: f32) -> f32;
-        }
-        __cospif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospi(arg1: f64) -> f64;
-        }
-        __cospi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpif(arg1: f32) -> f32;
-        }
-        __sinpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpi(arg1: f64) -> f64;
-        }
-        __sinpi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpif(arg1: f32) -> f32;
-        }
-        __tanpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpi(arg1: f64) -> f64;
-        }
-        __tanpi(arg_arg1)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[track_caller]
-pub unsafe fn __sincosf_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincosf_stret(arg1: f32) -> __float2;
-        }
-        __sincosf_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincos_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincos_stret(arg1: f64) -> __double2;
-        }
-        __sincos_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospif_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospif_stret(arg1: f32) -> __float2;
-        }
-        __sincospif_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospi_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospi_stret(arg1: f64) -> __double2;
-        }
-        __sincospi_stret(arg_arg1)
+        isnan(arg___value)
     })
 }
 #[track_caller]
@@ -13683,12 +11475,30 @@ pub unsafe fn j0(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __j0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0(arg1: f64) -> f64;
+        }
+        __j0(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn j1(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn j1(arg1: f64) -> f64;
         }
         j1(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1(arg1: f64) -> f64;
+        }
+        __j1(arg_arg1)
     })
 }
 #[track_caller]
@@ -13701,12 +11511,30 @@ pub unsafe fn jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+        }
+        __jn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
 pub unsafe fn y0(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn y0(arg1: f64) -> f64;
         }
         y0(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0(arg1: f64) -> f64;
+        }
+        __y0(arg_arg1)
     })
 }
 #[track_caller]
@@ -13719,6 +11547,15 @@ pub unsafe fn y1(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __y1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1(arg1: f64) -> f64;
+        }
+        __y1(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -13728,42 +11565,3155 @@ pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
-pub unsafe fn scalb(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalb(arg1: f64, arg2: f64) -> f64;
+            pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
         }
-        scalb(arg_arg1, arg_arg2)
+        __yn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erf(arg1: f64) -> f64;
+        }
+        erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erf(arg1: f64) -> f64;
+        }
+        __erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfc(arg1: f64) -> f64;
+        }
+        erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfc(arg1: f64) -> f64;
+        }
+        __erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma(arg1: f64) -> f64;
+        }
+        lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma(arg1: f64) -> f64;
+        }
+        __lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgamma(arg1: f64) -> f64;
+        }
+        tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgamma(arg1: f64) -> f64;
+        }
+        __tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gamma(arg1: f64) -> f64;
+        }
+        gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gamma(arg1: f64) -> f64;
+        }
+        __gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rint(__x: f64) -> f64;
+        }
+        rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rint(__x: f64) -> f64;
+        }
+        __rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafter(__x: f64, __y: f64) -> f64;
+        }
+        nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafter(__x: f64, __y: f64) -> f64;
+        }
+        __nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        __nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainder(__x: f64, __y: f64) -> f64;
+        }
+        remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainder(__x: f64, __y: f64) -> f64;
+        }
+        __remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        __scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        __ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        __scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyint(__x: f64) -> f64;
+        }
+        nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyint(__x: f64) -> f64;
+        }
+        __nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn round(__x: f64) -> f64;
+        }
+        round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __round(__x: f64) -> f64;
+        }
+        __round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn trunc(__x: f64) -> f64;
+        }
+        trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __trunc(__x: f64) -> f64;
+        }
+        __trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdim(__x: f64, __y: f64) -> f64;
+        }
+        fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdim(__x: f64, __y: f64) -> f64;
+        }
+        __fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmax(__x: f64, __y: f64) -> f64;
+        }
+        fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmax(__x: f64, __y: f64) -> f64;
+        }
+        __fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmin(__x: f64, __y: f64) -> f64;
+        }
+        fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmin(__x: f64, __y: f64) -> f64;
+        }
+        __fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        __fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalb(__x: f64, __n: f64) -> f64;
+        }
+        scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalb(__x: f64, __n: f64) -> f64;
+        }
+        __scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __signbitf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigf(arg___x: f32, arg___y: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+        }
+        __iseqsigf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __issignalingf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosf(__x: f32) -> f32;
+        }
+        acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosf(__x: f32) -> f32;
+        }
+        __acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinf(__x: f32) -> f32;
+        }
+        asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinf(__x: f32) -> f32;
+        }
+        __asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanf(__x: f32) -> f32;
+        }
+        atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanf(__x: f32) -> f32;
+        }
+        __atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2f(__y: f32, __x: f32) -> f32;
+        }
+        atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2f(__y: f32, __x: f32) -> f32;
+        }
+        __atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosf(__x: f32) -> f32;
+        }
+        cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosf(__x: f32) -> f32;
+        }
+        __cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinf(__x: f32) -> f32;
+        }
+        sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinf(__x: f32) -> f32;
+        }
+        __sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanf(__x: f32) -> f32;
+        }
+        tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanf(__x: f32) -> f32;
+        }
+        __tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshf(__x: f32) -> f32;
+        }
+        coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshf(__x: f32) -> f32;
+        }
+        __coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhf(__x: f32) -> f32;
+        }
+        sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhf(__x: f32) -> f32;
+        }
+        __sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhf(__x: f32) -> f32;
+        }
+        tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhf(__x: f32) -> f32;
+        }
+        __tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshf(__x: f32) -> f32;
+        }
+        acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshf(__x: f32) -> f32;
+        }
+        __acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhf(__x: f32) -> f32;
+        }
+        asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhf(__x: f32) -> f32;
+        }
+        __asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhf(__x: f32) -> f32;
+        }
+        atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhf(__x: f32) -> f32;
+        }
+        __atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expf(__x: f32) -> f32;
+        }
+        expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expf(__x: f32) -> f32;
+        }
+        __expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        __ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logf(__x: f32) -> f32;
+        }
+        logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logf(__x: f32) -> f32;
+        }
+        __logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10f(__x: f32) -> f32;
+        }
+        log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10f(__x: f32) -> f32;
+        }
+        __log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        __modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1f(__x: f32) -> f32;
+        }
+        expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1f(__x: f32) -> f32;
+        }
+        __expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pf(__x: f32) -> f32;
+        }
+        log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pf(__x: f32) -> f32;
+        }
+        __log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbf(__x: f32) -> f32;
+        }
+        logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbf(__x: f32) -> f32;
+        }
+        __logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2f(__x: f32) -> f32;
+        }
+        exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2f(__x: f32) -> f32;
+        }
+        __exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2f(__x: f32) -> f32;
+        }
+        log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2f(__x: f32) -> f32;
+        }
+        __log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powf(__x: f32, __y: f32) -> f32;
+        }
+        powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powf(__x: f32, __y: f32) -> f32;
+        }
+        __powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtf(__x: f32) -> f32;
+        }
+        sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtf(__x: f32) -> f32;
+        }
+        __sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotf(__x: f32, __y: f32) -> f32;
+        }
+        hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotf(__x: f32, __y: f32) -> f32;
+        }
+        __hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtf(__x: f32) -> f32;
+        }
+        cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtf(__x: f32) -> f32;
+        }
+        __cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceilf(__x: f32) -> f32;
+        }
+        ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceilf(__x: f32) -> f32;
+        }
+        __ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsf(__x: f32) -> f32;
+        }
+        fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsf(__x: f32) -> f32;
+        }
+        __fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorf(__x: f32) -> f32;
+        }
+        floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorf(__x: f32) -> f32;
+        }
+        __floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodf(__x: f32, __y: f32) -> f32;
+        }
+        fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodf(__x: f32, __y: f32) -> f32;
+        }
+        __fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dremf(__x: f32, __y: f32) -> f32;
+        }
+        dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dremf(__x: f32, __y: f32) -> f32;
+        }
+        __dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandf(__x: f32) -> f32;
+        }
+        significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandf(__x: f32) -> f32;
+        }
+        __significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignf(__x: f32, __y: f32) -> f32;
+        }
+        copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignf(__x: f32, __y: f32) -> f32;
+        }
+        __copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        __nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0f(arg1: f32) -> f32;
+        }
+        j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0f(arg1: f32) -> f32;
+        }
+        __j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1f(arg1: f32) -> f32;
+        }
+        j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1f(arg1: f32) -> f32;
+        }
+        __j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0f(arg1: f32) -> f32;
+        }
+        y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0f(arg1: f32) -> f32;
+        }
+        __y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1f(arg1: f32) -> f32;
+        }
+        y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1f(arg1: f32) -> f32;
+        }
+        __y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erff(arg1: f32) -> f32;
+        }
+        erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erff(arg1: f32) -> f32;
+        }
+        __erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcf(arg1: f32) -> f32;
+        }
+        erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcf(arg1: f32) -> f32;
+        }
+        __erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf(arg1: f32) -> f32;
+        }
+        lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf(arg1: f32) -> f32;
+        }
+        __lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammaf(arg1: f32) -> f32;
+        }
+        tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammaf(arg1: f32) -> f32;
+        }
+        __tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammaf(arg1: f32) -> f32;
+        }
+        gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammaf(arg1: f32) -> f32;
+        }
+        __gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintf(__x: f32) -> f32;
+        }
+        rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintf(__x: f32) -> f32;
+        }
+        __rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        __nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        __nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderf(__x: f32, __y: f32) -> f32;
+        }
+        remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderf(__x: f32, __y: f32) -> f32;
+        }
+        __remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        __scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        __ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        __scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintf(__x: f32) -> f32;
+        }
+        nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintf(__x: f32) -> f32;
+        }
+        __nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundf(__x: f32) -> f32;
+        }
+        roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundf(__x: f32) -> f32;
+        }
+        __roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncf(__x: f32) -> f32;
+        }
+        truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncf(__x: f32) -> f32;
+        }
+        __truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdimf(__x: f32, __y: f32) -> f32;
+        }
+        fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdimf(__x: f32, __y: f32) -> f32;
+        }
+        __fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        __fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminf(__x: f32, __y: f32) -> f32;
+        }
+        fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminf(__x: f32, __y: f32) -> f32;
+        }
+        __fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        __fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbf(__x: f32, __n: f32) -> f32;
+        }
+        scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbf(__x: f32, __n: f32) -> f32;
+        }
+        __scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __signbitl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigl(arg___x: u128, arg___y: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+        }
+        __iseqsigl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __issignalingl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosl(__x: u128) -> u128;
+        }
+        acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosl(__x: u128) -> u128;
+        }
+        __acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinl(__x: u128) -> u128;
+        }
+        asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinl(__x: u128) -> u128;
+        }
+        __asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanl(__x: u128) -> u128;
+        }
+        atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanl(__x: u128) -> u128;
+        }
+        __atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2l(__y: u128, __x: u128) -> u128;
+        }
+        atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2l(__y: u128, __x: u128) -> u128;
+        }
+        __atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosl(__x: u128) -> u128;
+        }
+        cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosl(__x: u128) -> u128;
+        }
+        __cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinl(__x: u128) -> u128;
+        }
+        sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinl(__x: u128) -> u128;
+        }
+        __sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanl(__x: u128) -> u128;
+        }
+        tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanl(__x: u128) -> u128;
+        }
+        __tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshl(__x: u128) -> u128;
+        }
+        coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshl(__x: u128) -> u128;
+        }
+        __coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhl(__x: u128) -> u128;
+        }
+        sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhl(__x: u128) -> u128;
+        }
+        __sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhl(__x: u128) -> u128;
+        }
+        tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhl(__x: u128) -> u128;
+        }
+        __tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshl(__x: u128) -> u128;
+        }
+        acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshl(__x: u128) -> u128;
+        }
+        __acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhl(__x: u128) -> u128;
+        }
+        asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhl(__x: u128) -> u128;
+        }
+        __asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhl(__x: u128) -> u128;
+        }
+        atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhl(__x: u128) -> u128;
+        }
+        __atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expl(__x: u128) -> u128;
+        }
+        expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expl(__x: u128) -> u128;
+        }
+        __expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        __ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logl(__x: u128) -> u128;
+        }
+        logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logl(__x: u128) -> u128;
+        }
+        __logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10l(__x: u128) -> u128;
+        }
+        log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10l(__x: u128) -> u128;
+        }
+        __log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        __modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1l(__x: u128) -> u128;
+        }
+        expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1l(__x: u128) -> u128;
+        }
+        __expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pl(__x: u128) -> u128;
+        }
+        log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pl(__x: u128) -> u128;
+        }
+        __log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbl(__x: u128) -> u128;
+        }
+        logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbl(__x: u128) -> u128;
+        }
+        __logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2l(__x: u128) -> u128;
+        }
+        exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2l(__x: u128) -> u128;
+        }
+        __exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2l(__x: u128) -> u128;
+        }
+        log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2l(__x: u128) -> u128;
+        }
+        __log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powl(__x: u128, __y: u128) -> u128;
+        }
+        powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powl(__x: u128, __y: u128) -> u128;
+        }
+        __powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtl(__x: u128) -> u128;
+        }
+        sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtl(__x: u128) -> u128;
+        }
+        __sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotl(__x: u128, __y: u128) -> u128;
+        }
+        hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotl(__x: u128, __y: u128) -> u128;
+        }
+        __hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtl(__x: u128) -> u128;
+        }
+        cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtl(__x: u128) -> u128;
+        }
+        __cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceill(__x: u128) -> u128;
+        }
+        ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceill(__x: u128) -> u128;
+        }
+        __ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsl(__x: u128) -> u128;
+        }
+        fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsl(__x: u128) -> u128;
+        }
+        __fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorl(__x: u128) -> u128;
+        }
+        floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorl(__x: u128) -> u128;
+        }
+        __floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodl(__x: u128, __y: u128) -> u128;
+        }
+        fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodl(__x: u128, __y: u128) -> u128;
+        }
+        __fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dreml(__x: u128, __y: u128) -> u128;
+        }
+        dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dreml(__x: u128, __y: u128) -> u128;
+        }
+        __dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandl(__x: u128) -> u128;
+        }
+        significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandl(__x: u128) -> u128;
+        }
+        __significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignl(__x: u128, __y: u128) -> u128;
+        }
+        copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignl(__x: u128, __y: u128) -> u128;
+        }
+        __copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        __nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0l(arg1: u128) -> u128;
+        }
+        j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0l(arg1: u128) -> u128;
+        }
+        __j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1l(arg1: u128) -> u128;
+        }
+        j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1l(arg1: u128) -> u128;
+        }
+        __j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0l(arg1: u128) -> u128;
+        }
+        y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0l(arg1: u128) -> u128;
+        }
+        __y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1l(arg1: u128) -> u128;
+        }
+        y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1l(arg1: u128) -> u128;
+        }
+        __y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfl(arg1: u128) -> u128;
+        }
+        erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfl(arg1: u128) -> u128;
+        }
+        __erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcl(arg1: u128) -> u128;
+        }
+        erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcl(arg1: u128) -> u128;
+        }
+        __erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal(arg1: u128) -> u128;
+        }
+        lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal(arg1: u128) -> u128;
+        }
+        __lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammal(arg1: u128) -> u128;
+        }
+        tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammal(arg1: u128) -> u128;
+        }
+        __tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammal(arg1: u128) -> u128;
+        }
+        gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammal(arg1: u128) -> u128;
+        }
+        __gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintl(__x: u128) -> u128;
+        }
+        rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintl(__x: u128) -> u128;
+        }
+        __rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        __nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        __nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderl(__x: u128, __y: u128) -> u128;
+        }
+        remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderl(__x: u128, __y: u128) -> u128;
+        }
+        __remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        __scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        __ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        __scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintl(__x: u128) -> u128;
+        }
+        nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintl(__x: u128) -> u128;
+        }
+        __nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundl(__x: u128) -> u128;
+        }
+        roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundl(__x: u128) -> u128;
+        }
+        __roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncl(__x: u128) -> u128;
+        }
+        truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncl(__x: u128) -> u128;
+        }
+        __truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquol(arg___x: u128, arg___y: u128, arg___quo: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquol(
+    arg___x: u128,
+    arg___y: u128,
+    arg___quo: *mut ::std::os::raw::c_int,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdiml(__x: u128, __y: u128) -> u128;
+        }
+        fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdiml(__x: u128, __y: u128) -> u128;
+        }
+        __fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        __fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminl(__x: u128, __y: u128) -> u128;
+        }
+        fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminl(__x: u128, __y: u128) -> u128;
+        }
+        __fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        __fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbl(__x: u128, __n: u128) -> u128;
+        }
+        scalbl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbl(__x: u128, __n: u128) -> u128;
+        }
+        __scalbl(arg___x, arg___n)
     })
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-impl Default for exception {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub const FP_NAN: _bindgen_ty_8 = 0;
+pub const FP_INFINITE: _bindgen_ty_8 = 1;
+pub const FP_ZERO: _bindgen_ty_8 = 2;
+pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
+pub const FP_NORMAL: _bindgen_ty_8 = 4;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn explicit_bzero(arg_buf: *mut ::std::os::raw::c_void, arg_len: usize) {
+pub unsafe fn strlcat(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn explicit_bzero(buf: *mut ::std::os::raw::c_void, len: usize);
+            pub fn strlcat(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
         }
-        explicit_bzero(arg_buf, arg_len)
+        strlcat(arg_dst, arg_src, arg_siz)
+    })
+}
+#[track_caller]
+pub unsafe fn strlcpy(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlcpy(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strlcpy(arg_dst, arg_src, arg_siz)
     })
 }
 #[track_caller]
@@ -14038,17 +14988,16 @@ pub unsafe fn wait_result_is_any_signal(
         wait_result_is_any_signal(arg_exit_status, arg_include_command_not_found)
     })
 }
-pub type jmp_buf = [::std::os::raw::c_int; 48usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 49usize];
-#[track_caller]
-pub unsafe fn longjmperror() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn longjmperror();
-        }
-        longjmperror()
-    })
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
 }
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[track_caller]
 pub unsafe fn message_level_is_interesting(arg_elevel: ::std::os::raw::c_int) -> bool {
     crate::ffi::pg_guard_ffi_boundary(move || {
@@ -16935,390 +17884,147 @@ pub unsafe fn HeapTupleGetUpdateXid(arg_tuple: HeapTupleHeader) -> TransactionId
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
-#[track_caller]
-pub unsafe fn open(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        open(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn openat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn openat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        openat(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn creat(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: mode_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn creat(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: mode_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        creat(arg_arg1, arg_arg2)
-    })
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
 #[track_caller]
 pub unsafe fn fcntl(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fcntl(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        fcntl(arg_arg1, arg_arg2)
+        fcntl(arg___fd, arg___cmd)
     })
 }
 #[track_caller]
-pub unsafe fn openx_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: filesec_t,
+pub unsafe fn open(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openx_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: filesec_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        openx_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn open_dprotected_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open_dprotected_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn open(
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        open_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        open(arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_dprotected_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: ::std::os::raw::c_int,
+pub unsafe fn openat(
+    arg___fd: ::std::os::raw::c_int,
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_dprotected_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-                arg5: ::std::os::raw::c_int,
+            pub fn openat(
+                __fd: ::std::os::raw::c_int,
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        openat_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        openat(arg___fd, arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_authenticated_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
+pub unsafe fn creat(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___mode: mode_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_authenticated_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn creat(
+                __file: *const ::std::os::raw::c_char,
+                __mode: mode_t,
             ) -> ::std::os::raw::c_int;
         }
-        openat_authenticated_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        creat(arg___file, arg___mode)
     })
 }
 #[track_caller]
-pub unsafe fn flock(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn lockf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flock(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+            pub fn lockf(
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        flock(arg_arg1, arg_arg2)
+        lockf(arg___fd, arg___cmd, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_init() -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_init() -> filesec_t;
-        }
-        filesec_init()
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_dup(arg_arg1: filesec_t) -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-        }
-        filesec_dup(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_free(arg_arg1: filesec_t) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_free(arg1: filesec_t);
-        }
-        filesec_free(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_get_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_void,
+pub unsafe fn posix_fadvise(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
+    arg___advise: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_get_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_void,
+            pub fn posix_fadvise(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
+                __advise: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_get_property(arg_arg1, arg_arg2, arg_arg3)
+        posix_fadvise(arg___fd, arg___offset, arg___len, arg___advise)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_query_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_int,
+pub unsafe fn posix_fallocate(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_query_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_int,
+            pub fn posix_fallocate(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_query_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_set_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *const ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_set_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_set_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_unset_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_unset_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_unset_property(arg_arg1, arg_arg2)
+        posix_fallocate(arg___fd, arg___offset, arg___len)
     })
 }
 pub type XLogRecPtr = uint64;
@@ -19123,7 +19829,7 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
@@ -19134,26 +19840,11 @@ impl Default for tm {
         }
     }
 }
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[track_caller]
-pub unsafe fn asctime(arg_arg1: *const tm) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
-        }
-        asctime(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[track_caller]
 pub unsafe fn clock() -> clock_t {
@@ -19165,103 +19856,167 @@ pub unsafe fn clock() -> clock_t {
     })
 }
 #[track_caller]
-pub unsafe fn ctime(arg_arg1: *const time_t) -> *mut ::std::os::raw::c_char {
+pub unsafe fn time(arg___timer: *mut time_t) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+            pub fn time(__timer: *mut time_t) -> time_t;
         }
-        ctime(arg_arg1)
+        time(arg___timer)
     })
 }
 #[track_caller]
-pub unsafe fn difftime(arg_arg1: time_t, arg_arg2: time_t) -> f64 {
+pub unsafe fn difftime(arg___time1: time_t, arg___time0: time_t) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+            pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
         }
-        difftime(arg_arg1, arg_arg2)
+        difftime(arg___time1, arg___time0)
     })
 }
 #[track_caller]
-pub unsafe fn getdate(arg_arg1: *const ::std::os::raw::c_char) -> *mut tm {
+pub unsafe fn mktime(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+            pub fn mktime(__tp: *mut tm) -> time_t;
         }
-        getdate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gmtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gmtime(arg1: *const time_t) -> *mut tm;
-        }
-        gmtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime(arg1: *const time_t) -> *mut tm;
-        }
-        localtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mktime(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mktime(arg1: *mut tm) -> time_t;
-        }
-        mktime(arg_arg1)
+        mktime(arg___tp)
     })
 }
 #[track_caller]
 pub unsafe fn strftime(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const tm,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
 ) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strftime(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const tm,
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
             ) -> usize;
         }
-        strftime(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        strftime(arg___s, arg___maxsize, arg___format, arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn strptime(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut tm,
+pub unsafe fn strftime_l(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
+    arg___loc: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strftime_l(
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
+                __loc: locale_t,
+            ) -> usize;
+        }
+        strftime_l(arg___s, arg___maxsize, arg___format, arg___tp, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime(__timer: *const time_t) -> *mut tm;
+        }
+        gmtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime(__timer: *const time_t) -> *mut tm;
+        }
+        localtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        gmtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        localtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime(arg___tp: *const tm) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+        }
+        asctime(arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn ctime(arg___timer: *const time_t) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+        }
+        ctime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime_r(
+    arg___tp: *const tm,
+    arg___buf: *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strptime(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut tm,
+            pub fn asctime_r(
+                __tp: *const tm,
+                __buf: *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strptime(arg_arg1, arg_arg2, arg_arg3)
+        asctime_r(arg___tp, arg___buf)
     })
 }
 #[track_caller]
-pub unsafe fn time(arg_arg1: *mut time_t) -> time_t {
+pub unsafe fn ctime_r(
+    arg___timer: *const time_t,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn time(arg1: *mut time_t) -> time_t;
+            pub fn ctime_r(
+                __timer: *const time_t,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        time(arg_arg1)
+        ctime_r(arg___timer, arg___buf)
     })
+}
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[track_caller]
 pub unsafe fn tzset() {
@@ -19272,123 +20027,54 @@ pub unsafe fn tzset() {
         tzset()
     })
 }
+extern "C" {
+    pub static mut daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut timezone: ::std::os::raw::c_long;
+}
 #[track_caller]
-pub unsafe fn asctime_r(
-    arg_arg1: *const tm,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timegm(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asctime_r(
-                arg1: *const tm,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timegm(__tp: *mut tm) -> time_t;
         }
-        asctime_r(arg_arg1, arg_arg2)
+        timegm(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn ctime_r(
-    arg_arg1: *const time_t,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timelocal(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime_r(
-                arg1: *const time_t,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timelocal(__tp: *mut tm) -> time_t;
         }
-        ctime_r(arg_arg1, arg_arg2)
+        timelocal(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn gmtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
+pub unsafe fn dysize(arg___year: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+            pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        gmtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
-        }
-        localtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn posix2time(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix2time(arg1: time_t) -> time_t;
-        }
-        posix2time(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tzsetwall() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tzsetwall();
-        }
-        tzsetwall()
-    })
-}
-#[track_caller]
-pub unsafe fn time2posix(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn time2posix(arg1: time_t) -> time_t;
-        }
-        time2posix(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timelocal(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timelocal(arg1: *mut tm) -> time_t;
-        }
-        timelocal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timegm(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timegm(arg1: *mut tm) -> time_t;
-        }
-        timegm(arg_arg1)
+        dysize(arg___year)
     })
 }
 #[track_caller]
 pub unsafe fn nanosleep(
-    arg___rqtp: *const timespec,
-    arg___rmtp: *mut timespec,
+    arg___requested_time: *const timespec,
+    arg___remaining: *mut timespec,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn nanosleep(
-                __rqtp: *const timespec,
-                __rmtp: *mut timespec,
+                __requested_time: *const timespec,
+                __remaining: *mut timespec,
             ) -> ::std::os::raw::c_int;
         }
-        nanosleep(arg___rqtp, arg___rmtp)
+        nanosleep(arg___requested_time, arg___remaining)
     })
 }
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn clock_getres(
     arg___clock_id: clockid_t,
@@ -19420,15 +20106,6 @@ pub unsafe fn clock_gettime(
     })
 }
 #[track_caller]
-pub unsafe fn clock_gettime_nsec_np(arg___clock_id: clockid_t) -> __uint64_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-        }
-        clock_gettime_nsec_np(arg___clock_id)
-    })
-}
-#[track_caller]
 pub unsafe fn clock_settime(
     arg___clock_id: clockid_t,
     arg___tp: *const timespec,
@@ -19444,18 +20121,121 @@ pub unsafe fn clock_settime(
     })
 }
 #[track_caller]
+pub unsafe fn clock_nanosleep(
+    arg___clock_id: clockid_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___req: *const timespec,
+    arg___rem: *mut timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_nanosleep(
+                __clock_id: clockid_t,
+                __flags: ::std::os::raw::c_int,
+                __req: *const timespec,
+                __rem: *mut timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_nanosleep(arg___clock_id, arg___flags, arg___req, arg___rem)
+    })
+}
+#[track_caller]
+pub unsafe fn clock_getcpuclockid(
+    arg___pid: pid_t,
+    arg___clock_id: *mut clockid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_getcpuclockid(
+                __pid: pid_t,
+                __clock_id: *mut clockid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_getcpuclockid(arg___pid, arg___clock_id)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_create(
+    arg___clock_id: clockid_t,
+    arg___evp: *mut sigevent,
+    arg___timerid: *mut timer_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_create(
+                __clock_id: clockid_t,
+                __evp: *mut sigevent,
+                __timerid: *mut timer_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_create(arg___clock_id, arg___evp, arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_delete(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_delete(arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_settime(
+    arg___timerid: timer_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___value: *const itimerspec,
+    arg___ovalue: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_settime(
+                __timerid: timer_t,
+                __flags: ::std::os::raw::c_int,
+                __value: *const itimerspec,
+                __ovalue: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_settime(arg___timerid, arg___flags, arg___value, arg___ovalue)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_gettime(
+    arg___timerid: timer_t,
+    arg___value: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_gettime(
+                __timerid: timer_t,
+                __value: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_gettime(arg___timerid, arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_getoverrun(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_getoverrun(arg___timerid)
+    })
+}
+#[track_caller]
 pub unsafe fn timespec_get(
-    arg_ts: *mut timespec,
-    arg_base: ::std::os::raw::c_int,
+    arg___ts: *mut timespec,
+    arg___base: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn timespec_get(
-                ts: *mut timespec,
-                base: ::std::os::raw::c_int,
+                __ts: *mut timespec,
+                __base: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        timespec_get(arg_ts, arg_base)
+        timespec_get(arg___ts, arg___base)
     })
 }
 pub type instr_time = timespec;
@@ -23753,7 +24533,7 @@ impl Default for PlanInvalItem {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct pg_atomic_flag {
-    pub value: ::std::os::raw::c_int,
+    pub value: ::std::os::raw::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -24490,7 +25270,7 @@ pub struct proclist_mutable_iter {
     pub cur: ::std::os::raw::c_int,
     pub next: ::std::os::raw::c_int,
 }
-pub type slock_t = ::std::os::raw::c_int;
+pub type slock_t = ::std::os::raw::c_uchar;
 extern "C" {
     pub static mut dummy_spinlock: slock_t;
 }
@@ -25167,12 +25947,11 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
@@ -25183,146 +25962,119 @@ impl Default for dirent {
         }
     }
 }
+pub const DT_UNKNOWN: _bindgen_ty_9 = 0;
+pub const DT_FIFO: _bindgen_ty_9 = 1;
+pub const DT_CHR: _bindgen_ty_9 = 2;
+pub const DT_DIR: _bindgen_ty_9 = 4;
+pub const DT_BLK: _bindgen_ty_9 = 6;
+pub const DT_REG: _bindgen_ty_9 = 8;
+pub const DT_LNK: _bindgen_ty_9 = 10;
+pub const DT_SOCK: _bindgen_ty_9 = 12;
+pub const DT_WHT: _bindgen_ty_9 = 14;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type DIR = __dirstream;
 #[track_caller]
-pub unsafe fn closedir(arg_arg1: *mut DIR) -> ::std::os::raw::c_int {
+pub unsafe fn closedir(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+            pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        closedir(arg_arg1)
+        closedir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn opendir(arg_arg1: *const ::std::os::raw::c_char) -> *mut DIR {
+pub unsafe fn opendir(arg___name: *const ::std::os::raw::c_char) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+            pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
         }
-        opendir(arg_arg1)
+        opendir(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn readdir(arg_arg1: *mut DIR) -> *mut dirent {
+pub unsafe fn fdopendir(arg___fd: ::std::os::raw::c_int) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+            pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
         }
-        readdir(arg_arg1)
+        fdopendir(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn readdir(arg___dirp: *mut DIR) -> *mut dirent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+        }
+        readdir(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn readdir_r(
-    arg_arg1: *mut DIR,
-    arg_arg2: *mut dirent,
-    arg_arg3: *mut *mut dirent,
+    arg___dirp: *mut DIR,
+    arg___entry: *mut dirent,
+    arg___result: *mut *mut dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn readdir_r(
-                arg1: *mut DIR,
-                arg2: *mut dirent,
-                arg3: *mut *mut dirent,
+                __dirp: *mut DIR,
+                __entry: *mut dirent,
+                __result: *mut *mut dirent,
             ) -> ::std::os::raw::c_int;
         }
-        readdir_r(arg_arg1, arg_arg2, arg_arg3)
+        readdir_r(arg___dirp, arg___entry, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn rewinddir(arg_arg1: *mut DIR) {
+pub unsafe fn rewinddir(arg___dirp: *mut DIR) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rewinddir(arg1: *mut DIR);
+            pub fn rewinddir(__dirp: *mut DIR);
         }
-        rewinddir(arg_arg1)
+        rewinddir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn seekdir(arg_arg1: *mut DIR, arg_arg2: ::std::os::raw::c_long) {
+pub unsafe fn seekdir(arg___dirp: *mut DIR, arg___pos: ::std::os::raw::c_long) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+            pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
         }
-        seekdir(arg_arg1, arg_arg2)
+        seekdir(arg___dirp, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn telldir(arg_arg1: *mut DIR) -> ::std::os::raw::c_long {
+pub unsafe fn telldir(arg___dirp: *mut DIR) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+            pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
         }
-        telldir(arg_arg1)
+        telldir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn fdopendir(arg_arg1: ::std::os::raw::c_int) -> *mut DIR {
+pub unsafe fn dirfd(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+            pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        fdopendir(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn alphasort(
-    arg_arg1: *mut *const dirent,
-    arg_arg2: *mut *const dirent,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alphasort(
-                arg1: *mut *const dirent,
-                arg2: *mut *const dirent,
-            ) -> ::std::os::raw::c_int;
-        }
-        alphasort(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn dirfd(arg_dirp: *mut DIR) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-        }
-        dirfd(arg_dirp)
+        dirfd(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn scandir(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: ::std::option::Option<
+    arg___dir: *const ::std::os::raw::c_char,
+    arg___namelist: *mut *mut *mut dirent,
+    arg___selector: ::std::option::Option<
         unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
     >,
-    arg_arg4: ::std::option::Option<
+    arg___cmp: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut *const dirent,
             arg2: *mut *const dirent,
@@ -25332,12 +26084,12 @@ pub unsafe fn scandir(
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn scandir(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: ::std::option::Option<
+                __dir: *const ::std::os::raw::c_char,
+                __namelist: *mut *mut *mut dirent,
+                __selector: ::std::option::Option<
                     unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
                 >,
-                arg4: ::std::option::Option<
+                __cmp: ::std::option::Option<
                     unsafe extern "C" fn(
                         arg1: *mut *const dirent,
                         arg2: *mut *const dirent,
@@ -25345,61 +26097,41 @@ pub unsafe fn scandir(
                 >,
             ) -> ::std::os::raw::c_int;
         }
-        scandir(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        scandir(arg___dir, arg___namelist, arg___selector, arg___cmp)
     })
 }
 #[track_caller]
-pub unsafe fn scandir_b(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: *mut ::std::os::raw::c_void,
+pub unsafe fn alphasort(
+    arg___e1: *mut *const dirent,
+    arg___e2: *mut *const dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scandir_b(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: *mut ::std::os::raw::c_void,
+            pub fn alphasort(
+                __e1: *mut *const dirent,
+                __e2: *mut *const dirent,
             ) -> ::std::os::raw::c_int;
         }
-        scandir_b(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        alphasort(arg___e1, arg___e2)
     })
 }
 #[track_caller]
 pub unsafe fn getdirentries(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___nbytes: usize,
+    arg___basep: *mut __off_t,
+) -> __ssize_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
             pub fn getdirentries(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __nbytes: usize,
+                __basep: *mut __off_t,
+            ) -> __ssize_t;
         }
-        getdirentries(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __opendir2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut DIR {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __opendir2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut DIR;
-        }
-        __opendir2(arg_arg1, arg_arg2)
+        getdirentries(arg___fd, arg___buf, arg___nbytes, arg___basep)
     })
 }
 pub const RecoveryInitSyncMethod_RECOVERY_INIT_SYNC_METHOD_FSYNC: RecoveryInitSyncMethod = 0;
@@ -37111,356 +37843,943 @@ pub unsafe fn extract_variadic_args(
         )
     })
 }
-extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
 }
-extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+impl Default for sigval {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const SI_ASYNCNL: _bindgen_ty_10 = -60;
+pub const SI_DETHREAD: _bindgen_ty_10 = -7;
+pub const SI_TKILL: _bindgen_ty_10 = -6;
+pub const SI_SIGIO: _bindgen_ty_10 = -5;
+pub const SI_ASYNCIO: _bindgen_ty_10 = -4;
+pub const SI_MESGQ: _bindgen_ty_10 = -3;
+pub const SI_TIMER: _bindgen_ty_10 = -2;
+pub const SI_QUEUE: _bindgen_ty_10 = -1;
+pub const SI_USER: _bindgen_ty_10 = 0;
+pub const SI_KERNEL: _bindgen_ty_10 = 128;
+pub type _bindgen_ty_10 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: _bindgen_ty_11 = 1;
+pub const ILL_ILLOPN: _bindgen_ty_11 = 2;
+pub const ILL_ILLADR: _bindgen_ty_11 = 3;
+pub const ILL_ILLTRP: _bindgen_ty_11 = 4;
+pub const ILL_PRVOPC: _bindgen_ty_11 = 5;
+pub const ILL_PRVREG: _bindgen_ty_11 = 6;
+pub const ILL_COPROC: _bindgen_ty_11 = 7;
+pub const ILL_BADSTK: _bindgen_ty_11 = 8;
+pub const ILL_BADIADDR: _bindgen_ty_11 = 9;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: _bindgen_ty_12 = 1;
+pub const FPE_INTOVF: _bindgen_ty_12 = 2;
+pub const FPE_FLTDIV: _bindgen_ty_12 = 3;
+pub const FPE_FLTOVF: _bindgen_ty_12 = 4;
+pub const FPE_FLTUND: _bindgen_ty_12 = 5;
+pub const FPE_FLTRES: _bindgen_ty_12 = 6;
+pub const FPE_FLTINV: _bindgen_ty_12 = 7;
+pub const FPE_FLTSUB: _bindgen_ty_12 = 8;
+pub const FPE_FLTUNK: _bindgen_ty_12 = 14;
+pub const FPE_CONDTRAP: _bindgen_ty_12 = 15;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: _bindgen_ty_13 = 1;
+pub const SEGV_ACCERR: _bindgen_ty_13 = 2;
+pub const SEGV_BNDERR: _bindgen_ty_13 = 3;
+pub const SEGV_PKUERR: _bindgen_ty_13 = 4;
+pub const SEGV_ACCADI: _bindgen_ty_13 = 5;
+pub const SEGV_ADIDERR: _bindgen_ty_13 = 6;
+pub const SEGV_ADIPERR: _bindgen_ty_13 = 7;
+pub const SEGV_MTEAERR: _bindgen_ty_13 = 8;
+pub const SEGV_MTESERR: _bindgen_ty_13 = 9;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: _bindgen_ty_14 = 1;
+pub const BUS_ADRERR: _bindgen_ty_14 = 2;
+pub const BUS_OBJERR: _bindgen_ty_14 = 3;
+pub const BUS_MCEERR_AR: _bindgen_ty_14 = 4;
+pub const BUS_MCEERR_AO: _bindgen_ty_14 = 5;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: _bindgen_ty_15 = 1;
+pub const CLD_KILLED: _bindgen_ty_15 = 2;
+pub const CLD_DUMPED: _bindgen_ty_15 = 3;
+pub const CLD_TRAPPED: _bindgen_ty_15 = 4;
+pub const CLD_STOPPED: _bindgen_ty_15 = 5;
+pub const CLD_CONTINUED: _bindgen_ty_15 = 6;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
+pub const POLL_IN: _bindgen_ty_16 = 1;
+pub const POLL_OUT: _bindgen_ty_16 = 2;
+pub const POLL_MSG: _bindgen_ty_16 = 3;
+pub const POLL_ERR: _bindgen_ty_16 = 4;
+pub const POLL_PRI: _bindgen_ty_16 = 5;
+pub const POLL_HUP: _bindgen_ty_16 = 6;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: _bindgen_ty_17 = 0;
+pub const SIGEV_NONE: _bindgen_ty_17 = 1;
+pub const SIGEV_THREAD: _bindgen_ty_17 = 2;
+pub const SIGEV_THREAD_ID: _bindgen_ty_17 = 4;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[track_caller]
-pub unsafe fn raise(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __sysv_signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __sysv_signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        raise(arg_arg1)
+        __sysv_signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn bsd_signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bsd_signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        bsd_signal(arg_arg1, arg_arg2)
+        signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn kill(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn kill(arg___pid: __pid_t, arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        kill(arg_arg1, arg_arg2)
+        kill(arg___pid, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn killpg(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        killpg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pthread_kill(
-    arg_arg1: pthread_t,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn killpg(
+    arg___pgrp: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_kill(
-                arg1: pthread_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_kill(arg_arg1, arg_arg2)
+        killpg(arg___pgrp, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn pthread_sigmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
-) -> ::std::os::raw::c_int {
+pub unsafe fn raise(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_sigmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
-            ) -> ::std::os::raw::c_int;
+            pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_sigmask(arg_arg1, arg_arg2, arg_arg3)
+        raise(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn sigaction(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigaction,
-    arg_arg3: *mut sigaction,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ssignal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigaction(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigaction,
-                arg3: *mut sigaction,
-            ) -> ::std::os::raw::c_int;
+            pub fn ssignal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        sigaction(arg_arg1, arg_arg2, arg_arg3)
+        ssignal(arg___sig, arg___handler)
+    })
+}
+#[track_caller]
+pub unsafe fn gsignal(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        gsignal(arg___sig)
+    })
+}
+#[track_caller]
+pub unsafe fn psignal(arg___sig: ::std::os::raw::c_int, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
+        }
+        psignal(arg___sig, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn psiginfo(arg___pinfo: *const siginfo_t, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
+        }
+        psiginfo(arg___pinfo, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn sigblock(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigblock(arg___mask)
+    })
+}
+#[track_caller]
+pub unsafe fn sigsetmask(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigsetmask(arg___mask)
+    })
+}
+pub type sig_t = __sighandler_t;
+#[track_caller]
+pub unsafe fn sigemptyset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigemptyset(arg___set)
+    })
+}
+#[track_caller]
+pub unsafe fn sigfillset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigfillset(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigaddset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigaddset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigaddset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigaltstack(
-    arg_arg1: *const stack_t,
-    arg_arg2: *mut stack_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
-        }
-        sigaltstack(arg_arg1, arg_arg2)
+        sigaddset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigdelset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigdelset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigdelset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigemptyset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigemptyset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigfillset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigfillset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sighold(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sighold(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigignore(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigignore(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn siginterrupt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn siginterrupt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        siginterrupt(arg_arg1, arg_arg2)
+        sigdelset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigismember(
-    arg_arg1: *const sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigismember(
-                arg1: *const sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigismember(arg_arg1, arg_arg2)
+        sigismember(arg___set, arg___signo)
     })
 }
-#[track_caller]
-pub unsafe fn sigpause(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigpause(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
 }
-#[track_caller]
-pub unsafe fn sigpending(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        sigpending(arg_arg1)
-    })
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[track_caller]
 pub unsafe fn sigprocmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
+    arg___how: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___oset: *mut sigset_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigprocmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
+                __how: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __oset: *mut sigset_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigprocmask(arg_arg1, arg_arg2, arg_arg3)
+        sigprocmask(arg___how, arg___set, arg___oset)
     })
 }
 #[track_caller]
-pub unsafe fn sigrelse(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn sigsuspend(arg___set: *const sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
         }
-        sigrelse(arg_arg1)
+        sigsuspend(arg___set)
     })
 }
 #[track_caller]
-pub unsafe fn sigset(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn sigaction(
+    arg___sig: ::std::os::raw::c_int,
+    arg___act: *const sigaction,
+    arg___oact: *mut sigaction,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigset(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn sigaction(
+                __sig: ::std::os::raw::c_int,
+                __act: *const sigaction,
+                __oact: *mut sigaction,
+            ) -> ::std::os::raw::c_int;
         }
-        sigset(arg_arg1, arg_arg2)
+        sigaction(arg___sig, arg___act, arg___oact)
     })
 }
 #[track_caller]
-pub unsafe fn sigsuspend(arg_arg1: *const sigset_t) -> ::std::os::raw::c_int {
+pub unsafe fn sigpending(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+            pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
         }
-        sigsuspend(arg_arg1)
+        sigpending(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigwait(
-    arg_arg1: *const sigset_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___sig: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigwait(
-                arg1: *const sigset_t,
-                arg2: *mut ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __sig: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigwait(arg_arg1, arg_arg2)
+        sigwait(arg___set, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn psignal(arg_arg1: ::std::os::raw::c_uint, arg_arg2: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
-        }
-        psignal(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigblock(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigblock(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigsetmask(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigsetmask(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigvec(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sigvec,
-    arg_arg3: *mut sigvec,
+pub unsafe fn sigwaitinfo(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigvec(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sigvec,
-                arg3: *mut sigvec,
+            pub fn sigwaitinfo(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigvec(arg_arg1, arg_arg2, arg_arg3)
+        sigwaitinfo(arg___set, arg___info)
+    })
+}
+#[track_caller]
+pub unsafe fn sigtimedwait(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
+    arg___timeout: *const timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigtimedwait(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
+                __timeout: *const timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigtimedwait(arg___set, arg___info, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn sigqueue(
+    arg___pid: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
+    arg___val: sigval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigqueue(
+                __pid: __pid_t,
+                __sig: ::std::os::raw::c_int,
+                __val: sigval,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigqueue(arg___pid, arg___sig, arg___val)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn siginterrupt(
+    arg___sig: ::std::os::raw::c_int,
+    arg___interrupt: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn siginterrupt(
+                __sig: ::std::os::raw::c_int,
+                __interrupt: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        siginterrupt(arg___sig, arg___interrupt)
+    })
+}
+pub const SS_ONSTACK: _bindgen_ty_18 = 1;
+pub const SS_DISABLE: _bindgen_ty_18 = 2;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
+#[track_caller]
+pub unsafe fn sigaltstack(
+    arg___ss: *const stack_t,
+    arg___oss: *mut stack_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+        }
+        sigaltstack(arg___ss, arg___oss)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn pthread_sigmask(
+    arg___how: ::std::os::raw::c_int,
+    arg___newmask: *const __sigset_t,
+    arg___oldmask: *mut __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_sigmask(
+                __how: ::std::os::raw::c_int,
+                __newmask: *const __sigset_t,
+                __oldmask: *mut __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_sigmask(arg___how, arg___newmask, arg___oldmask)
+    })
+}
+#[track_caller]
+pub unsafe fn pthread_kill(
+    arg___threadid: pthread_t,
+    arg___signo: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_kill(
+                __threadid: pthread_t,
+                __signo: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_kill(arg___threadid, arg___signo)
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmin() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmin()
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmax() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmax()
     })
 }
 pub type pg_time_t = int64;
@@ -38618,9 +39937,8 @@ pub unsafe fn pgstat_progress_end_command() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -41576,20 +42894,46 @@ pub const RmgrIds_RM_NEXT_ID: RmgrIds = 22;
 pub type RmgrIds = ::std::os::raw::c_uint;
 pub type pg_crc32c = uint32;
 #[track_caller]
-pub unsafe fn pg_comp_crc32c_armv8(
+pub unsafe fn pg_comp_crc32c_sb8(
     arg_crc: pg_crc32c,
     arg_data: *const ::std::os::raw::c_void,
     arg_len: usize,
 ) -> pg_crc32c {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pg_comp_crc32c_armv8(
+            pub fn pg_comp_crc32c_sb8(
                 crc: pg_crc32c,
                 data: *const ::std::os::raw::c_void,
                 len: usize,
             ) -> pg_crc32c;
         }
-        pg_comp_crc32c_armv8(arg_crc, arg_data, arg_len)
+        pg_comp_crc32c_sb8(arg_crc, arg_data, arg_len)
+    })
+}
+extern "C" {
+    pub static mut pg_comp_crc32c: ::std::option::Option<
+        unsafe extern "C" fn(
+            crc: pg_crc32c,
+            data: *const ::std::os::raw::c_void,
+            len: usize,
+        ) -> pg_crc32c,
+    >;
+}
+#[track_caller]
+pub unsafe fn pg_comp_crc32c_sse42(
+    arg_crc: pg_crc32c,
+    arg_data: *const ::std::os::raw::c_void,
+    arg_len: usize,
+) -> pg_crc32c {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pg_comp_crc32c_sse42(
+                crc: pg_crc32c,
+                data: *const ::std::os::raw::c_void,
+                len: usize,
+            ) -> pg_crc32c;
+        }
+        pg_comp_crc32c_sse42(arg_crc, arg_data, arg_len)
     })
 }
 pub const ForkNumber_InvalidForkNumber: ForkNumber = -1;
@@ -112109,8 +113453,29 @@ pub unsafe fn range_split_internal(
         range_split_internal(arg_typcache, arg_r1, arg_r2, arg_output1, arg_output2)
     })
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+impl Default for __va_list_tag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AttrMissing {
@@ -112201,2526 +113566,2947 @@ pub struct ResourceOwnerData {
 pub struct SnapBuild {
     pub _address: u8,
 }
+impl pg_sys::seal::Sealed for A_ArrayExpr {}
 impl pg_sys::PgNode for A_ArrayExpr {}
 impl std::fmt::Display for A_ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Const {}
 impl pg_sys::PgNode for A_Const {}
 impl std::fmt::Display for A_Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Expr {}
 impl pg_sys::PgNode for A_Expr {}
 impl std::fmt::Display for A_Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indices {}
 impl pg_sys::PgNode for A_Indices {}
 impl std::fmt::Display for A_Indices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indirection {}
 impl pg_sys::PgNode for A_Indirection {}
 impl std::fmt::Display for A_Indirection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Star {}
 impl pg_sys::PgNode for A_Star {}
 impl std::fmt::Display for A_Star {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AccessPriv {}
 impl pg_sys::PgNode for AccessPriv {}
 impl std::fmt::Display for AccessPriv {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Agg {}
 impl pg_sys::PgNode for Agg {}
 impl std::fmt::Display for Agg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggPath {}
 impl pg_sys::PgNode for AggPath {}
 impl std::fmt::Display for AggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggState {}
 impl pg_sys::PgNode for AggState {}
 impl std::fmt::Display for AggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Aggref {}
 impl pg_sys::PgNode for Aggref {}
 impl std::fmt::Display for Aggref {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Alias {}
 impl pg_sys::PgNode for Alias {}
 impl std::fmt::Display for Alias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterCollationStmt {}
 impl pg_sys::PgNode for AlterCollationStmt {}
 impl std::fmt::Display for AlterCollationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseSetStmt {}
 impl pg_sys::PgNode for AlterDatabaseSetStmt {}
 impl std::fmt::Display for AlterDatabaseSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseStmt {}
 impl pg_sys::PgNode for AlterDatabaseStmt {}
 impl std::fmt::Display for AlterDatabaseStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDefaultPrivilegesStmt {}
 impl pg_sys::PgNode for AlterDefaultPrivilegesStmt {}
 impl std::fmt::Display for AlterDefaultPrivilegesStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDomainStmt {}
 impl pg_sys::PgNode for AlterDomainStmt {}
 impl std::fmt::Display for AlterDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEnumStmt {}
 impl pg_sys::PgNode for AlterEnumStmt {}
 impl std::fmt::Display for AlterEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEventTrigStmt {}
 impl pg_sys::PgNode for AlterEventTrigStmt {}
 impl std::fmt::Display for AlterEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionContentsStmt {}
 impl pg_sys::PgNode for AlterExtensionContentsStmt {}
 impl std::fmt::Display for AlterExtensionContentsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionStmt {}
 impl pg_sys::PgNode for AlterExtensionStmt {}
 impl std::fmt::Display for AlterExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFdwStmt {}
 impl pg_sys::PgNode for AlterFdwStmt {}
 impl std::fmt::Display for AlterFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterForeignServerStmt {}
 impl pg_sys::PgNode for AlterForeignServerStmt {}
 impl std::fmt::Display for AlterForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFunctionStmt {}
 impl pg_sys::PgNode for AlterFunctionStmt {}
 impl std::fmt::Display for AlterFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectDependsStmt {}
 impl pg_sys::PgNode for AlterObjectDependsStmt {}
 impl std::fmt::Display for AlterObjectDependsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectSchemaStmt {}
 impl pg_sys::PgNode for AlterObjectSchemaStmt {}
 impl std::fmt::Display for AlterObjectSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOpFamilyStmt {}
 impl pg_sys::PgNode for AlterOpFamilyStmt {}
 impl std::fmt::Display for AlterOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOperatorStmt {}
 impl pg_sys::PgNode for AlterOperatorStmt {}
 impl std::fmt::Display for AlterOperatorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOwnerStmt {}
 impl pg_sys::PgNode for AlterOwnerStmt {}
 impl std::fmt::Display for AlterOwnerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPolicyStmt {}
 impl pg_sys::PgNode for AlterPolicyStmt {}
 impl std::fmt::Display for AlterPolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPublicationStmt {}
 impl pg_sys::PgNode for AlterPublicationStmt {}
 impl std::fmt::Display for AlterPublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleSetStmt {}
 impl pg_sys::PgNode for AlterRoleSetStmt {}
 impl std::fmt::Display for AlterRoleSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleStmt {}
 impl pg_sys::PgNode for AlterRoleStmt {}
 impl std::fmt::Display for AlterRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSeqStmt {}
 impl pg_sys::PgNode for AlterSeqStmt {}
 impl std::fmt::Display for AlterSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterStatsStmt {}
 impl pg_sys::PgNode for AlterStatsStmt {}
 impl std::fmt::Display for AlterStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSubscriptionStmt {}
 impl pg_sys::PgNode for AlterSubscriptionStmt {}
 impl std::fmt::Display for AlterSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSystemStmt {}
 impl pg_sys::PgNode for AlterSystemStmt {}
 impl std::fmt::Display for AlterSystemStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSConfigurationStmt {}
 impl pg_sys::PgNode for AlterTSConfigurationStmt {}
 impl std::fmt::Display for AlterTSConfigurationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSDictionaryStmt {}
 impl pg_sys::PgNode for AlterTSDictionaryStmt {}
 impl std::fmt::Display for AlterTSDictionaryStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableCmd {}
 impl pg_sys::PgNode for AlterTableCmd {}
 impl std::fmt::Display for AlterTableCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableMoveAllStmt {}
 impl pg_sys::PgNode for AlterTableMoveAllStmt {}
 impl std::fmt::Display for AlterTableMoveAllStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableSpaceOptionsStmt {}
 impl pg_sys::PgNode for AlterTableSpaceOptionsStmt {}
 impl std::fmt::Display for AlterTableSpaceOptionsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableStmt {}
 impl pg_sys::PgNode for AlterTableStmt {}
 impl std::fmt::Display for AlterTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTypeStmt {}
 impl pg_sys::PgNode for AlterTypeStmt {}
 impl std::fmt::Display for AlterTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterUserMappingStmt {}
 impl pg_sys::PgNode for AlterUserMappingStmt {}
 impl std::fmt::Display for AlterUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlan {}
 impl pg_sys::PgNode for AlternativeSubPlan {}
 impl std::fmt::Display for AlternativeSubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Append {}
 impl pg_sys::PgNode for Append {}
 impl std::fmt::Display for Append {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendPath {}
 impl pg_sys::PgNode for AppendPath {}
 impl std::fmt::Display for AppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendRelInfo {}
 impl pg_sys::PgNode for AppendRelInfo {}
 impl std::fmt::Display for AppendRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendState {}
 impl pg_sys::PgNode for AppendState {}
 impl std::fmt::Display for AppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayCoerceExpr {}
 impl pg_sys::PgNode for ArrayCoerceExpr {}
 impl std::fmt::Display for ArrayCoerceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayExpr {}
 impl pg_sys::PgNode for ArrayExpr {}
 impl std::fmt::Display for ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BaseBackupCmd {}
 impl pg_sys::PgNode for BaseBackupCmd {}
 impl std::fmt::Display for BaseBackupCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAnd {}
 impl pg_sys::PgNode for BitmapAnd {}
 impl std::fmt::Display for BitmapAnd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndPath {}
 impl pg_sys::PgNode for BitmapAndPath {}
 impl std::fmt::Display for BitmapAndPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndState {}
 impl pg_sys::PgNode for BitmapAndState {}
 impl std::fmt::Display for BitmapAndState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapPath {}
 impl pg_sys::PgNode for BitmapHeapPath {}
 impl std::fmt::Display for BitmapHeapPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScan {}
 impl pg_sys::PgNode for BitmapHeapScan {}
 impl std::fmt::Display for BitmapHeapScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScanState {}
 impl pg_sys::PgNode for BitmapHeapScanState {}
 impl std::fmt::Display for BitmapHeapScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScan {}
 impl pg_sys::PgNode for BitmapIndexScan {}
 impl std::fmt::Display for BitmapIndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScanState {}
 impl pg_sys::PgNode for BitmapIndexScanState {}
 impl std::fmt::Display for BitmapIndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOr {}
 impl pg_sys::PgNode for BitmapOr {}
 impl std::fmt::Display for BitmapOr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrPath {}
 impl pg_sys::PgNode for BitmapOrPath {}
 impl std::fmt::Display for BitmapOrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrState {}
 impl pg_sys::PgNode for BitmapOrState {}
 impl std::fmt::Display for BitmapOrState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BoolExpr {}
 impl pg_sys::PgNode for BoolExpr {}
 impl std::fmt::Display for BoolExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BooleanTest {}
 impl pg_sys::PgNode for BooleanTest {}
 impl std::fmt::Display for BooleanTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BufferHeapTupleTableSlot {}
 impl pg_sys::PgNode for BufferHeapTupleTableSlot {}
 impl std::fmt::Display for BufferHeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CTECycleClause {}
 impl pg_sys::PgNode for CTECycleClause {}
 impl std::fmt::Display for CTECycleClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CTESearchClause {}
 impl pg_sys::PgNode for CTESearchClause {}
 impl std::fmt::Display for CTESearchClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallContext {}
 impl pg_sys::PgNode for CallContext {}
 impl std::fmt::Display for CallContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallStmt {}
 impl pg_sys::PgNode for CallStmt {}
 impl std::fmt::Display for CallStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseExpr {}
 impl pg_sys::PgNode for CaseExpr {}
 impl std::fmt::Display for CaseExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseTestExpr {}
 impl pg_sys::PgNode for CaseTestExpr {}
 impl std::fmt::Display for CaseTestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseWhen {}
 impl pg_sys::PgNode for CaseWhen {}
 impl std::fmt::Display for CaseWhen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CheckPointStmt {}
 impl pg_sys::PgNode for CheckPointStmt {}
 impl std::fmt::Display for CheckPointStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClosePortalStmt {}
 impl pg_sys::PgNode for ClosePortalStmt {}
 impl std::fmt::Display for ClosePortalStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClusterStmt {}
 impl pg_sys::PgNode for ClusterStmt {}
 impl std::fmt::Display for ClusterStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoalesceExpr {}
 impl pg_sys::PgNode for CoalesceExpr {}
 impl std::fmt::Display for CoalesceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomain {}
 impl pg_sys::PgNode for CoerceToDomain {}
 impl std::fmt::Display for CoerceToDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomainValue {}
 impl pg_sys::PgNode for CoerceToDomainValue {}
 impl std::fmt::Display for CoerceToDomainValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceViaIO {}
 impl pg_sys::PgNode for CoerceViaIO {}
 impl std::fmt::Display for CoerceViaIO {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateClause {}
 impl pg_sys::PgNode for CollateClause {}
 impl std::fmt::Display for CollateClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateExpr {}
 impl pg_sys::PgNode for CollateExpr {}
 impl std::fmt::Display for CollateExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnDef {}
 impl pg_sys::PgNode for ColumnDef {}
 impl std::fmt::Display for ColumnDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnRef {}
 impl pg_sys::PgNode for ColumnRef {}
 impl std::fmt::Display for ColumnRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommentStmt {}
 impl pg_sys::PgNode for CommentStmt {}
 impl std::fmt::Display for CommentStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommonTableExpr {}
 impl pg_sys::PgNode for CommonTableExpr {}
 impl std::fmt::Display for CommonTableExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CompositeTypeStmt {}
 impl pg_sys::PgNode for CompositeTypeStmt {}
 impl std::fmt::Display for CompositeTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Const {}
 impl pg_sys::PgNode for Const {}
 impl std::fmt::Display for Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Constraint {}
 impl pg_sys::PgNode for Constraint {}
 impl std::fmt::Display for Constraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConstraintsSetStmt {}
 impl pg_sys::PgNode for ConstraintsSetStmt {}
 impl std::fmt::Display for ConstraintsSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConvertRowtypeExpr {}
 impl pg_sys::PgNode for ConvertRowtypeExpr {}
 impl std::fmt::Display for ConvertRowtypeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CopyStmt {}
 impl pg_sys::PgNode for CopyStmt {}
 impl std::fmt::Display for CopyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateAmStmt {}
 impl pg_sys::PgNode for CreateAmStmt {}
 impl std::fmt::Display for CreateAmStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateCastStmt {}
 impl pg_sys::PgNode for CreateCastStmt {}
 impl std::fmt::Display for CreateCastStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateConversionStmt {}
 impl pg_sys::PgNode for CreateConversionStmt {}
 impl std::fmt::Display for CreateConversionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateDomainStmt {}
 impl pg_sys::PgNode for CreateDomainStmt {}
 impl std::fmt::Display for CreateDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEnumStmt {}
 impl pg_sys::PgNode for CreateEnumStmt {}
 impl std::fmt::Display for CreateEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEventTrigStmt {}
 impl pg_sys::PgNode for CreateEventTrigStmt {}
 impl std::fmt::Display for CreateEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateExtensionStmt {}
 impl pg_sys::PgNode for CreateExtensionStmt {}
 impl std::fmt::Display for CreateExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFdwStmt {}
 impl pg_sys::PgNode for CreateFdwStmt {}
 impl std::fmt::Display for CreateFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignServerStmt {}
 impl pg_sys::PgNode for CreateForeignServerStmt {}
 impl std::fmt::Display for CreateForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignTableStmt {}
 impl pg_sys::PgNode for CreateForeignTableStmt {}
 impl std::fmt::Display for CreateForeignTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFunctionStmt {}
 impl pg_sys::PgNode for CreateFunctionStmt {}
 impl std::fmt::Display for CreateFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassItem {}
 impl pg_sys::PgNode for CreateOpClassItem {}
 impl std::fmt::Display for CreateOpClassItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassStmt {}
 impl pg_sys::PgNode for CreateOpClassStmt {}
 impl std::fmt::Display for CreateOpClassStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpFamilyStmt {}
 impl pg_sys::PgNode for CreateOpFamilyStmt {}
 impl std::fmt::Display for CreateOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePLangStmt {}
 impl pg_sys::PgNode for CreatePLangStmt {}
 impl std::fmt::Display for CreatePLangStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePolicyStmt {}
 impl pg_sys::PgNode for CreatePolicyStmt {}
 impl std::fmt::Display for CreatePolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePublicationStmt {}
 impl pg_sys::PgNode for CreatePublicationStmt {}
 impl std::fmt::Display for CreatePublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRangeStmt {}
 impl pg_sys::PgNode for CreateRangeStmt {}
 impl std::fmt::Display for CreateRangeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateReplicationSlotCmd {}
 impl pg_sys::PgNode for CreateReplicationSlotCmd {}
 impl std::fmt::Display for CreateReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRoleStmt {}
 impl pg_sys::PgNode for CreateRoleStmt {}
 impl std::fmt::Display for CreateRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSchemaStmt {}
 impl pg_sys::PgNode for CreateSchemaStmt {}
 impl std::fmt::Display for CreateSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSeqStmt {}
 impl pg_sys::PgNode for CreateSeqStmt {}
 impl std::fmt::Display for CreateSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStatsStmt {}
 impl pg_sys::PgNode for CreateStatsStmt {}
 impl std::fmt::Display for CreateStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStmt {}
 impl pg_sys::PgNode for CreateStmt {}
 impl std::fmt::Display for CreateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSubscriptionStmt {}
 impl pg_sys::PgNode for CreateSubscriptionStmt {}
 impl std::fmt::Display for CreateSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableAsStmt {}
 impl pg_sys::PgNode for CreateTableAsStmt {}
 impl std::fmt::Display for CreateTableAsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableSpaceStmt {}
 impl pg_sys::PgNode for CreateTableSpaceStmt {}
 impl std::fmt::Display for CreateTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTransformStmt {}
 impl pg_sys::PgNode for CreateTransformStmt {}
 impl std::fmt::Display for CreateTransformStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTrigStmt {}
 impl pg_sys::PgNode for CreateTrigStmt {}
 impl std::fmt::Display for CreateTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateUserMappingStmt {}
 impl pg_sys::PgNode for CreateUserMappingStmt {}
 impl std::fmt::Display for CreateUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatedbStmt {}
 impl pg_sys::PgNode for CreatedbStmt {}
 impl std::fmt::Display for CreatedbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScan {}
 impl pg_sys::PgNode for CteScan {}
 impl std::fmt::Display for CteScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScanState {}
 impl pg_sys::PgNode for CteScanState {}
 impl std::fmt::Display for CteScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CurrentOfExpr {}
 impl pg_sys::PgNode for CurrentOfExpr {}
 impl std::fmt::Display for CurrentOfExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomPath {}
 impl pg_sys::PgNode for CustomPath {}
 impl std::fmt::Display for CustomPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScan {}
 impl pg_sys::PgNode for CustomScan {}
 impl std::fmt::Display for CustomScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScanState {}
 impl pg_sys::PgNode for CustomScanState {}
 impl std::fmt::Display for CustomScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeallocateStmt {}
 impl pg_sys::PgNode for DeallocateStmt {}
 impl std::fmt::Display for DeallocateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeclareCursorStmt {}
 impl pg_sys::PgNode for DeclareCursorStmt {}
 impl std::fmt::Display for DeclareCursorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefElem {}
 impl pg_sys::PgNode for DefElem {}
 impl std::fmt::Display for DefElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefineStmt {}
 impl pg_sys::PgNode for DefineStmt {}
 impl std::fmt::Display for DefineStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeleteStmt {}
 impl pg_sys::PgNode for DeleteStmt {}
 impl std::fmt::Display for DeleteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DiscardStmt {}
 impl pg_sys::PgNode for DiscardStmt {}
 impl std::fmt::Display for DiscardStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DoStmt {}
 impl pg_sys::PgNode for DoStmt {}
 impl std::fmt::Display for DoStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DomainConstraintState {}
 impl pg_sys::PgNode for DomainConstraintState {}
 impl std::fmt::Display for DomainConstraintState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropOwnedStmt {}
 impl pg_sys::PgNode for DropOwnedStmt {}
 impl std::fmt::Display for DropOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropReplicationSlotCmd {}
 impl pg_sys::PgNode for DropReplicationSlotCmd {}
 impl std::fmt::Display for DropReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropRoleStmt {}
 impl pg_sys::PgNode for DropRoleStmt {}
 impl std::fmt::Display for DropRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropStmt {}
 impl pg_sys::PgNode for DropStmt {}
 impl std::fmt::Display for DropStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropSubscriptionStmt {}
 impl pg_sys::PgNode for DropSubscriptionStmt {}
 impl std::fmt::Display for DropSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropTableSpaceStmt {}
 impl pg_sys::PgNode for DropTableSpaceStmt {}
 impl std::fmt::Display for DropTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropUserMappingStmt {}
 impl pg_sys::PgNode for DropUserMappingStmt {}
 impl std::fmt::Display for DropUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropdbStmt {}
 impl pg_sys::PgNode for DropdbStmt {}
 impl std::fmt::Display for DropdbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EState {}
 impl pg_sys::PgNode for EState {}
 impl std::fmt::Display for EState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceClass {}
 impl pg_sys::PgNode for EquivalenceClass {}
 impl std::fmt::Display for EquivalenceClass {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceMember {}
 impl pg_sys::PgNode for EquivalenceMember {}
 impl std::fmt::Display for EquivalenceMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EventTriggerData {}
 impl pg_sys::PgNode for EventTriggerData {}
 impl std::fmt::Display for EventTriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExecuteStmt {}
 impl pg_sys::PgNode for ExecuteStmt {}
 impl std::fmt::Display for ExecuteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExplainStmt {}
 impl pg_sys::PgNode for ExplainStmt {}
 impl std::fmt::Display for ExplainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Expr {}
 impl pg_sys::PgNode for Expr {}
 impl std::fmt::Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprContext {}
 impl pg_sys::PgNode for ExprContext {}
 impl std::fmt::Display for ExprContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprState {}
 impl pg_sys::PgNode for ExprState {}
 impl std::fmt::Display for ExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExtensibleNode {}
 impl pg_sys::PgNode for ExtensibleNode {}
 impl std::fmt::Display for ExtensibleNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FdwRoutine {}
 impl pg_sys::PgNode for FdwRoutine {}
 impl std::fmt::Display for FdwRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FetchStmt {}
 impl pg_sys::PgNode for FetchStmt {}
 impl std::fmt::Display for FetchStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldSelect {}
 impl pg_sys::PgNode for FieldSelect {}
 impl std::fmt::Display for FieldSelect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldStore {}
 impl pg_sys::PgNode for FieldStore {}
 impl std::fmt::Display for FieldStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyCacheInfo {}
 impl pg_sys::PgNode for ForeignKeyCacheInfo {}
 impl std::fmt::Display for ForeignKeyCacheInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyOptInfo {}
 impl pg_sys::PgNode for ForeignKeyOptInfo {}
 impl std::fmt::Display for ForeignKeyOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignPath {}
 impl pg_sys::PgNode for ForeignPath {}
 impl std::fmt::Display for ForeignPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScan {}
 impl pg_sys::PgNode for ForeignScan {}
 impl std::fmt::Display for ForeignScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScanState {}
 impl pg_sys::PgNode for ForeignScanState {}
 impl std::fmt::Display for ForeignScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FromExpr {}
 impl pg_sys::PgNode for FromExpr {}
 impl std::fmt::Display for FromExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncCall {}
 impl pg_sys::PgNode for FuncCall {}
 impl std::fmt::Display for FuncCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncExpr {}
 impl pg_sys::PgNode for FuncExpr {}
 impl std::fmt::Display for FuncExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionParameter {}
 impl pg_sys::PgNode for FunctionParameter {}
 impl std::fmt::Display for FunctionParameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScan {}
 impl pg_sys::PgNode for FunctionScan {}
 impl std::fmt::Display for FunctionScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScanState {}
 impl pg_sys::PgNode for FunctionScanState {}
 impl std::fmt::Display for FunctionScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Gather {}
 impl pg_sys::PgNode for Gather {}
 impl std::fmt::Display for Gather {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMerge {}
 impl pg_sys::PgNode for GatherMerge {}
 impl std::fmt::Display for GatherMerge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergePath {}
 impl pg_sys::PgNode for GatherMergePath {}
 impl std::fmt::Display for GatherMergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergeState {}
 impl pg_sys::PgNode for GatherMergeState {}
 impl std::fmt::Display for GatherMergeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherPath {}
 impl pg_sys::PgNode for GatherPath {}
 impl std::fmt::Display for GatherPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherState {}
 impl pg_sys::PgNode for GatherState {}
 impl std::fmt::Display for GatherState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantRoleStmt {}
 impl pg_sys::PgNode for GrantRoleStmt {}
 impl std::fmt::Display for GrantRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantStmt {}
 impl pg_sys::PgNode for GrantStmt {}
 impl std::fmt::Display for GrantStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Group {}
 impl pg_sys::PgNode for Group {}
 impl std::fmt::Display for Group {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupPath {}
 impl pg_sys::PgNode for GroupPath {}
 impl std::fmt::Display for GroupPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupResultPath {}
 impl pg_sys::PgNode for GroupResultPath {}
 impl std::fmt::Display for GroupResultPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupState {}
 impl pg_sys::PgNode for GroupState {}
 impl std::fmt::Display for GroupState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingFunc {}
 impl pg_sys::PgNode for GroupingFunc {}
 impl std::fmt::Display for GroupingFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSet {}
 impl pg_sys::PgNode for GroupingSet {}
 impl std::fmt::Display for GroupingSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetData {}
 impl pg_sys::PgNode for GroupingSetData {}
 impl std::fmt::Display for GroupingSetData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetsPath {}
 impl pg_sys::PgNode for GroupingSetsPath {}
 impl std::fmt::Display for GroupingSetsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Hash {}
 impl pg_sys::PgNode for Hash {}
 impl std::fmt::Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoin {}
 impl pg_sys::PgNode for HashJoin {}
 impl std::fmt::Display for HashJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoinState {}
 impl pg_sys::PgNode for HashJoinState {}
 impl std::fmt::Display for HashJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashPath {}
 impl pg_sys::PgNode for HashPath {}
 impl std::fmt::Display for HashPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashState {}
 impl pg_sys::PgNode for HashState {}
 impl std::fmt::Display for HashState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HeapTupleTableSlot {}
 impl pg_sys::PgNode for HeapTupleTableSlot {}
 impl std::fmt::Display for HeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IdentifySystemCmd {}
 impl pg_sys::PgNode for IdentifySystemCmd {}
 impl std::fmt::Display for IdentifySystemCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ImportForeignSchemaStmt {}
 impl pg_sys::PgNode for ImportForeignSchemaStmt {}
 impl std::fmt::Display for ImportForeignSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSort {}
 impl pg_sys::PgNode for IncrementalSort {}
 impl std::fmt::Display for IncrementalSort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSortPath {}
 impl pg_sys::PgNode for IncrementalSortPath {}
 impl std::fmt::Display for IncrementalSortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSortState {}
 impl pg_sys::PgNode for IncrementalSortState {}
 impl std::fmt::Display for IncrementalSortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexAmRoutine {}
 impl pg_sys::PgNode for IndexAmRoutine {}
 impl std::fmt::Display for IndexAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexClause {}
 impl pg_sys::PgNode for IndexClause {}
 impl std::fmt::Display for IndexClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexElem {}
 impl pg_sys::PgNode for IndexElem {}
 impl std::fmt::Display for IndexElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexInfo {}
 impl pg_sys::PgNode for IndexInfo {}
 impl std::fmt::Display for IndexInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScan {}
 impl pg_sys::PgNode for IndexOnlyScan {}
 impl std::fmt::Display for IndexOnlyScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScanState {}
 impl pg_sys::PgNode for IndexOnlyScanState {}
 impl std::fmt::Display for IndexOnlyScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOptInfo {}
 impl pg_sys::PgNode for IndexOptInfo {}
 impl std::fmt::Display for IndexOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexPath {}
 impl pg_sys::PgNode for IndexPath {}
 impl std::fmt::Display for IndexPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScan {}
 impl pg_sys::PgNode for IndexScan {}
 impl std::fmt::Display for IndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScanState {}
 impl pg_sys::PgNode for IndexScanState {}
 impl std::fmt::Display for IndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexStmt {}
 impl pg_sys::PgNode for IndexStmt {}
 impl std::fmt::Display for IndexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferClause {}
 impl pg_sys::PgNode for InferClause {}
 impl std::fmt::Display for InferClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferenceElem {}
 impl pg_sys::PgNode for InferenceElem {}
 impl std::fmt::Display for InferenceElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InlineCodeBlock {}
 impl pg_sys::PgNode for InlineCodeBlock {}
 impl std::fmt::Display for InlineCodeBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InsertStmt {}
 impl pg_sys::PgNode for InsertStmt {}
 impl std::fmt::Display for InsertStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IntoClause {}
 impl pg_sys::PgNode for IntoClause {}
 impl std::fmt::Display for IntoClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Join {}
 impl pg_sys::PgNode for Join {}
 impl std::fmt::Display for Join {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinExpr {}
 impl pg_sys::PgNode for JoinExpr {}
 impl std::fmt::Display for JoinExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinPath {}
 impl pg_sys::PgNode for JoinPath {}
 impl std::fmt::Display for JoinPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinState {}
 impl pg_sys::PgNode for JoinState {}
 impl std::fmt::Display for JoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JunkFilter {}
 impl pg_sys::PgNode for JunkFilter {}
 impl std::fmt::Display for JunkFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Limit {}
 impl pg_sys::PgNode for Limit {}
 impl std::fmt::Display for Limit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitPath {}
 impl pg_sys::PgNode for LimitPath {}
 impl std::fmt::Display for LimitPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitState {}
 impl pg_sys::PgNode for LimitState {}
 impl std::fmt::Display for LimitState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for List {}
 impl pg_sys::PgNode for List {}
 impl std::fmt::Display for List {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ListenStmt {}
 impl pg_sys::PgNode for ListenStmt {}
 impl std::fmt::Display for ListenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LoadStmt {}
 impl pg_sys::PgNode for LoadStmt {}
 impl std::fmt::Display for LoadStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRows {}
 impl pg_sys::PgNode for LockRows {}
 impl std::fmt::Display for LockRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsPath {}
 impl pg_sys::PgNode for LockRowsPath {}
 impl std::fmt::Display for LockRowsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsState {}
 impl pg_sys::PgNode for LockRowsState {}
 impl std::fmt::Display for LockRowsState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockStmt {}
 impl pg_sys::PgNode for LockStmt {}
 impl std::fmt::Display for LockStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockingClause {}
 impl pg_sys::PgNode for LockingClause {}
 impl std::fmt::Display for LockingClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Material {}
 impl pg_sys::PgNode for Material {}
 impl std::fmt::Display for Material {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialPath {}
 impl pg_sys::PgNode for MaterialPath {}
 impl std::fmt::Display for MaterialPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialState {}
 impl pg_sys::PgNode for MaterialState {}
 impl std::fmt::Display for MaterialState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Memoize {}
 impl pg_sys::PgNode for Memoize {}
 impl std::fmt::Display for Memoize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoizePath {}
 impl pg_sys::PgNode for MemoizePath {}
 impl std::fmt::Display for MemoizePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoizeState {}
 impl pg_sys::PgNode for MemoizeState {}
 impl std::fmt::Display for MemoizeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoryContextData {}
 impl pg_sys::PgNode for MemoryContextData {}
 impl std::fmt::Display for MemoryContextData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppend {}
 impl pg_sys::PgNode for MergeAppend {}
 impl std::fmt::Display for MergeAppend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendPath {}
 impl pg_sys::PgNode for MergeAppendPath {}
 impl std::fmt::Display for MergeAppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendState {}
 impl pg_sys::PgNode for MergeAppendState {}
 impl std::fmt::Display for MergeAppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoin {}
 impl pg_sys::PgNode for MergeJoin {}
 impl std::fmt::Display for MergeJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoinState {}
 impl pg_sys::PgNode for MergeJoinState {}
 impl std::fmt::Display for MergeJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergePath {}
 impl pg_sys::PgNode for MergePath {}
 impl std::fmt::Display for MergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggInfo {}
 impl pg_sys::PgNode for MinMaxAggInfo {}
 impl std::fmt::Display for MinMaxAggInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggPath {}
 impl pg_sys::PgNode for MinMaxAggPath {}
 impl std::fmt::Display for MinMaxAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxExpr {}
 impl pg_sys::PgNode for MinMaxExpr {}
 impl std::fmt::Display for MinMaxExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinimalTupleTableSlot {}
 impl pg_sys::PgNode for MinimalTupleTableSlot {}
 impl std::fmt::Display for MinimalTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTable {}
 impl pg_sys::PgNode for ModifyTable {}
 impl std::fmt::Display for ModifyTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTablePath {}
 impl pg_sys::PgNode for ModifyTablePath {}
 impl std::fmt::Display for ModifyTablePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTableState {}
 impl pg_sys::PgNode for ModifyTableState {}
 impl std::fmt::Display for ModifyTableState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MultiAssignRef {}
 impl pg_sys::PgNode for MultiAssignRef {}
 impl std::fmt::Display for MultiAssignRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedArgExpr {}
 impl pg_sys::PgNode for NamedArgExpr {}
 impl std::fmt::Display for NamedArgExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScan {}
 impl pg_sys::PgNode for NamedTuplestoreScan {}
 impl std::fmt::Display for NamedTuplestoreScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScanState {}
 impl pg_sys::PgNode for NamedTuplestoreScanState {}
 impl std::fmt::Display for NamedTuplestoreScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoop {}
 impl pg_sys::PgNode for NestLoop {}
 impl std::fmt::Display for NestLoop {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopParam {}
 impl pg_sys::PgNode for NestLoopParam {}
 impl std::fmt::Display for NestLoopParam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopState {}
 impl pg_sys::PgNode for NestLoopState {}
 impl std::fmt::Display for NestLoopState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NextValueExpr {}
 impl pg_sys::PgNode for NextValueExpr {}
 impl std::fmt::Display for NextValueExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Node {}
 impl pg_sys::PgNode for Node {}
 impl std::fmt::Display for Node {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NotifyStmt {}
 impl pg_sys::PgNode for NotifyStmt {}
 impl std::fmt::Display for NotifyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NullTest {}
 impl pg_sys::PgNode for NullTest {}
 impl std::fmt::Display for NullTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ObjectWithArgs {}
 impl pg_sys::PgNode for ObjectWithArgs {}
 impl std::fmt::Display for ObjectWithArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictClause {}
 impl pg_sys::PgNode for OnConflictClause {}
 impl std::fmt::Display for OnConflictClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictExpr {}
 impl pg_sys::PgNode for OnConflictExpr {}
 impl std::fmt::Display for OnConflictExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictSetState {}
 impl pg_sys::PgNode for OnConflictSetState {}
 impl std::fmt::Display for OnConflictSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OpExpr {}
 impl pg_sys::PgNode for OpExpr {}
 impl std::fmt::Display for OpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PLAssignStmt {}
 impl pg_sys::PgNode for PLAssignStmt {}
 impl std::fmt::Display for PLAssignStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Param {}
 impl pg_sys::PgNode for Param {}
 impl std::fmt::Display for Param {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamPathInfo {}
 impl pg_sys::PgNode for ParamPathInfo {}
 impl std::fmt::Display for ParamPathInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamRef {}
 impl pg_sys::PgNode for ParamRef {}
 impl std::fmt::Display for ParamRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionBoundSpec {}
 impl pg_sys::PgNode for PartitionBoundSpec {}
 impl std::fmt::Display for PartitionBoundSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionCmd {}
 impl pg_sys::PgNode for PartitionCmd {}
 impl std::fmt::Display for PartitionCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionElem {}
 impl pg_sys::PgNode for PartitionElem {}
 impl std::fmt::Display for PartitionElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneInfo {}
 impl pg_sys::PgNode for PartitionPruneInfo {}
 impl std::fmt::Display for PartitionPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStep {}
 impl pg_sys::PgNode for PartitionPruneStep {}
 impl std::fmt::Display for PartitionPruneStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepCombine {}
 impl pg_sys::PgNode for PartitionPruneStepCombine {}
 impl std::fmt::Display for PartitionPruneStepCombine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepOp {}
 impl pg_sys::PgNode for PartitionPruneStepOp {}
 impl std::fmt::Display for PartitionPruneStepOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionRangeDatum {}
 impl pg_sys::PgNode for PartitionRangeDatum {}
 impl std::fmt::Display for PartitionRangeDatum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionSpec {}
 impl pg_sys::PgNode for PartitionSpec {}
 impl std::fmt::Display for PartitionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionedRelPruneInfo {}
 impl pg_sys::PgNode for PartitionedRelPruneInfo {}
 impl std::fmt::Display for PartitionedRelPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Path {}
 impl pg_sys::PgNode for Path {}
 impl std::fmt::Display for Path {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathKey {}
 impl pg_sys::PgNode for PathKey {}
 impl std::fmt::Display for PathKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathTarget {}
 impl pg_sys::PgNode for PathTarget {}
 impl std::fmt::Display for PathTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderInfo {}
 impl pg_sys::PgNode for PlaceHolderInfo {}
 impl std::fmt::Display for PlaceHolderInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderVar {}
 impl pg_sys::PgNode for PlaceHolderVar {}
 impl std::fmt::Display for PlaceHolderVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Plan {}
 impl pg_sys::PgNode for Plan {}
 impl std::fmt::Display for Plan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanInvalItem {}
 impl pg_sys::PgNode for PlanInvalItem {}
 impl std::fmt::Display for PlanInvalItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanRowMark {}
 impl pg_sys::PgNode for PlanRowMark {}
 impl std::fmt::Display for PlanRowMark {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanState {}
 impl pg_sys::PgNode for PlanState {}
 impl std::fmt::Display for PlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannedStmt {}
 impl pg_sys::PgNode for PlannedStmt {}
 impl std::fmt::Display for PlannedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerGlobal {}
 impl pg_sys::PgNode for PlannerGlobal {}
 impl std::fmt::Display for PlannerGlobal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerInfo {}
 impl pg_sys::PgNode for PlannerInfo {}
 impl std::fmt::Display for PlannerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerParamItem {}
 impl pg_sys::PgNode for PlannerParamItem {}
 impl std::fmt::Display for PlannerParamItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PrepareStmt {}
 impl pg_sys::PgNode for PrepareStmt {}
 impl std::fmt::Display for PrepareStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSet {}
 impl pg_sys::PgNode for ProjectSet {}
 impl std::fmt::Display for ProjectSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetPath {}
 impl pg_sys::PgNode for ProjectSetPath {}
 impl std::fmt::Display for ProjectSetPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetState {}
 impl pg_sys::PgNode for ProjectSetState {}
 impl std::fmt::Display for ProjectSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionInfo {}
 impl pg_sys::PgNode for ProjectionInfo {}
 impl std::fmt::Display for ProjectionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionPath {}
 impl pg_sys::PgNode for ProjectionPath {}
 impl std::fmt::Display for ProjectionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Query {}
 impl pg_sys::PgNode for Query {}
 impl std::fmt::Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeFunction {}
 impl pg_sys::PgNode for RangeFunction {}
 impl std::fmt::Display for RangeFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeSubselect {}
 impl pg_sys::PgNode for RangeSubselect {}
 impl std::fmt::Display for RangeSubselect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFunc {}
 impl pg_sys::PgNode for RangeTableFunc {}
 impl std::fmt::Display for RangeTableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFuncCol {}
 impl pg_sys::PgNode for RangeTableFuncCol {}
 impl std::fmt::Display for RangeTableFuncCol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableSample {}
 impl pg_sys::PgNode for RangeTableSample {}
 impl std::fmt::Display for RangeTableSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblEntry {}
 impl pg_sys::PgNode for RangeTblEntry {}
 impl std::fmt::Display for RangeTblEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblFunction {}
 impl pg_sys::PgNode for RangeTblFunction {}
 impl std::fmt::Display for RangeTblFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblRef {}
 impl pg_sys::PgNode for RangeTblRef {}
 impl std::fmt::Display for RangeTblRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeVar {}
 impl pg_sys::PgNode for RangeVar {}
 impl std::fmt::Display for RangeVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RawStmt {}
 impl pg_sys::PgNode for RawStmt {}
 impl std::fmt::Display for RawStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReassignOwnedStmt {}
 impl pg_sys::PgNode for ReassignOwnedStmt {}
 impl std::fmt::Display for ReassignOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnion {}
 impl pg_sys::PgNode for RecursiveUnion {}
 impl std::fmt::Display for RecursiveUnion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionPath {}
 impl pg_sys::PgNode for RecursiveUnionPath {}
 impl std::fmt::Display for RecursiveUnionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionState {}
 impl pg_sys::PgNode for RecursiveUnionState {}
 impl std::fmt::Display for RecursiveUnionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RefreshMatViewStmt {}
 impl pg_sys::PgNode for RefreshMatViewStmt {}
 impl std::fmt::Display for RefreshMatViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReindexStmt {}
 impl pg_sys::PgNode for ReindexStmt {}
 impl std::fmt::Display for ReindexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelOptInfo {}
 impl pg_sys::PgNode for RelOptInfo {}
 impl std::fmt::Display for RelOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelabelType {}
 impl pg_sys::PgNode for RelabelType {}
 impl std::fmt::Display for RelabelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RenameStmt {}
 impl pg_sys::PgNode for RenameStmt {}
 impl std::fmt::Display for RenameStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReplicaIdentityStmt {}
 impl pg_sys::PgNode for ReplicaIdentityStmt {}
 impl std::fmt::Display for ReplicaIdentityStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResTarget {}
 impl pg_sys::PgNode for ResTarget {}
 impl std::fmt::Display for ResTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RestrictInfo {}
 impl pg_sys::PgNode for RestrictInfo {}
 impl std::fmt::Display for RestrictInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Result {}
 impl pg_sys::PgNode for Result {}
 impl std::fmt::Display for Result {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultRelInfo {}
 impl pg_sys::PgNode for ResultRelInfo {}
 impl std::fmt::Display for ResultRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultState {}
 impl pg_sys::PgNode for ResultState {}
 impl std::fmt::Display for ResultState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReturnSetInfo {}
 impl pg_sys::PgNode for ReturnSetInfo {}
 impl std::fmt::Display for ReturnSetInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReturnStmt {}
 impl pg_sys::PgNode for ReturnStmt {}
 impl std::fmt::Display for ReturnStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RoleSpec {}
 impl pg_sys::PgNode for RoleSpec {}
 impl std::fmt::Display for RoleSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RollupData {}
 impl pg_sys::PgNode for RollupData {}
 impl std::fmt::Display for RollupData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowCompareExpr {}
 impl pg_sys::PgNode for RowCompareExpr {}
 impl std::fmt::Display for RowCompareExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowExpr {}
 impl pg_sys::PgNode for RowExpr {}
 impl std::fmt::Display for RowExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowIdentityVarInfo {}
 impl pg_sys::PgNode for RowIdentityVarInfo {}
 impl std::fmt::Display for RowIdentityVarInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowMarkClause {}
 impl pg_sys::PgNode for RowMarkClause {}
 impl std::fmt::Display for RowMarkClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RuleStmt {}
 impl pg_sys::PgNode for RuleStmt {}
 impl std::fmt::Display for RuleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLCmd {}
 impl pg_sys::PgNode for SQLCmd {}
 impl std::fmt::Display for SQLCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLValueFunction {}
 impl pg_sys::PgNode for SQLValueFunction {}
 impl std::fmt::Display for SQLValueFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScan {}
 impl pg_sys::PgNode for SampleScan {}
 impl std::fmt::Display for SampleScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScanState {}
 impl pg_sys::PgNode for SampleScanState {}
 impl std::fmt::Display for SampleScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScalarArrayOpExpr {}
 impl pg_sys::PgNode for ScalarArrayOpExpr {}
 impl std::fmt::Display for ScalarArrayOpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Scan {}
 impl pg_sys::PgNode for Scan {}
 impl std::fmt::Display for Scan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScanState {}
 impl pg_sys::PgNode for ScanState {}
 impl std::fmt::Display for ScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SecLabelStmt {}
 impl pg_sys::PgNode for SecLabelStmt {}
 impl std::fmt::Display for SecLabelStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SelectStmt {}
 impl pg_sys::PgNode for SelectStmt {}
 impl std::fmt::Display for SelectStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SeqScanState {}
 impl pg_sys::PgNode for SeqScanState {}
 impl std::fmt::Display for SeqScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetExprState {}
 impl pg_sys::PgNode for SetExprState {}
 impl std::fmt::Display for SetExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOp {}
 impl pg_sys::PgNode for SetOp {}
 impl std::fmt::Display for SetOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpPath {}
 impl pg_sys::PgNode for SetOpPath {}
 impl std::fmt::Display for SetOpPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpState {}
 impl pg_sys::PgNode for SetOpState {}
 impl std::fmt::Display for SetOpState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOperationStmt {}
 impl pg_sys::PgNode for SetOperationStmt {}
 impl std::fmt::Display for SetOperationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetToDefault {}
 impl pg_sys::PgNode for SetToDefault {}
 impl std::fmt::Display for SetToDefault {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Sort {}
 impl pg_sys::PgNode for Sort {}
 impl std::fmt::Display for Sort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortBy {}
 impl pg_sys::PgNode for SortBy {}
 impl std::fmt::Display for SortBy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortGroupClause {}
 impl pg_sys::PgNode for SortGroupClause {}
 impl std::fmt::Display for SortGroupClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortPath {}
 impl pg_sys::PgNode for SortPath {}
 impl std::fmt::Display for SortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortState {}
 impl pg_sys::PgNode for SortState {}
 impl std::fmt::Display for SortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SpecialJoinInfo {}
 impl pg_sys::PgNode for SpecialJoinInfo {}
 impl std::fmt::Display for SpecialJoinInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StartReplicationCmd {}
 impl pg_sys::PgNode for StartReplicationCmd {}
 impl std::fmt::Display for StartReplicationCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StatisticExtInfo {}
 impl pg_sys::PgNode for StatisticExtInfo {}
 impl std::fmt::Display for StatisticExtInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StatsElem {}
 impl pg_sys::PgNode for StatsElem {}
 impl std::fmt::Display for StatsElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubLink {}
 impl pg_sys::PgNode for SubLink {}
 impl std::fmt::Display for SubLink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlan {}
 impl pg_sys::PgNode for SubPlan {}
 impl std::fmt::Display for SubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlanState {}
 impl pg_sys::PgNode for SubPlanState {}
 impl std::fmt::Display for SubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScan {}
 impl pg_sys::PgNode for SubqueryScan {}
 impl std::fmt::Display for SubqueryScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanPath {}
 impl pg_sys::PgNode for SubqueryScanPath {}
 impl std::fmt::Display for SubqueryScanPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanState {}
 impl pg_sys::PgNode for SubqueryScanState {}
 impl std::fmt::Display for SubqueryScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubscriptingRef {}
 impl pg_sys::PgNode for SubscriptingRef {}
 impl std::fmt::Display for SubscriptingRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestCost {}
 impl pg_sys::PgNode for SupportRequestCost {}
 impl std::fmt::Display for SupportRequestCost {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestIndexCondition {}
 impl pg_sys::PgNode for SupportRequestIndexCondition {}
 impl std::fmt::Display for SupportRequestIndexCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestRows {}
 impl pg_sys::PgNode for SupportRequestRows {}
 impl std::fmt::Display for SupportRequestRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSelectivity {}
 impl pg_sys::PgNode for SupportRequestSelectivity {}
 impl std::fmt::Display for SupportRequestSelectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSimplify {}
 impl pg_sys::PgNode for SupportRequestSimplify {}
 impl std::fmt::Display for SupportRequestSimplify {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableAmRoutine {}
 impl pg_sys::PgNode for TableAmRoutine {}
 impl std::fmt::Display for TableAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFunc {}
 impl pg_sys::PgNode for TableFunc {}
 impl std::fmt::Display for TableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScan {}
 impl pg_sys::PgNode for TableFuncScan {}
 impl std::fmt::Display for TableFuncScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScanState {}
 impl pg_sys::PgNode for TableFuncScanState {}
 impl std::fmt::Display for TableFuncScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableLikeClause {}
 impl pg_sys::PgNode for TableLikeClause {}
 impl std::fmt::Display for TableLikeClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableSampleClause {}
 impl pg_sys::PgNode for TableSampleClause {}
 impl std::fmt::Display for TableSampleClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TargetEntry {}
 impl pg_sys::PgNode for TargetEntry {}
 impl std::fmt::Display for TargetEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidPath {}
 impl pg_sys::PgNode for TidPath {}
 impl std::fmt::Display for TidPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidRangePath {}
 impl pg_sys::PgNode for TidRangePath {}
 impl std::fmt::Display for TidRangePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidRangeScan {}
 impl pg_sys::PgNode for TidRangeScan {}
 impl std::fmt::Display for TidRangeScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidRangeScanState {}
 impl pg_sys::PgNode for TidRangeScanState {}
 impl std::fmt::Display for TidRangeScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScan {}
 impl pg_sys::PgNode for TidScan {}
 impl std::fmt::Display for TidScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScanState {}
 impl pg_sys::PgNode for TidScanState {}
 impl std::fmt::Display for TidScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TimeLineHistoryCmd {}
 impl pg_sys::PgNode for TimeLineHistoryCmd {}
 impl std::fmt::Display for TimeLineHistoryCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TransactionStmt {}
 impl pg_sys::PgNode for TransactionStmt {}
 impl std::fmt::Display for TransactionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerData {}
 impl pg_sys::PgNode for TriggerData {}
 impl std::fmt::Display for TriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerTransition {}
 impl pg_sys::PgNode for TriggerTransition {}
 impl std::fmt::Display for TriggerTransition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TruncateStmt {}
 impl pg_sys::PgNode for TruncateStmt {}
 impl std::fmt::Display for TruncateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TupleTableSlot {}
 impl pg_sys::PgNode for TupleTableSlot {}
 impl std::fmt::Display for TupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeCast {}
 impl pg_sys::PgNode for TypeCast {}
 impl std::fmt::Display for TypeCast {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeName {}
 impl pg_sys::PgNode for TypeName {}
 impl std::fmt::Display for TypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Unique {}
 impl pg_sys::PgNode for Unique {}
 impl std::fmt::Display for Unique {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniquePath {}
 impl pg_sys::PgNode for UniquePath {}
 impl std::fmt::Display for UniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniqueState {}
 impl pg_sys::PgNode for UniqueState {}
 impl std::fmt::Display for UniqueState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UnlistenStmt {}
 impl pg_sys::PgNode for UnlistenStmt {}
 impl std::fmt::Display for UnlistenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpdateStmt {}
 impl pg_sys::PgNode for UpdateStmt {}
 impl std::fmt::Display for UpdateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpperUniquePath {}
 impl pg_sys::PgNode for UpperUniquePath {}
 impl std::fmt::Display for UpperUniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumRelation {}
 impl pg_sys::PgNode for VacuumRelation {}
 impl std::fmt::Display for VacuumRelation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumStmt {}
 impl pg_sys::PgNode for VacuumStmt {}
 impl std::fmt::Display for VacuumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Value {}
 impl pg_sys::PgNode for Value {}
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScan {}
 impl pg_sys::PgNode for ValuesScan {}
 impl std::fmt::Display for ValuesScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScanState {}
 impl pg_sys::PgNode for ValuesScanState {}
 impl std::fmt::Display for ValuesScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Var {}
 impl pg_sys::PgNode for Var {}
 impl std::fmt::Display for Var {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableSetStmt {}
 impl pg_sys::PgNode for VariableSetStmt {}
 impl std::fmt::Display for VariableSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableShowStmt {}
 impl pg_sys::PgNode for VariableShowStmt {}
 impl std::fmt::Display for VariableShowStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ViewStmt {}
 impl pg_sys::PgNode for ViewStmt {}
 impl std::fmt::Display for ViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VirtualTupleTableSlot {}
 impl pg_sys::PgNode for VirtualTupleTableSlot {}
 impl std::fmt::Display for VirtualTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAgg {}
 impl pg_sys::PgNode for WindowAgg {}
 impl std::fmt::Display for WindowAgg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggPath {}
 impl pg_sys::PgNode for WindowAggPath {}
 impl std::fmt::Display for WindowAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggState {}
 impl pg_sys::PgNode for WindowAggState {}
 impl std::fmt::Display for WindowAggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowClause {}
 impl pg_sys::PgNode for WindowClause {}
 impl std::fmt::Display for WindowClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowDef {}
 impl pg_sys::PgNode for WindowDef {}
 impl std::fmt::Display for WindowDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFunc {}
 impl pg_sys::PgNode for WindowFunc {}
 impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFuncExprState {}
 impl pg_sys::PgNode for WindowFuncExprState {}
 impl std::fmt::Display for WindowFuncExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithCheckOption {}
 impl pg_sys::PgNode for WithCheckOption {}
 impl std::fmt::Display for WithCheckOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithClause {}
 impl pg_sys::PgNode for WithClause {}
 impl std::fmt::Display for WithClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScan {}
 impl pg_sys::PgNode for WorkTableScan {}
 impl std::fmt::Display for WorkTableScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScanState {}
 impl pg_sys::PgNode for WorkTableScanState {}
 impl std::fmt::Display for WorkTableScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlExpr {}
 impl pg_sys::PgNode for XmlExpr {}
 impl std::fmt::Display for XmlExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlSerialize {}
 impl pg_sys::PgNode for XmlSerialize {}
 impl std::fmt::Display for XmlSerialize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/pgx-pg-sys/src/pg15.rs
+++ b/pgx-pg-sys/src/pg15.rs
@@ -164,34 +164,33 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 107usize] = b" '--prefix=/Users/e_ridge/.pgx/15.0/pgx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 106usize] = b" '--prefix=/home/atelier/.pgx/15.1/pgx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28815;
 pub const DEF_PGPORT_STR: &[u8; 6usize] = b"28815\0";
 pub const DLSUFFIX: &[u8; 4usize] = b".so\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
+pub const HAVE_APPEND_HISTORY: u32 = 1;
 pub const HAVE_ATOMICS: u32 = 1;
 pub const HAVE_BACKTRACE_SYMBOLS: u32 = 1;
 pub const HAVE_CLOCK_GETTIME: u32 = 1;
 pub const HAVE_COMPUTED_GOTO: u32 = 1;
-pub const HAVE_COPYFILE: u32 = 1;
-pub const HAVE_COPYFILE_H: u32 = 1;
-pub const HAVE_DECL_FDATASYNC: u32 = 0;
-pub const HAVE_DECL_F_FULLFSYNC: u32 = 1;
-pub const HAVE_DECL_POSIX_FADVISE: u32 = 0;
+pub const HAVE_DECL_FDATASYNC: u32 = 1;
+pub const HAVE_DECL_F_FULLFSYNC: u32 = 0;
+pub const HAVE_DECL_POSIX_FADVISE: u32 = 1;
 pub const HAVE_DECL_PREADV: u32 = 1;
 pub const HAVE_DECL_PWRITEV: u32 = 1;
 pub const HAVE_DECL_RTLD_GLOBAL: u32 = 1;
 pub const HAVE_DECL_RTLD_NOW: u32 = 1;
 pub const HAVE_DECL_SIGWAIT: u32 = 1;
-pub const HAVE_DECL_STRLCAT: u32 = 1;
-pub const HAVE_DECL_STRLCPY: u32 = 1;
+pub const HAVE_DECL_STRLCAT: u32 = 0;
+pub const HAVE_DECL_STRLCPY: u32 = 0;
 pub const HAVE_DECL_STRNLEN: u32 = 1;
 pub const HAVE_DECL_STRTOLL: u32 = 1;
 pub const HAVE_DECL_STRTOULL: u32 = 1;
 pub const HAVE_DLOPEN: u32 = 1;
 pub const HAVE_EXECINFO_H: u32 = 1;
+pub const HAVE_EXPLICIT_BZERO: u32 = 1;
 pub const HAVE_FDATASYNC: u32 = 1;
-pub const HAVE_FLS: u32 = 1;
 pub const HAVE_FSEEKO: u32 = 1;
 pub const HAVE_FUNCNAME__FUNC: u32 = 1;
 pub const HAVE_GCC__ATOMIC_INT32_CAS: u32 = 1;
@@ -201,11 +200,11 @@ pub const HAVE_GCC__SYNC_INT32_CAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT32_TAS: u32 = 1;
 pub const HAVE_GCC__SYNC_INT64_CAS: u32 = 1;
 pub const HAVE_GETADDRINFO: u32 = 1;
+pub const HAVE_GETHOSTBYNAME_R: u32 = 1;
 pub const HAVE_GETIFADDRS: u32 = 1;
 pub const HAVE_GETOPT: u32 = 1;
 pub const HAVE_GETOPT_H: u32 = 1;
 pub const HAVE_GETOPT_LONG: u32 = 1;
-pub const HAVE_GETPEEREID: u32 = 1;
 pub const HAVE_GETPWUID_R: u32 = 1;
 pub const HAVE_GETRLIMIT: u32 = 1;
 pub const HAVE_GETRUSAGE: u32 = 1;
@@ -215,10 +214,8 @@ pub const HAVE_INET_ATON: u32 = 1;
 pub const HAVE_INET_PTON: u32 = 1;
 pub const HAVE_INTTYPES_H: u32 = 1;
 pub const HAVE_INT_OPTERR: u32 = 1;
-pub const HAVE_INT_OPTRESET: u32 = 1;
 pub const HAVE_INT_TIMEZONE: u32 = 1;
 pub const HAVE_IPV6: u32 = 1;
-pub const HAVE_KQUEUE: u32 = 1;
 pub const HAVE_LANGINFO_H: u32 = 1;
 pub const HAVE_LIBM: u32 = 1;
 pub const HAVE_LIBREADLINE: u32 = 1;
@@ -226,18 +223,19 @@ pub const HAVE_LIBZ: u32 = 1;
 pub const HAVE_LINK: u32 = 1;
 pub const HAVE_LOCALE_T: u32 = 1;
 pub const HAVE_LONG_INT_64: u32 = 1;
-pub const HAVE_MBSTOWCS_L: u32 = 1;
 pub const HAVE_MEMORY_H: u32 = 1;
-pub const HAVE_MEMSET_S: u32 = 1;
 pub const HAVE_MKDTEMP: u32 = 1;
 pub const HAVE_NETINET_TCP_H: u32 = 1;
 pub const HAVE_NET_IF_H: u32 = 1;
 pub const HAVE_POLL: u32 = 1;
 pub const HAVE_POLL_H: u32 = 1;
 pub const HAVE_POSIX_DECL_SIGWAIT: u32 = 1;
+pub const HAVE_POSIX_FADVISE: u32 = 1;
+pub const HAVE_POSIX_FALLOCATE: u32 = 1;
+pub const HAVE_PPOLL: u32 = 1;
 pub const HAVE_PREAD: u32 = 1;
 pub const HAVE_PTHREAD: u32 = 1;
-pub const HAVE_PTHREAD_IS_THREADED_NP: u32 = 1;
+pub const HAVE_PTHREAD_BARRIER_WAIT: u32 = 1;
 pub const HAVE_PTHREAD_PRIO_INHERIT: u32 = 1;
 pub const HAVE_PWRITE: u32 = 1;
 pub const HAVE_READLINE_HISTORY_H: u32 = 1;
@@ -245,7 +243,11 @@ pub const HAVE_READLINE_READLINE_H: u32 = 1;
 pub const HAVE_READLINK: u32 = 1;
 pub const HAVE_READV: u32 = 1;
 pub const HAVE_RL_COMPLETION_MATCHES: u32 = 1;
+pub const HAVE_RL_COMPLETION_SUPPRESS_QUOTE: u32 = 1;
 pub const HAVE_RL_FILENAME_COMPLETION_FUNCTION: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTE_CHARACTERS: u32 = 1;
+pub const HAVE_RL_FILENAME_QUOTING_FUNCTION: u32 = 1;
+pub const HAVE_RL_RESET_SCREEN_SIZE: u32 = 1;
 pub const HAVE_RL_VARIABLE_BIND: u32 = 1;
 pub const HAVE_SETENV: u32 = 1;
 pub const HAVE_SETSID: u32 = 1;
@@ -255,11 +257,10 @@ pub const HAVE_SPINLOCKS: u32 = 1;
 pub const HAVE_STDBOOL_H: u32 = 1;
 pub const HAVE_STDINT_H: u32 = 1;
 pub const HAVE_STDLIB_H: u32 = 1;
+pub const HAVE_STRCHRNUL: u32 = 1;
 pub const HAVE_STRERROR_R: u32 = 1;
 pub const HAVE_STRINGS_H: u32 = 1;
 pub const HAVE_STRING_H: u32 = 1;
-pub const HAVE_STRLCAT: u32 = 1;
-pub const HAVE_STRLCPY: u32 = 1;
 pub const HAVE_STRNLEN: u32 = 1;
 pub const HAVE_STRSIGNAL: u32 = 1;
 pub const HAVE_STRTOF: u32 = 1;
@@ -267,35 +268,35 @@ pub const HAVE_STRTOLL: u32 = 1;
 pub const HAVE_STRTOULL: u32 = 1;
 pub const HAVE_STRUCT_ADDRINFO: u32 = 1;
 pub const HAVE_STRUCT_OPTION: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_SA_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY: u32 = 1;
-pub const HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN: u32 = 1;
 pub const HAVE_STRUCT_SOCKADDR_UN: u32 = 1;
 pub const HAVE_STRUCT_TM_TM_ZONE: u32 = 1;
 pub const HAVE_SYMLINK: u32 = 1;
+pub const HAVE_SYNCFS: u32 = 1;
+pub const HAVE_SYNC_FILE_RANGE: u32 = 1;
 pub const HAVE_SYSLOG: u32 = 1;
-pub const HAVE_SYS_EVENT_H: u32 = 1;
+pub const HAVE_SYS_EPOLL_H: u32 = 1;
 pub const HAVE_SYS_IPC_H: u32 = 1;
+pub const HAVE_SYS_PERSONALITY_H: u32 = 1;
+pub const HAVE_SYS_PRCTL_H: u32 = 1;
 pub const HAVE_SYS_RESOURCE_H: u32 = 1;
 pub const HAVE_SYS_SELECT_H: u32 = 1;
 pub const HAVE_SYS_SEM_H: u32 = 1;
 pub const HAVE_SYS_SHM_H: u32 = 1;
-pub const HAVE_SYS_SOCKIO_H: u32 = 1;
+pub const HAVE_SYS_SIGNALFD_H: u32 = 1;
 pub const HAVE_SYS_STAT_H: u32 = 1;
 pub const HAVE_SYS_TYPES_H: u32 = 1;
-pub const HAVE_SYS_UCRED_H: u32 = 1;
 pub const HAVE_SYS_UIO_H: u32 = 1;
 pub const HAVE_SYS_UN_H: u32 = 1;
 pub const HAVE_TERMIOS_H: u32 = 1;
 pub const HAVE_TYPEOF: u32 = 1;
-pub const HAVE_UNION_SEMUN: u32 = 1;
 pub const HAVE_UNISTD_H: u32 = 1;
 pub const HAVE_UNSETENV: u32 = 1;
 pub const HAVE_USELOCALE: u32 = 1;
-pub const HAVE_WCSTOMBS_L: u32 = 1;
 pub const HAVE_WCTYPE_H: u32 = 1;
 pub const HAVE_WRITEV: u32 = 1;
+pub const HAVE_X86_64_POPCNTQ: u32 = 1;
 pub const HAVE__BOOL: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP16: u32 = 1;
 pub const HAVE__BUILTIN_BSWAP32: u32 = 1;
@@ -308,25 +309,26 @@ pub const HAVE__BUILTIN_OP_OVERFLOW: u32 = 1;
 pub const HAVE__BUILTIN_POPCOUNT: u32 = 1;
 pub const HAVE__BUILTIN_TYPES_COMPATIBLE_P: u32 = 1;
 pub const HAVE__BUILTIN_UNREACHABLE: u32 = 1;
+pub const HAVE__GET_CPUID: u32 = 1;
 pub const HAVE__STATIC_ASSERT: u32 = 1;
 pub const INT64_MODIFIER: &[u8; 2usize] = b"l\0";
-pub const LOCALE_T_IN_XLOCALE: u32 = 1;
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32usize] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11usize] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 15.0\0";
+pub const PACKAGE_STRING: &[u8; 16usize] = b"PostgreSQL 15.1\0";
 pub const PACKAGE_TARNAME: &[u8; 11usize] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28usize] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5usize] = b"15.0\0";
+pub const PACKAGE_VERSION: &[u8; 5usize] = b"15.1\0";
 pub const PG_KRB_SRVNAM: &[u8; 9usize] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3usize] = b"15\0";
 pub const PG_MAJORVERSION_NUM: u32 = 15;
-pub const PG_MINORVERSION_NUM: u32 = 0;
+pub const PG_MINORVERSION_NUM: u32 = 1;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5usize] = b"15.0\0";
-pub const PG_VERSION_NUM: u32 = 150000;
-pub const PG_VERSION_STR : & [u8 ; 116usize] = b"PostgreSQL 15.0 on aarch64-apple-darwin22.1.0, compiled by Apple clang version 14.0.0 (clang-1400.0.29.202), 64-bit\0" ;
+pub const PG_VERSION: &[u8; 5usize] = b"15.1\0";
+pub const PG_VERSION_NUM: u32 = 150001;
+pub const PG_VERSION_STR: &[u8; 77usize] =
+    b"PostgreSQL 15.1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.2.0, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -334,12 +336,10 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
-pub const USE_ARMV8_CRC32C: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
+pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
-pub const WCSTOMBS_L_IN_XLOCALE: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const NAMEDATALEN: u32 = 64;
@@ -356,566 +356,214 @@ pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const HAVE_WORKING_LINK: u32 = 1;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &[u8; 5usize] = b"/tmp\0";
 pub const DEFAULT_EVENT_SOURCE: &[u8; 11usize] = b"PostgreSQL\0";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const TRACE_SORT: u32 = 1;
-pub const __darwin__: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14usize] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_13_0: u32 = 130000;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 130000;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 36;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10usize] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
+pub const P_tmpdir: &[u8; 5usize] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __DARWIN_FD_SETSIZE: u32 = 1024;
-pub const __DARWIN_NBBY: u32 = 8;
-pub const NBBY: u32 = 8;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
+pub const UINT8_MAX: u32 = 255;
+pub const UINT16_MAX: u32 = 65535;
+pub const UINT32_MAX: u32 = 4294967295;
+pub const INT_LEAST8_MIN: i32 = -128;
+pub const INT_LEAST16_MIN: i32 = -32768;
+pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST8_MAX: u32 = 127;
+pub const INT_LEAST16_MAX: u32 = 32767;
+pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const UINT_LEAST8_MAX: u32 = 255;
+pub const UINT_LEAST16_MAX: u32 = 65535;
+pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const INT_FAST8_MIN: i32 = -128;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST8_MAX: u32 = 127;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST8_MAX: u32 = 255;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINTPTR_MAX: i32 = -1;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIG_ATOMIC_MIN: i32 = -2147483648;
+pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _ERRNO_H: u32 = 1;
+pub const _BITS_ERRNO_H: u32 = 1;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -926,7 +574,7 @@ pub const E2BIG: u32 = 7;
 pub const ENOEXEC: u32 = 8;
 pub const EBADF: u32 = 9;
 pub const ECHILD: u32 = 10;
-pub const EDEADLK: u32 = 11;
+pub const EAGAIN: u32 = 11;
 pub const ENOMEM: u32 = 12;
 pub const EACCES: u32 = 13;
 pub const EFAULT: u32 = 14;
@@ -950,92 +598,151 @@ pub const EMLINK: u32 = 31;
 pub const EPIPE: u32 = 32;
 pub const EDOM: u32 = 33;
 pub const ERANGE: u32 = 34;
-pub const EAGAIN: u32 = 35;
-pub const EWOULDBLOCK: u32 = 35;
-pub const EINPROGRESS: u32 = 36;
-pub const EALREADY: u32 = 37;
-pub const ENOTSOCK: u32 = 38;
-pub const EDESTADDRREQ: u32 = 39;
-pub const EMSGSIZE: u32 = 40;
-pub const EPROTOTYPE: u32 = 41;
-pub const ENOPROTOOPT: u32 = 42;
-pub const EPROTONOSUPPORT: u32 = 43;
-pub const ESOCKTNOSUPPORT: u32 = 44;
-pub const ENOTSUP: u32 = 45;
-pub const EPFNOSUPPORT: u32 = 46;
-pub const EAFNOSUPPORT: u32 = 47;
-pub const EADDRINUSE: u32 = 48;
-pub const EADDRNOTAVAIL: u32 = 49;
-pub const ENETDOWN: u32 = 50;
-pub const ENETUNREACH: u32 = 51;
-pub const ENETRESET: u32 = 52;
-pub const ECONNABORTED: u32 = 53;
-pub const ECONNRESET: u32 = 54;
-pub const ENOBUFS: u32 = 55;
-pub const EISCONN: u32 = 56;
-pub const ENOTCONN: u32 = 57;
-pub const ESHUTDOWN: u32 = 58;
-pub const ETOOMANYREFS: u32 = 59;
-pub const ETIMEDOUT: u32 = 60;
-pub const ECONNREFUSED: u32 = 61;
-pub const ELOOP: u32 = 62;
-pub const ENAMETOOLONG: u32 = 63;
-pub const EHOSTDOWN: u32 = 64;
-pub const EHOSTUNREACH: u32 = 65;
-pub const ENOTEMPTY: u32 = 66;
-pub const EPROCLIM: u32 = 67;
-pub const EUSERS: u32 = 68;
-pub const EDQUOT: u32 = 69;
-pub const ESTALE: u32 = 70;
-pub const EREMOTE: u32 = 71;
-pub const EBADRPC: u32 = 72;
-pub const ERPCMISMATCH: u32 = 73;
-pub const EPROGUNAVAIL: u32 = 74;
-pub const EPROGMISMATCH: u32 = 75;
-pub const EPROCUNAVAIL: u32 = 76;
-pub const ENOLCK: u32 = 77;
-pub const ENOSYS: u32 = 78;
-pub const EFTYPE: u32 = 79;
-pub const EAUTH: u32 = 80;
-pub const ENEEDAUTH: u32 = 81;
-pub const EPWROFF: u32 = 82;
-pub const EDEVERR: u32 = 83;
-pub const EOVERFLOW: u32 = 84;
-pub const EBADEXEC: u32 = 85;
-pub const EBADARCH: u32 = 86;
-pub const ESHLIBVERS: u32 = 87;
-pub const EBADMACHO: u32 = 88;
-pub const ECANCELED: u32 = 89;
-pub const EIDRM: u32 = 90;
-pub const ENOMSG: u32 = 91;
-pub const EILSEQ: u32 = 92;
-pub const ENOATTR: u32 = 93;
-pub const EBADMSG: u32 = 94;
-pub const EMULTIHOP: u32 = 95;
-pub const ENODATA: u32 = 96;
-pub const ENOLINK: u32 = 97;
-pub const ENOSR: u32 = 98;
-pub const ENOSTR: u32 = 99;
-pub const EPROTO: u32 = 100;
-pub const ETIME: u32 = 101;
-pub const EOPNOTSUPP: u32 = 102;
-pub const ENOPOLICY: u32 = 103;
-pub const ENOTRECOVERABLE: u32 = 104;
-pub const EOWNERDEAD: u32 = 105;
-pub const EQFULL: u32 = 106;
-pub const ELAST: u32 = 106;
-pub const LC_ALL: u32 = 0;
-pub const LC_COLLATE: u32 = 1;
-pub const LC_CTYPE: u32 = 2;
-pub const LC_MONETARY: u32 = 3;
-pub const LC_NUMERIC: u32 = 4;
-pub const LC_TIME: u32 = 5;
-pub const LC_MESSAGES: u32 = 6;
-pub const _LC_LAST: u32 = 7;
+pub const EDEADLK: u32 = 35;
+pub const ENAMETOOLONG: u32 = 36;
+pub const ENOLCK: u32 = 37;
+pub const ENOSYS: u32 = 38;
+pub const ENOTEMPTY: u32 = 39;
+pub const ELOOP: u32 = 40;
+pub const EWOULDBLOCK: u32 = 11;
+pub const ENOMSG: u32 = 42;
+pub const EIDRM: u32 = 43;
+pub const ECHRNG: u32 = 44;
+pub const EL2NSYNC: u32 = 45;
+pub const EL3HLT: u32 = 46;
+pub const EL3RST: u32 = 47;
+pub const ELNRNG: u32 = 48;
+pub const EUNATCH: u32 = 49;
+pub const ENOCSI: u32 = 50;
+pub const EL2HLT: u32 = 51;
+pub const EBADE: u32 = 52;
+pub const EBADR: u32 = 53;
+pub const EXFULL: u32 = 54;
+pub const ENOANO: u32 = 55;
+pub const EBADRQC: u32 = 56;
+pub const EBADSLT: u32 = 57;
+pub const EDEADLOCK: u32 = 35;
+pub const EBFONT: u32 = 59;
+pub const ENOSTR: u32 = 60;
+pub const ENODATA: u32 = 61;
+pub const ETIME: u32 = 62;
+pub const ENOSR: u32 = 63;
+pub const ENONET: u32 = 64;
+pub const ENOPKG: u32 = 65;
+pub const EREMOTE: u32 = 66;
+pub const ENOLINK: u32 = 67;
+pub const EADV: u32 = 68;
+pub const ESRMNT: u32 = 69;
+pub const ECOMM: u32 = 70;
+pub const EPROTO: u32 = 71;
+pub const EMULTIHOP: u32 = 72;
+pub const EDOTDOT: u32 = 73;
+pub const EBADMSG: u32 = 74;
+pub const EOVERFLOW: u32 = 75;
+pub const ENOTUNIQ: u32 = 76;
+pub const EBADFD: u32 = 77;
+pub const EREMCHG: u32 = 78;
+pub const ELIBACC: u32 = 79;
+pub const ELIBBAD: u32 = 80;
+pub const ELIBSCN: u32 = 81;
+pub const ELIBMAX: u32 = 82;
+pub const ELIBEXEC: u32 = 83;
+pub const EILSEQ: u32 = 84;
+pub const ERESTART: u32 = 85;
+pub const ESTRPIPE: u32 = 86;
+pub const EUSERS: u32 = 87;
+pub const ENOTSOCK: u32 = 88;
+pub const EDESTADDRREQ: u32 = 89;
+pub const EMSGSIZE: u32 = 90;
+pub const EPROTOTYPE: u32 = 91;
+pub const ENOPROTOOPT: u32 = 92;
+pub const EPROTONOSUPPORT: u32 = 93;
+pub const ESOCKTNOSUPPORT: u32 = 94;
+pub const EOPNOTSUPP: u32 = 95;
+pub const EPFNOSUPPORT: u32 = 96;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ENETDOWN: u32 = 100;
+pub const ENETUNREACH: u32 = 101;
+pub const ENETRESET: u32 = 102;
+pub const ECONNABORTED: u32 = 103;
+pub const ECONNRESET: u32 = 104;
+pub const ENOBUFS: u32 = 105;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ESHUTDOWN: u32 = 108;
+pub const ETOOMANYREFS: u32 = 109;
+pub const ETIMEDOUT: u32 = 110;
+pub const ECONNREFUSED: u32 = 111;
+pub const EHOSTDOWN: u32 = 112;
+pub const EHOSTUNREACH: u32 = 113;
+pub const EALREADY: u32 = 114;
+pub const EINPROGRESS: u32 = 115;
+pub const ESTALE: u32 = 116;
+pub const EUCLEAN: u32 = 117;
+pub const ENOTNAM: u32 = 118;
+pub const ENAVAIL: u32 = 119;
+pub const EISNAM: u32 = 120;
+pub const EREMOTEIO: u32 = 121;
+pub const EDQUOT: u32 = 122;
+pub const ENOMEDIUM: u32 = 123;
+pub const EMEDIUMTYPE: u32 = 124;
+pub const ECANCELED: u32 = 125;
+pub const ENOKEY: u32 = 126;
+pub const EKEYEXPIRED: u32 = 127;
+pub const EKEYREVOKED: u32 = 128;
+pub const EKEYREJECTED: u32 = 129;
+pub const EOWNERDEAD: u32 = 130;
+pub const ENOTRECOVERABLE: u32 = 131;
+pub const ERFKILL: u32 = 132;
+pub const EHWPOISON: u32 = 133;
+pub const ENOTSUP: u32 = 95;
+pub const _LOCALE_H: u32 = 1;
+pub const _BITS_LOCALE_H: u32 = 1;
+pub const __LC_CTYPE: u32 = 0;
+pub const __LC_NUMERIC: u32 = 1;
+pub const __LC_TIME: u32 = 2;
+pub const __LC_COLLATE: u32 = 3;
+pub const __LC_MONETARY: u32 = 4;
+pub const __LC_MESSAGES: u32 = 5;
+pub const __LC_ALL: u32 = 6;
+pub const __LC_PAPER: u32 = 7;
+pub const __LC_NAME: u32 = 8;
+pub const __LC_ADDRESS: u32 = 9;
+pub const __LC_TELEPHONE: u32 = 10;
+pub const __LC_MEASUREMENT: u32 = 11;
+pub const __LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE: u32 = 0;
+pub const LC_NUMERIC: u32 = 1;
+pub const LC_TIME: u32 = 2;
+pub const LC_COLLATE: u32 = 3;
+pub const LC_MONETARY: u32 = 4;
+pub const LC_MESSAGES: u32 = 5;
+pub const LC_ALL: u32 = 6;
+pub const LC_PAPER: u32 = 7;
+pub const LC_NAME: u32 = 8;
+pub const LC_ADDRESS: u32 = 9;
+pub const LC_TELEPHONE: u32 = 10;
+pub const LC_MEASUREMENT: u32 = 11;
+pub const LC_IDENTIFICATION: u32 = 12;
+pub const LC_CTYPE_MASK: u32 = 1;
+pub const LC_NUMERIC_MASK: u32 = 2;
+pub const LC_TIME_MASK: u32 = 4;
+pub const LC_COLLATE_MASK: u32 = 8;
+pub const LC_MONETARY_MASK: u32 = 16;
+pub const LC_MESSAGES_MASK: u32 = 32;
+pub const LC_PAPER_MASK: u32 = 128;
+pub const LC_NAME_MASK: u32 = 256;
+pub const LC_ADDRESS_MASK: u32 = 512;
+pub const LC_TELEPHONE_MASK: u32 = 1024;
+pub const LC_MEASUREMENT_MASK: u32 = 2048;
+pub const LC_IDENTIFICATION_MASK: u32 = 4096;
+pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4usize] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4usize] = b"%lu\0";
 pub const HAVE_INT128: u32 = 1;
@@ -1059,44 +766,26 @@ pub const PG_BINARY: u32 = 0;
 pub const PG_BINARY_A: &[u8; 2usize] = b"a\0";
 pub const PG_BINARY_R: &[u8; 2usize] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2usize] = b"w\0";
-pub const _CACHED_RUNES: u32 = 256;
-pub const _CRMASK: i32 = -256;
-pub const _RUNE_MAGIC_A: &[u8; 9usize] = b"RuneMagA\0";
-pub const _CTYPE_A: u32 = 256;
-pub const _CTYPE_C: u32 = 512;
-pub const _CTYPE_D: u32 = 1024;
-pub const _CTYPE_G: u32 = 2048;
-pub const _CTYPE_L: u32 = 4096;
-pub const _CTYPE_P: u32 = 8192;
-pub const _CTYPE_S: u32 = 16384;
-pub const _CTYPE_U: u32 = 32768;
-pub const _CTYPE_X: u32 = 65536;
-pub const _CTYPE_B: u32 = 131072;
-pub const _CTYPE_R: u32 = 262144;
-pub const _CTYPE_I: u32 = 524288;
-pub const _CTYPE_T: u32 = 1048576;
-pub const _CTYPE_Q: u32 = 2097152;
-pub const _CTYPE_SW0: u32 = 536870912;
-pub const _CTYPE_SW1: u32 = 1073741824;
-pub const _CTYPE_SW2: u32 = 2147483648;
-pub const _CTYPE_SW3: u32 = 3221225472;
-pub const _CTYPE_SWM: u32 = 3758096384;
-pub const _CTYPE_SWS: u32 = 30;
+pub const _CTYPE_H: u32 = 1;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 15.0\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28usize] = b"postgres (PostgreSQL) 15.1\n\0";
 pub const EXE: &[u8; 1usize] = b"\0";
 pub const DEVNULL: &[u8; 10usize] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
 pub const PG_STRERROR_R_BUFLEN: u32 = 256;
 pub const PG_IOLBF: u32 = 1;
-pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -1110,13 +799,9 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const _JBLEN: u32 = 48;
+pub const _SETJMP_H: u32 = 1;
+pub const _BITS_SETJMP_H: u32 = 1;
+pub const __jmp_buf_tag_defined: u32 = 1;
 pub const DEBUG5: u32 = 10;
 pub const DEBUG4: u32 = 11;
 pub const DEBUG3: u32 = 12;
@@ -1195,161 +880,135 @@ pub const LP_DEAD: u32 = 3;
 pub const SpecTokenOffsetNumber: u32 = 65534;
 pub const MovedPartitionsOffsetNumber: u32 = 65533;
 pub const FIELDNO_HEAPTUPLEDATA_DATA: u32 = 3;
+pub const _FCNTL_H: u32 = 1;
+pub const __O_LARGEFILE: u32 = 0;
+pub const F_GETLK64: u32 = 5;
+pub const F_SETLK64: u32 = 6;
+pub const F_SETLKW64: u32 = 7;
+pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
 pub const O_RDWR: u32 = 2;
-pub const O_ACCMODE: u32 = 3;
-pub const FREAD: u32 = 1;
-pub const FWRITE: u32 = 2;
-pub const O_NONBLOCK: u32 = 4;
-pub const O_APPEND: u32 = 8;
-pub const O_SYNC: u32 = 128;
-pub const O_SHLOCK: u32 = 16;
-pub const O_EXLOCK: u32 = 32;
-pub const O_ASYNC: u32 = 64;
-pub const O_FSYNC: u32 = 128;
-pub const O_NOFOLLOW: u32 = 256;
-pub const O_CREAT: u32 = 512;
-pub const O_TRUNC: u32 = 1024;
-pub const O_EXCL: u32 = 2048;
-pub const O_EVTONLY: u32 = 32768;
-pub const O_NOCTTY: u32 = 131072;
-pub const O_DIRECTORY: u32 = 1048576;
-pub const O_SYMLINK: u32 = 2097152;
-pub const O_DSYNC: u32 = 4194304;
-pub const O_CLOEXEC: u32 = 16777216;
-pub const O_NOFOLLOW_ANY: u32 = 536870912;
-pub const O_EXEC: u32 = 1073741824;
-pub const O_SEARCH: u32 = 1074790400;
-pub const AT_FDCWD: i32 = -2;
-pub const AT_EACCESS: u32 = 16;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 32;
-pub const AT_SYMLINK_FOLLOW: u32 = 64;
-pub const AT_REMOVEDIR: u32 = 128;
-pub const AT_REALDEV: u32 = 512;
-pub const AT_FDONLY: u32 = 1024;
-pub const AT_SYMLINK_NOFOLLOW_ANY: u32 = 2048;
-pub const O_DP_GETRAWENCRYPTED: u32 = 1;
-pub const O_DP_GETRAWUNENCRYPTED: u32 = 2;
-pub const O_DP_AUTHENTICATE: u32 = 4;
-pub const AUTH_OPEN_NOAUTHFD: i32 = -1;
-pub const FAPPEND: u32 = 8;
-pub const FASYNC: u32 = 64;
-pub const FFSYNC: u32 = 128;
-pub const FFDSYNC: u32 = 4194304;
-pub const FNONBLOCK: u32 = 4;
-pub const FNDELAY: u32 = 4;
-pub const O_NDELAY: u32 = 4;
-pub const CPF_OVERWRITE: u32 = 1;
-pub const CPF_IGNORE_MODE: u32 = 2;
-pub const CPF_MASK: u32 = 3;
+pub const O_CREAT: u32 = 64;
+pub const O_EXCL: u32 = 128;
+pub const O_NOCTTY: u32 = 256;
+pub const O_TRUNC: u32 = 512;
+pub const O_APPEND: u32 = 1024;
+pub const O_NONBLOCK: u32 = 2048;
+pub const O_NDELAY: u32 = 2048;
+pub const O_SYNC: u32 = 1052672;
+pub const O_FSYNC: u32 = 1052672;
+pub const O_ASYNC: u32 = 8192;
+pub const __O_DIRECTORY: u32 = 65536;
+pub const __O_NOFOLLOW: u32 = 131072;
+pub const __O_CLOEXEC: u32 = 524288;
+pub const __O_DIRECT: u32 = 16384;
+pub const __O_NOATIME: u32 = 262144;
+pub const __O_PATH: u32 = 2097152;
+pub const __O_DSYNC: u32 = 4096;
+pub const __O_TMPFILE: u32 = 4259840;
+pub const F_GETLK: u32 = 5;
+pub const F_SETLK: u32 = 6;
+pub const F_SETLKW: u32 = 7;
+pub const O_DIRECTORY: u32 = 65536;
+pub const O_NOFOLLOW: u32 = 131072;
+pub const O_CLOEXEC: u32 = 524288;
+pub const O_DSYNC: u32 = 4096;
+pub const O_RSYNC: u32 = 1052672;
 pub const F_DUPFD: u32 = 0;
 pub const F_GETFD: u32 = 1;
 pub const F_SETFD: u32 = 2;
 pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
-pub const F_GETOWN: u32 = 5;
-pub const F_SETOWN: u32 = 6;
-pub const F_GETLK: u32 = 7;
-pub const F_SETLK: u32 = 8;
-pub const F_SETLKW: u32 = 9;
-pub const F_SETLKWTIMEOUT: u32 = 10;
-pub const F_FLUSH_DATA: u32 = 40;
-pub const F_CHKCLEAN: u32 = 41;
-pub const F_PREALLOCATE: u32 = 42;
-pub const F_SETSIZE: u32 = 43;
-pub const F_RDADVISE: u32 = 44;
-pub const F_RDAHEAD: u32 = 45;
-pub const F_NOCACHE: u32 = 48;
-pub const F_LOG2PHYS: u32 = 49;
-pub const F_GETPATH: u32 = 50;
-pub const F_FULLFSYNC: u32 = 51;
-pub const F_PATHPKG_CHECK: u32 = 52;
-pub const F_FREEZE_FS: u32 = 53;
-pub const F_THAW_FS: u32 = 54;
-pub const F_GLOBAL_NOCACHE: u32 = 55;
-pub const F_ADDSIGS: u32 = 59;
-pub const F_ADDFILESIGS: u32 = 61;
-pub const F_NODIRECT: u32 = 62;
-pub const F_GETPROTECTIONCLASS: u32 = 63;
-pub const F_SETPROTECTIONCLASS: u32 = 64;
-pub const F_LOG2PHYS_EXT: u32 = 65;
-pub const F_GETLKPID: u32 = 66;
-pub const F_SETBACKINGSTORE: u32 = 70;
-pub const F_GETPATH_MTMINFO: u32 = 71;
-pub const F_GETCODEDIR: u32 = 72;
-pub const F_SETNOSIGPIPE: u32 = 73;
-pub const F_GETNOSIGPIPE: u32 = 74;
-pub const F_TRANSCODEKEY: u32 = 75;
-pub const F_SINGLE_WRITER: u32 = 76;
-pub const F_GETPROTECTIONLEVEL: u32 = 77;
-pub const F_FINDSIGS: u32 = 78;
-pub const F_ADDFILESIGS_FOR_DYLD_SIM: u32 = 83;
-pub const F_BARRIERFSYNC: u32 = 85;
-pub const F_ADDFILESIGS_RETURN: u32 = 97;
-pub const F_CHECK_LV: u32 = 98;
-pub const F_PUNCHHOLE: u32 = 99;
-pub const F_TRIM_ACTIVE_FILE: u32 = 100;
-pub const F_SPECULATIVE_READ: u32 = 101;
-pub const F_GETPATH_NOFIRMLINK: u32 = 102;
-pub const F_ADDFILESIGS_INFO: u32 = 103;
-pub const F_ADDFILESUPPL: u32 = 104;
-pub const F_GETSIGSINFO: u32 = 105;
-pub const F_SETLEASE: u32 = 106;
-pub const F_GETLEASE: u32 = 107;
-pub const F_TRANSFEREXTENTS: u32 = 110;
-pub const FCNTL_FS_SPECIFIC_BASE: u32 = 65536;
-pub const F_DUPFD_CLOEXEC: u32 = 67;
+pub const __F_SETOWN: u32 = 8;
+pub const __F_GETOWN: u32 = 9;
+pub const F_SETOWN: u32 = 8;
+pub const F_GETOWN: u32 = 9;
+pub const __F_SETSIG: u32 = 10;
+pub const __F_GETSIG: u32 = 11;
+pub const __F_SETOWN_EX: u32 = 15;
+pub const __F_GETOWN_EX: u32 = 16;
+pub const F_DUPFD_CLOEXEC: u32 = 1030;
 pub const FD_CLOEXEC: u32 = 1;
-pub const F_RDLCK: u32 = 1;
+pub const F_RDLCK: u32 = 0;
+pub const F_WRLCK: u32 = 1;
 pub const F_UNLCK: u32 = 2;
-pub const F_WRLCK: u32 = 3;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const S_IFMT: u32 = 61440;
-pub const S_IFIFO: u32 = 4096;
-pub const S_IFCHR: u32 = 8192;
-pub const S_IFDIR: u32 = 16384;
-pub const S_IFBLK: u32 = 24576;
-pub const S_IFREG: u32 = 32768;
-pub const S_IFLNK: u32 = 40960;
-pub const S_IFSOCK: u32 = 49152;
-pub const S_IFWHT: u32 = 57344;
-pub const S_IRWXU: u32 = 448;
-pub const S_IRUSR: u32 = 256;
-pub const S_IWUSR: u32 = 128;
-pub const S_IXUSR: u32 = 64;
-pub const S_IRWXG: u32 = 56;
-pub const S_IRGRP: u32 = 32;
-pub const S_IWGRP: u32 = 16;
-pub const S_IXGRP: u32 = 8;
-pub const S_IRWXO: u32 = 7;
-pub const S_IROTH: u32 = 4;
-pub const S_IWOTH: u32 = 2;
-pub const S_IXOTH: u32 = 1;
-pub const S_ISUID: u32 = 2048;
-pub const S_ISGID: u32 = 1024;
-pub const S_ISVTX: u32 = 512;
-pub const S_ISTXT: u32 = 512;
-pub const S_IREAD: u32 = 256;
-pub const S_IWRITE: u32 = 128;
-pub const S_IEXEC: u32 = 64;
-pub const F_ALLOCATECONTIG: u32 = 2;
-pub const F_ALLOCATEALL: u32 = 4;
-pub const F_ALLOCATEPERSIST: u32 = 8;
-pub const F_PEOFPOSMODE: u32 = 3;
-pub const F_VOLPOSMODE: u32 = 4;
-pub const USER_FSIGNATURES_CDHASH_LEN: u32 = 20;
-pub const GETSIGSINFO_PLATFORM_BINARY: u32 = 1;
+pub const F_EXLCK: u32 = 4;
+pub const F_SHLCK: u32 = 8;
 pub const LOCK_SH: u32 = 1;
 pub const LOCK_EX: u32 = 2;
 pub const LOCK_NB: u32 = 4;
 pub const LOCK_UN: u32 = 8;
-pub const O_POPUP: u32 = 2147483648;
-pub const O_ALERT: u32 = 536870912;
+pub const FAPPEND: u32 = 1024;
+pub const FFSYNC: u32 = 1052672;
+pub const FASYNC: u32 = 8192;
+pub const FNONBLOCK: u32 = 2048;
+pub const FNDELAY: u32 = 2048;
+pub const __POSIX_FADV_DONTNEED: u32 = 4;
+pub const __POSIX_FADV_NOREUSE: u32 = 5;
+pub const POSIX_FADV_NORMAL: u32 = 0;
+pub const POSIX_FADV_RANDOM: u32 = 1;
+pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
+pub const POSIX_FADV_WILLNEED: u32 = 3;
+pub const POSIX_FADV_DONTNEED: u32 = 4;
+pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const _BITS_STAT_H: u32 = 1;
+pub const _BITS_STRUCT_STAT_H: u32 = 1;
+pub const __S_IFMT: u32 = 61440;
+pub const __S_IFDIR: u32 = 16384;
+pub const __S_IFCHR: u32 = 8192;
+pub const __S_IFBLK: u32 = 24576;
+pub const __S_IFREG: u32 = 32768;
+pub const __S_IFIFO: u32 = 4096;
+pub const __S_IFLNK: u32 = 40960;
+pub const __S_IFSOCK: u32 = 49152;
+pub const __S_ISUID: u32 = 2048;
+pub const __S_ISGID: u32 = 1024;
+pub const __S_ISVTX: u32 = 512;
+pub const __S_IREAD: u32 = 256;
+pub const __S_IWRITE: u32 = 128;
+pub const __S_IEXEC: u32 = 64;
+pub const UTIME_NOW: u32 = 1073741823;
+pub const UTIME_OMIT: u32 = 1073741822;
+pub const S_IFMT: u32 = 61440;
+pub const S_IFDIR: u32 = 16384;
+pub const S_IFCHR: u32 = 8192;
+pub const S_IFBLK: u32 = 24576;
+pub const S_IFREG: u32 = 32768;
+pub const S_IFIFO: u32 = 4096;
+pub const S_IFLNK: u32 = 40960;
+pub const S_IFSOCK: u32 = 49152;
+pub const S_ISUID: u32 = 2048;
+pub const S_ISGID: u32 = 1024;
+pub const S_ISVTX: u32 = 512;
+pub const S_IRUSR: u32 = 256;
+pub const S_IWUSR: u32 = 128;
+pub const S_IXUSR: u32 = 64;
+pub const S_IRWXU: u32 = 448;
+pub const S_IRGRP: u32 = 32;
+pub const S_IWGRP: u32 = 16;
+pub const S_IXGRP: u32 = 8;
+pub const S_IRWXG: u32 = 56;
+pub const S_IROTH: u32 = 4;
+pub const S_IWOTH: u32 = 2;
+pub const S_IXOTH: u32 = 1;
+pub const S_IRWXO: u32 = 7;
+pub const R_OK: u32 = 4;
+pub const W_OK: u32 = 2;
+pub const X_OK: u32 = 1;
+pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
+pub const F_ULOCK: u32 = 0;
+pub const F_LOCK: u32 = 1;
+pub const F_TLOCK: u32 = 2;
+pub const F_TEST: u32 = 3;
 pub const InvalidXLogRecPtr: u32 = 0;
-pub const OPEN_SYNC_FLAG: u32 = 128;
-pub const OPEN_DATASYNC_FLAG: u32 = 4194304;
+pub const OPEN_SYNC_FLAG: u32 = 1052672;
+pub const OPEN_DATASYNC_FLAG: u32 = 4096;
 pub const FirstGenbkiObjectId: u32 = 10000;
 pub const FirstUnpinnedObjectId: u32 = 12000;
 pub const FirstNormalObjectId: u32 = 16384;
@@ -1678,7 +1337,24 @@ pub const FIELDNO_HEAPTUPLETABLESLOT_OFF: u32 = 2;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_TUPLE: u32 = 1;
 pub const FIELDNO_MINIMALTUPLETABLESLOT_OFF: u32 = 4;
 pub const BITS_PER_BITMAPWORD: u32 = 64;
+pub const _TIME_H: u32 = 1;
+pub const _BITS_TIME_H: u32 = 1;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_TAI: u32 = 11;
+pub const TIMER_ABSTIME: u32 = 1;
+pub const __struct_tm_defined: u32 = 1;
+pub const __itimerspec_defined: u32 = 1;
 pub const TIME_UTC: u32 = 1;
+pub const PG_INSTR_CLOCK: u32 = 1;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ISNULL: u32 = 4;
 pub const FIELDNO_FUNCTIONCALLINFODATA_ARGS: u32 = 6;
 pub const PG_MAGIC_FUNCTION_NAME_STRING: &[u8; 14usize] = b"Pg_magic_func\0";
@@ -1793,121 +1469,84 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 256;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 512;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 1024;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 2048;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
 pub const DSM_IMPL_POSIX: u32 = 1;
 pub const DSM_IMPL_SYSV: u32 = 2;
 pub const DSM_IMPL_WINDOWS: u32 = 3;
@@ -1938,26 +1577,10 @@ pub const HASH_SHARED_MEM: u32 = 2048;
 pub const HASH_ATTACH: u32 = 4096;
 pub const HASH_FIXED_SIZE: u32 = 8192;
 pub const NO_MAX_DSIZE: i32 = -1;
-pub const __DARWIN_MAXNAMLEN: u32 = 255;
-pub const __DARWIN_MAXPATHLEN: u32 = 1024;
+pub const _DIRENT_H: u32 = 1;
+pub const _DIRENT_MATCHES_DIRENT64: u32 = 1;
 pub const MAXNAMLEN: u32 = 255;
-pub const DT_UNKNOWN: u32 = 0;
-pub const DT_FIFO: u32 = 1;
-pub const DT_CHR: u32 = 2;
-pub const DT_DIR: u32 = 4;
-pub const DT_BLK: u32 = 6;
-pub const DT_REG: u32 = 8;
-pub const DT_LNK: u32 = 10;
-pub const DT_SOCK: u32 = 12;
-pub const DT_WHT: u32 = 14;
-pub const DIRBLKSIZ: u32 = 1024;
-pub const DTF_HIDEW: u32 = 1;
-pub const DTF_NODUP: u32 = 2;
-pub const DTF_REWIND: u32 = 4;
-pub const __DTF_READALL: u32 = 8;
-pub const __DTF_SKIPREAD: u32 = 16;
-pub const __DTF_ATEND: u32 = 32;
-pub const PG_O_DIRECT: u32 = 2147483648;
+pub const PG_O_DIRECT: u32 = 0;
 pub const PG_TEMP_FILES_DIR: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const PG_TEMP_FILE_PREFIX: &[u8; 10usize] = b"pgsql_tmp\0";
 pub const SHARED_TUPLESTORE_SINGLE_PASS: u32 = 1;
@@ -2009,6 +1632,7 @@ pub const FIELDNO_EXPRCONTEXT_CASEDATUM: u32 = 10;
 pub const FIELDNO_EXPRCONTEXT_CASENULL: u32 = 11;
 pub const FIELDNO_EXPRCONTEXT_DOMAINDATUM: u32 = 12;
 pub const FIELDNO_EXPRCONTEXT_DOMAINNULL: u32 = 13;
+pub const TRY_POPCNT_FAST: u32 = 1;
 pub const MERGE_INSERT: u32 = 1;
 pub const MERGE_UPDATE: u32 = 2;
 pub const MERGE_DELETE: u32 = 4;
@@ -2033,8 +1657,89 @@ pub const EXEC_FLAG_BACKWARD: u32 = 4;
 pub const EXEC_FLAG_MARK: u32 = 8;
 pub const EXEC_FLAG_SKIP_TRIGGERS: u32 = 16;
 pub const EXEC_FLAG_WITH_NO_DATA: u32 = 32;
+pub const MAT_SRF_USE_EXPECTED_DESC: u32 = 1;
+pub const MAT_SRF_BLESS: u32 = 2;
 pub const SRF_SINGLE_USE_EXPECTED: u32 = 1;
 pub const SRF_SINGLE_BLESS: u32 = 2;
+pub const _BITS_SIGNUM_GENERIC_H: u32 = 1;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const _BITS_SIGNUM_ARCH_H: u32 = 1;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const __SIGRTMIN: u32 = 32;
+pub const __SIGRTMAX: u32 = 64;
+pub const _NSIG: u32 = 65;
+pub const __sig_atomic_t_defined: u32 = 1;
+pub const __siginfo_t_defined: u32 = 1;
+pub const __SI_MAX_SIZE: u32 = 128;
+pub const _BITS_SIGINFO_ARCH_H: u32 = 1;
+pub const __SI_ERRNO_THEN_CODE: u32 = 1;
+pub const __SI_HAVE_SIGSYS: u32 = 1;
+pub const _BITS_SIGINFO_CONSTS_H: u32 = 1;
+pub const __SI_ASYNCIO_AFTER_SIGIO: u32 = 1;
+pub const __sigevent_t_defined: u32 = 1;
+pub const __SIGEV_MAX_SIZE: u32 = 64;
+pub const _BITS_SIGEVENT_CONSTS_H: u32 = 1;
+pub const NSIG: u32 = 65;
+pub const _BITS_SIGACTION_H: u32 = 1;
+pub const SA_NOCLDSTOP: u32 = 1;
+pub const SA_NOCLDWAIT: u32 = 2;
+pub const SA_SIGINFO: u32 = 4;
+pub const SA_ONSTACK: u32 = 134217728;
+pub const SA_RESTART: u32 = 268435456;
+pub const SA_NODEFER: u32 = 1073741824;
+pub const SA_RESETHAND: u32 = 2147483648;
+pub const SA_INTERRUPT: u32 = 536870912;
+pub const SA_NOMASK: u32 = 1073741824;
+pub const SA_ONESHOT: u32 = 2147483648;
+pub const SA_STACK: u32 = 134217728;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const _BITS_SIGCONTEXT_H: u32 = 1;
+pub const FP_XSTATE_MAGIC1: u32 = 1179670611;
+pub const FP_XSTATE_MAGIC2: u32 = 1179670597;
+pub const __stack_t_defined: u32 = 1;
+pub const _SYS_UCONTEXT_H: u32 = 1;
+pub const __NGREG: u32 = 23;
+pub const NGREG: u32 = 23;
+pub const _BITS_SIGSTACK_H: u32 = 1;
+pub const MINSIGSTKSZ: u32 = 2048;
+pub const SIGSTKSZ: u32 = 8192;
+pub const _BITS_SS_FLAGS_H: u32 = 1;
+pub const __sigstack_defined: u32 = 1;
+pub const _BITS_SIGTHREAD_H: u32 = 1;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -2057,353 +1762,365 @@ pub const MIN_XFN_CHARS: u32 = 16;
 pub const MAX_XFN_CHARS: u32 = 40;
 pub const VALID_XFN_CHARS: &[u8; 40usize] = b"0123456789ABCDEF.history.backup.partial\0";
 pub const PGSTAT_NUM_PROGRESS_PARAM: u32 = 20;
-pub const KEV_INET_SUBCLASS: u32 = 1;
-pub const KEV_INET_NEW_ADDR: u32 = 1;
-pub const KEV_INET_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET_ADDR_DELETED: u32 = 3;
-pub const KEV_INET_SIFDSTADDR: u32 = 4;
-pub const KEV_INET_SIFBRDADDR: u32 = 5;
-pub const KEV_INET_SIFNETMASK: u32 = 6;
-pub const KEV_INET_ARPCOLLISION: u32 = 7;
-pub const KEV_INET_PORTINUSE: u32 = 8;
-pub const KEV_INET_ARPRTRFAILURE: u32 = 9;
-pub const KEV_INET_ARPRTRALIVE: u32 = 10;
-pub const KEV_DL_SUBCLASS: u32 = 2;
-pub const KEV_DL_SIFFLAGS: u32 = 1;
-pub const KEV_DL_SIFMETRICS: u32 = 2;
-pub const KEV_DL_SIFMTU: u32 = 3;
-pub const KEV_DL_SIFPHYS: u32 = 4;
-pub const KEV_DL_SIFMEDIA: u32 = 5;
-pub const KEV_DL_SIFGENERIC: u32 = 6;
-pub const KEV_DL_ADDMULTI: u32 = 7;
-pub const KEV_DL_DELMULTI: u32 = 8;
-pub const KEV_DL_IF_ATTACHED: u32 = 9;
-pub const KEV_DL_IF_DETACHING: u32 = 10;
-pub const KEV_DL_IF_DETACHED: u32 = 11;
-pub const KEV_DL_LINK_OFF: u32 = 12;
-pub const KEV_DL_LINK_ON: u32 = 13;
-pub const KEV_DL_PROTO_ATTACHED: u32 = 14;
-pub const KEV_DL_PROTO_DETACHED: u32 = 15;
-pub const KEV_DL_LINK_ADDRESS_CHANGED: u32 = 16;
-pub const KEV_DL_WAKEFLAGS_CHANGED: u32 = 17;
-pub const KEV_DL_IF_IDLE_ROUTE_REFCNT: u32 = 18;
-pub const KEV_DL_IFCAP_CHANGED: u32 = 19;
-pub const KEV_DL_LINK_QUALITY_METRIC_CHANGED: u32 = 20;
-pub const KEV_DL_NODE_PRESENCE: u32 = 21;
-pub const KEV_DL_NODE_ABSENCE: u32 = 22;
-pub const KEV_DL_PRIMARY_ELECTED: u32 = 23;
-pub const KEV_DL_ISSUES: u32 = 24;
-pub const KEV_DL_IFDELEGATE_CHANGED: u32 = 25;
-pub const KEV_DL_AWDL_RESTRICTED: u32 = 26;
-pub const KEV_DL_AWDL_UNRESTRICTED: u32 = 27;
-pub const KEV_DL_RRC_STATE_CHANGED: u32 = 28;
-pub const KEV_DL_QOS_MODE_CHANGED: u32 = 29;
-pub const KEV_DL_LOW_POWER_MODE_CHANGED: u32 = 30;
-pub const KEV_INET6_SUBCLASS: u32 = 6;
-pub const KEV_INET6_NEW_USER_ADDR: u32 = 1;
-pub const KEV_INET6_CHANGED_ADDR: u32 = 2;
-pub const KEV_INET6_ADDR_DELETED: u32 = 3;
-pub const KEV_INET6_NEW_LL_ADDR: u32 = 4;
-pub const KEV_INET6_NEW_RTADV_ADDR: u32 = 5;
-pub const KEV_INET6_DEFROUTER: u32 = 6;
-pub const KEV_INET6_REQUEST_NAT64_PREFIX: u32 = 7;
-pub const SOCK_STREAM: u32 = 1;
-pub const SOCK_DGRAM: u32 = 2;
-pub const SOCK_RAW: u32 = 3;
-pub const SOCK_RDM: u32 = 4;
-pub const SOCK_SEQPACKET: u32 = 5;
-pub const SO_DEBUG: u32 = 1;
-pub const SO_ACCEPTCONN: u32 = 2;
-pub const SO_REUSEADDR: u32 = 4;
-pub const SO_KEEPALIVE: u32 = 8;
-pub const SO_DONTROUTE: u32 = 16;
-pub const SO_BROADCAST: u32 = 32;
-pub const SO_USELOOPBACK: u32 = 64;
-pub const SO_LINGER: u32 = 128;
-pub const SO_LINGER_SEC: u32 = 4224;
-pub const SO_OOBINLINE: u32 = 256;
-pub const SO_REUSEPORT: u32 = 512;
-pub const SO_TIMESTAMP: u32 = 1024;
-pub const SO_TIMESTAMP_MONOTONIC: u32 = 2048;
-pub const SO_DONTTRUNC: u32 = 8192;
-pub const SO_WANTMORE: u32 = 16384;
-pub const SO_WANTOOBFLAG: u32 = 32768;
-pub const SO_SNDBUF: u32 = 4097;
-pub const SO_RCVBUF: u32 = 4098;
-pub const SO_SNDLOWAT: u32 = 4099;
-pub const SO_RCVLOWAT: u32 = 4100;
-pub const SO_SNDTIMEO: u32 = 4101;
-pub const SO_RCVTIMEO: u32 = 4102;
-pub const SO_ERROR: u32 = 4103;
-pub const SO_TYPE: u32 = 4104;
-pub const SO_LABEL: u32 = 4112;
-pub const SO_PEERLABEL: u32 = 4113;
-pub const SO_NREAD: u32 = 4128;
-pub const SO_NKE: u32 = 4129;
-pub const SO_NOSIGPIPE: u32 = 4130;
-pub const SO_NOADDRERR: u32 = 4131;
-pub const SO_NWRITE: u32 = 4132;
-pub const SO_REUSESHAREUID: u32 = 4133;
-pub const SO_NOTIFYCONFLICT: u32 = 4134;
-pub const SO_UPCALLCLOSEWAIT: u32 = 4135;
-pub const SO_RANDOMPORT: u32 = 4226;
-pub const SO_NP_EXTENSIONS: u32 = 4227;
-pub const SO_NUMRCVPKT: u32 = 4370;
-pub const SO_NET_SERVICE_TYPE: u32 = 4374;
-pub const SO_NETSVC_MARKING_LEVEL: u32 = 4377;
-pub const SO_RESOLVER_SIGNATURE: u32 = 4401;
-pub const NET_SERVICE_TYPE_BE: u32 = 0;
-pub const NET_SERVICE_TYPE_BK: u32 = 1;
-pub const NET_SERVICE_TYPE_SIG: u32 = 2;
-pub const NET_SERVICE_TYPE_VI: u32 = 3;
-pub const NET_SERVICE_TYPE_VO: u32 = 4;
-pub const NET_SERVICE_TYPE_RV: u32 = 5;
-pub const NET_SERVICE_TYPE_AV: u32 = 6;
-pub const NET_SERVICE_TYPE_OAM: u32 = 7;
-pub const NET_SERVICE_TYPE_RD: u32 = 8;
-pub const NETSVC_MRKNG_UNKNOWN: u32 = 0;
-pub const NETSVC_MRKNG_LVL_L2: u32 = 1;
-pub const NETSVC_MRKNG_LVL_L3L2_ALL: u32 = 2;
-pub const NETSVC_MRKNG_LVL_L3L2_BK: u32 = 3;
-pub const SAE_ASSOCID_ANY: u32 = 0;
-pub const SAE_CONNID_ANY: u32 = 0;
-pub const CONNECT_RESUME_ON_READ_WRITE: u32 = 1;
-pub const CONNECT_DATA_IDEMPOTENT: u32 = 2;
-pub const CONNECT_DATA_AUTHENTICATED: u32 = 4;
-pub const SONPX_SETOPTSHUT: u32 = 1;
-pub const SOL_SOCKET: u32 = 65535;
-pub const AF_UNSPEC: u32 = 0;
-pub const AF_UNIX: u32 = 1;
-pub const AF_LOCAL: u32 = 1;
-pub const AF_INET: u32 = 2;
-pub const AF_IMPLINK: u32 = 3;
-pub const AF_PUP: u32 = 4;
-pub const AF_CHAOS: u32 = 5;
-pub const AF_NS: u32 = 6;
-pub const AF_ISO: u32 = 7;
-pub const AF_OSI: u32 = 7;
-pub const AF_ECMA: u32 = 8;
-pub const AF_DATAKIT: u32 = 9;
-pub const AF_CCITT: u32 = 10;
-pub const AF_SNA: u32 = 11;
-pub const AF_DECnet: u32 = 12;
-pub const AF_DLI: u32 = 13;
-pub const AF_LAT: u32 = 14;
-pub const AF_HYLINK: u32 = 15;
-pub const AF_APPLETALK: u32 = 16;
-pub const AF_ROUTE: u32 = 17;
-pub const AF_LINK: u32 = 18;
-pub const pseudo_AF_XTP: u32 = 19;
-pub const AF_COIP: u32 = 20;
-pub const AF_CNT: u32 = 21;
-pub const pseudo_AF_RTIP: u32 = 22;
-pub const AF_IPX: u32 = 23;
-pub const AF_SIP: u32 = 24;
-pub const pseudo_AF_PIP: u32 = 25;
-pub const AF_NDRV: u32 = 27;
-pub const AF_ISDN: u32 = 28;
-pub const AF_E164: u32 = 28;
-pub const pseudo_AF_KEY: u32 = 29;
-pub const AF_INET6: u32 = 30;
-pub const AF_NATM: u32 = 31;
-pub const AF_SYSTEM: u32 = 32;
-pub const AF_NETBIOS: u32 = 33;
-pub const AF_PPP: u32 = 34;
-pub const pseudo_AF_HDRCMPLT: u32 = 35;
-pub const AF_RESERVED_36: u32 = 36;
-pub const AF_IEEE80211: u32 = 37;
-pub const AF_UTUN: u32 = 38;
-pub const AF_VSOCK: u32 = 40;
-pub const AF_MAX: u32 = 41;
-pub const SOCK_MAXADDRLEN: u32 = 255;
-pub const _SS_MAXSIZE: u32 = 128;
+pub const _SYS_SOCKET_H: u32 = 1;
+pub const __iovec_defined: u32 = 1;
 pub const PF_UNSPEC: u32 = 0;
 pub const PF_LOCAL: u32 = 1;
 pub const PF_UNIX: u32 = 1;
+pub const PF_FILE: u32 = 1;
 pub const PF_INET: u32 = 2;
-pub const PF_IMPLINK: u32 = 3;
-pub const PF_PUP: u32 = 4;
-pub const PF_CHAOS: u32 = 5;
-pub const PF_NS: u32 = 6;
-pub const PF_ISO: u32 = 7;
-pub const PF_OSI: u32 = 7;
-pub const PF_ECMA: u32 = 8;
-pub const PF_DATAKIT: u32 = 9;
-pub const PF_CCITT: u32 = 10;
-pub const PF_SNA: u32 = 11;
+pub const PF_AX25: u32 = 3;
+pub const PF_IPX: u32 = 4;
+pub const PF_APPLETALK: u32 = 5;
+pub const PF_NETROM: u32 = 6;
+pub const PF_BRIDGE: u32 = 7;
+pub const PF_ATMPVC: u32 = 8;
+pub const PF_X25: u32 = 9;
+pub const PF_INET6: u32 = 10;
+pub const PF_ROSE: u32 = 11;
 pub const PF_DECnet: u32 = 12;
-pub const PF_DLI: u32 = 13;
-pub const PF_LAT: u32 = 14;
-pub const PF_HYLINK: u32 = 15;
-pub const PF_APPLETALK: u32 = 16;
-pub const PF_ROUTE: u32 = 17;
-pub const PF_LINK: u32 = 18;
-pub const PF_XTP: u32 = 19;
-pub const PF_COIP: u32 = 20;
-pub const PF_CNT: u32 = 21;
-pub const PF_SIP: u32 = 24;
-pub const PF_IPX: u32 = 23;
-pub const PF_RTIP: u32 = 22;
-pub const PF_PIP: u32 = 25;
-pub const PF_NDRV: u32 = 27;
-pub const PF_ISDN: u32 = 28;
-pub const PF_KEY: u32 = 29;
-pub const PF_INET6: u32 = 30;
-pub const PF_NATM: u32 = 31;
-pub const PF_SYSTEM: u32 = 32;
-pub const PF_NETBIOS: u32 = 33;
-pub const PF_PPP: u32 = 34;
-pub const PF_RESERVED_36: u32 = 36;
-pub const PF_UTUN: u32 = 38;
+pub const PF_NETBEUI: u32 = 13;
+pub const PF_SECURITY: u32 = 14;
+pub const PF_KEY: u32 = 15;
+pub const PF_NETLINK: u32 = 16;
+pub const PF_ROUTE: u32 = 16;
+pub const PF_PACKET: u32 = 17;
+pub const PF_ASH: u32 = 18;
+pub const PF_ECONET: u32 = 19;
+pub const PF_ATMSVC: u32 = 20;
+pub const PF_RDS: u32 = 21;
+pub const PF_SNA: u32 = 22;
+pub const PF_IRDA: u32 = 23;
+pub const PF_PPPOX: u32 = 24;
+pub const PF_WANPIPE: u32 = 25;
+pub const PF_LLC: u32 = 26;
+pub const PF_IB: u32 = 27;
+pub const PF_MPLS: u32 = 28;
+pub const PF_CAN: u32 = 29;
+pub const PF_TIPC: u32 = 30;
+pub const PF_BLUETOOTH: u32 = 31;
+pub const PF_IUCV: u32 = 32;
+pub const PF_RXRPC: u32 = 33;
+pub const PF_ISDN: u32 = 34;
+pub const PF_PHONET: u32 = 35;
+pub const PF_IEEE802154: u32 = 36;
+pub const PF_CAIF: u32 = 37;
+pub const PF_ALG: u32 = 38;
+pub const PF_NFC: u32 = 39;
 pub const PF_VSOCK: u32 = 40;
-pub const PF_MAX: u32 = 41;
-pub const NET_MAXID: u32 = 41;
-pub const NET_RT_DUMP: u32 = 1;
-pub const NET_RT_FLAGS: u32 = 2;
-pub const NET_RT_IFLIST: u32 = 3;
-pub const NET_RT_STAT: u32 = 4;
-pub const NET_RT_TRASH: u32 = 5;
-pub const NET_RT_IFLIST2: u32 = 6;
-pub const NET_RT_DUMP2: u32 = 7;
-pub const NET_RT_FLAGS_PRIV: u32 = 10;
-pub const NET_RT_MAXID: u32 = 11;
-pub const SOMAXCONN: u32 = 128;
-pub const MSG_OOB: u32 = 1;
-pub const MSG_PEEK: u32 = 2;
-pub const MSG_DONTROUTE: u32 = 4;
-pub const MSG_EOR: u32 = 8;
-pub const MSG_TRUNC: u32 = 16;
-pub const MSG_CTRUNC: u32 = 32;
-pub const MSG_WAITALL: u32 = 64;
-pub const MSG_DONTWAIT: u32 = 128;
-pub const MSG_EOF: u32 = 256;
-pub const MSG_WAITSTREAM: u32 = 512;
-pub const MSG_FLUSH: u32 = 1024;
-pub const MSG_HOLD: u32 = 2048;
-pub const MSG_SEND: u32 = 4096;
-pub const MSG_HAVEMORE: u32 = 8192;
-pub const MSG_RCVMORE: u32 = 16384;
-pub const MSG_NEEDSA: u32 = 65536;
-pub const MSG_NOSIGNAL: u32 = 524288;
-pub const SCM_RIGHTS: u32 = 1;
-pub const SCM_TIMESTAMP: u32 = 2;
-pub const SCM_CREDS: u32 = 3;
-pub const SCM_TIMESTAMP_MONOTONIC: u32 = 4;
-pub const SHUT_RD: u32 = 0;
-pub const SHUT_WR: u32 = 1;
-pub const SHUT_RDWR: u32 = 2;
-pub const IPPROTO_IP: u32 = 0;
-pub const IPPROTO_HOPOPTS: u32 = 0;
-pub const IPPROTO_ICMP: u32 = 1;
-pub const IPPROTO_IGMP: u32 = 2;
-pub const IPPROTO_GGP: u32 = 3;
-pub const IPPROTO_IPV4: u32 = 4;
-pub const IPPROTO_IPIP: u32 = 4;
-pub const IPPROTO_TCP: u32 = 6;
-pub const IPPROTO_ST: u32 = 7;
-pub const IPPROTO_EGP: u32 = 8;
-pub const IPPROTO_PIGP: u32 = 9;
-pub const IPPROTO_RCCMON: u32 = 10;
-pub const IPPROTO_NVPII: u32 = 11;
-pub const IPPROTO_PUP: u32 = 12;
-pub const IPPROTO_ARGUS: u32 = 13;
-pub const IPPROTO_EMCON: u32 = 14;
-pub const IPPROTO_XNET: u32 = 15;
-pub const IPPROTO_CHAOS: u32 = 16;
-pub const IPPROTO_UDP: u32 = 17;
-pub const IPPROTO_MUX: u32 = 18;
-pub const IPPROTO_MEAS: u32 = 19;
-pub const IPPROTO_HMP: u32 = 20;
-pub const IPPROTO_PRM: u32 = 21;
-pub const IPPROTO_IDP: u32 = 22;
-pub const IPPROTO_TRUNK1: u32 = 23;
-pub const IPPROTO_TRUNK2: u32 = 24;
-pub const IPPROTO_LEAF1: u32 = 25;
-pub const IPPROTO_LEAF2: u32 = 26;
-pub const IPPROTO_RDP: u32 = 27;
-pub const IPPROTO_IRTP: u32 = 28;
-pub const IPPROTO_TP: u32 = 29;
-pub const IPPROTO_BLT: u32 = 30;
-pub const IPPROTO_NSP: u32 = 31;
-pub const IPPROTO_INP: u32 = 32;
-pub const IPPROTO_SEP: u32 = 33;
-pub const IPPROTO_3PC: u32 = 34;
-pub const IPPROTO_IDPR: u32 = 35;
-pub const IPPROTO_XTP: u32 = 36;
-pub const IPPROTO_DDP: u32 = 37;
-pub const IPPROTO_CMTP: u32 = 38;
-pub const IPPROTO_TPXX: u32 = 39;
-pub const IPPROTO_IL: u32 = 40;
-pub const IPPROTO_IPV6: u32 = 41;
-pub const IPPROTO_SDRP: u32 = 42;
-pub const IPPROTO_ROUTING: u32 = 43;
-pub const IPPROTO_FRAGMENT: u32 = 44;
-pub const IPPROTO_IDRP: u32 = 45;
-pub const IPPROTO_RSVP: u32 = 46;
-pub const IPPROTO_GRE: u32 = 47;
-pub const IPPROTO_MHRP: u32 = 48;
-pub const IPPROTO_BHA: u32 = 49;
-pub const IPPROTO_ESP: u32 = 50;
-pub const IPPROTO_AH: u32 = 51;
-pub const IPPROTO_INLSP: u32 = 52;
-pub const IPPROTO_SWIPE: u32 = 53;
-pub const IPPROTO_NHRP: u32 = 54;
-pub const IPPROTO_ICMPV6: u32 = 58;
-pub const IPPROTO_NONE: u32 = 59;
-pub const IPPROTO_DSTOPTS: u32 = 60;
-pub const IPPROTO_AHIP: u32 = 61;
-pub const IPPROTO_CFTP: u32 = 62;
-pub const IPPROTO_HELLO: u32 = 63;
-pub const IPPROTO_SATEXPAK: u32 = 64;
-pub const IPPROTO_KRYPTOLAN: u32 = 65;
-pub const IPPROTO_RVD: u32 = 66;
-pub const IPPROTO_IPPC: u32 = 67;
-pub const IPPROTO_ADFS: u32 = 68;
-pub const IPPROTO_SATMON: u32 = 69;
-pub const IPPROTO_VISA: u32 = 70;
-pub const IPPROTO_IPCV: u32 = 71;
-pub const IPPROTO_CPNX: u32 = 72;
-pub const IPPROTO_CPHB: u32 = 73;
-pub const IPPROTO_WSN: u32 = 74;
-pub const IPPROTO_PVP: u32 = 75;
-pub const IPPROTO_BRSATMON: u32 = 76;
-pub const IPPROTO_ND: u32 = 77;
-pub const IPPROTO_WBMON: u32 = 78;
-pub const IPPROTO_WBEXPAK: u32 = 79;
-pub const IPPROTO_EON: u32 = 80;
-pub const IPPROTO_VMTP: u32 = 81;
-pub const IPPROTO_SVMTP: u32 = 82;
-pub const IPPROTO_VINES: u32 = 83;
-pub const IPPROTO_TTP: u32 = 84;
-pub const IPPROTO_IGP: u32 = 85;
-pub const IPPROTO_DGP: u32 = 86;
-pub const IPPROTO_TCF: u32 = 87;
-pub const IPPROTO_IGRP: u32 = 88;
-pub const IPPROTO_OSPFIGP: u32 = 89;
-pub const IPPROTO_SRPC: u32 = 90;
-pub const IPPROTO_LARP: u32 = 91;
-pub const IPPROTO_MTP: u32 = 92;
-pub const IPPROTO_AX25: u32 = 93;
-pub const IPPROTO_IPEIP: u32 = 94;
-pub const IPPROTO_MICP: u32 = 95;
-pub const IPPROTO_SCCSP: u32 = 96;
-pub const IPPROTO_ETHERIP: u32 = 97;
-pub const IPPROTO_ENCAP: u32 = 98;
-pub const IPPROTO_APES: u32 = 99;
-pub const IPPROTO_GMTP: u32 = 100;
-pub const IPPROTO_PIM: u32 = 103;
-pub const IPPROTO_IPCOMP: u32 = 108;
-pub const IPPROTO_PGM: u32 = 113;
-pub const IPPROTO_SCTP: u32 = 132;
-pub const IPPROTO_DIVERT: u32 = 254;
-pub const IPPROTO_RAW: u32 = 255;
-pub const IPPROTO_MAX: u32 = 256;
-pub const IPPROTO_DONE: u32 = 257;
-pub const __DARWIN_IPPORT_RESERVED: u32 = 1024;
-pub const IPPORT_USERRESERVED: u32 = 5000;
-pub const IPPORT_HIFIRSTAUTO: u32 = 49152;
-pub const IPPORT_HILASTAUTO: u32 = 65535;
-pub const IPPORT_RESERVEDSTART: u32 = 600;
+pub const PF_KCM: u32 = 41;
+pub const PF_QIPCRTR: u32 = 42;
+pub const PF_SMC: u32 = 43;
+pub const PF_XDP: u32 = 44;
+pub const PF_MCTP: u32 = 45;
+pub const PF_MAX: u32 = 46;
+pub const AF_UNSPEC: u32 = 0;
+pub const AF_LOCAL: u32 = 1;
+pub const AF_UNIX: u32 = 1;
+pub const AF_FILE: u32 = 1;
+pub const AF_INET: u32 = 2;
+pub const AF_AX25: u32 = 3;
+pub const AF_IPX: u32 = 4;
+pub const AF_APPLETALK: u32 = 5;
+pub const AF_NETROM: u32 = 6;
+pub const AF_BRIDGE: u32 = 7;
+pub const AF_ATMPVC: u32 = 8;
+pub const AF_X25: u32 = 9;
+pub const AF_INET6: u32 = 10;
+pub const AF_ROSE: u32 = 11;
+pub const AF_DECnet: u32 = 12;
+pub const AF_NETBEUI: u32 = 13;
+pub const AF_SECURITY: u32 = 14;
+pub const AF_KEY: u32 = 15;
+pub const AF_NETLINK: u32 = 16;
+pub const AF_ROUTE: u32 = 16;
+pub const AF_PACKET: u32 = 17;
+pub const AF_ASH: u32 = 18;
+pub const AF_ECONET: u32 = 19;
+pub const AF_ATMSVC: u32 = 20;
+pub const AF_RDS: u32 = 21;
+pub const AF_SNA: u32 = 22;
+pub const AF_IRDA: u32 = 23;
+pub const AF_PPPOX: u32 = 24;
+pub const AF_WANPIPE: u32 = 25;
+pub const AF_LLC: u32 = 26;
+pub const AF_IB: u32 = 27;
+pub const AF_MPLS: u32 = 28;
+pub const AF_CAN: u32 = 29;
+pub const AF_TIPC: u32 = 30;
+pub const AF_BLUETOOTH: u32 = 31;
+pub const AF_IUCV: u32 = 32;
+pub const AF_RXRPC: u32 = 33;
+pub const AF_ISDN: u32 = 34;
+pub const AF_PHONET: u32 = 35;
+pub const AF_IEEE802154: u32 = 36;
+pub const AF_CAIF: u32 = 37;
+pub const AF_ALG: u32 = 38;
+pub const AF_NFC: u32 = 39;
+pub const AF_VSOCK: u32 = 40;
+pub const AF_KCM: u32 = 41;
+pub const AF_QIPCRTR: u32 = 42;
+pub const AF_SMC: u32 = 43;
+pub const AF_XDP: u32 = 44;
+pub const AF_MCTP: u32 = 45;
+pub const AF_MAX: u32 = 46;
+pub const SOL_RAW: u32 = 255;
+pub const SOL_DECNET: u32 = 261;
+pub const SOL_X25: u32 = 262;
+pub const SOL_PACKET: u32 = 263;
+pub const SOL_ATM: u32 = 264;
+pub const SOL_AAL: u32 = 265;
+pub const SOL_IRDA: u32 = 266;
+pub const SOL_NETBEUI: u32 = 267;
+pub const SOL_LLC: u32 = 268;
+pub const SOL_DCCP: u32 = 269;
+pub const SOL_NETLINK: u32 = 270;
+pub const SOL_TIPC: u32 = 271;
+pub const SOL_RXRPC: u32 = 272;
+pub const SOL_PPPOL2TP: u32 = 273;
+pub const SOL_BLUETOOTH: u32 = 274;
+pub const SOL_PNPIPE: u32 = 275;
+pub const SOL_RDS: u32 = 276;
+pub const SOL_IUCV: u32 = 277;
+pub const SOL_CAIF: u32 = 278;
+pub const SOL_ALG: u32 = 279;
+pub const SOL_NFC: u32 = 280;
+pub const SOL_KCM: u32 = 281;
+pub const SOL_TLS: u32 = 282;
+pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
+pub const SOMAXCONN: u32 = 4096;
+pub const _BITS_SOCKADDR_H: u32 = 1;
+pub const _SS_SIZE: u32 = 128;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const FIOSETOWN: u32 = 35073;
+pub const SIOCSPGRP: u32 = 35074;
+pub const FIOGETOWN: u32 = 35075;
+pub const SIOCGPGRP: u32 = 35076;
+pub const SIOCATMARK: u32 = 35077;
+pub const SIOCGSTAMP_OLD: u32 = 35078;
+pub const SIOCGSTAMPNS_OLD: u32 = 35079;
+pub const SOL_SOCKET: u32 = 1;
+pub const SO_DEBUG: u32 = 1;
+pub const SO_REUSEADDR: u32 = 2;
+pub const SO_TYPE: u32 = 3;
+pub const SO_ERROR: u32 = 4;
+pub const SO_DONTROUTE: u32 = 5;
+pub const SO_BROADCAST: u32 = 6;
+pub const SO_SNDBUF: u32 = 7;
+pub const SO_RCVBUF: u32 = 8;
+pub const SO_SNDBUFFORCE: u32 = 32;
+pub const SO_RCVBUFFORCE: u32 = 33;
+pub const SO_KEEPALIVE: u32 = 9;
+pub const SO_OOBINLINE: u32 = 10;
+pub const SO_NO_CHECK: u32 = 11;
+pub const SO_PRIORITY: u32 = 12;
+pub const SO_LINGER: u32 = 13;
+pub const SO_BSDCOMPAT: u32 = 14;
+pub const SO_REUSEPORT: u32 = 15;
+pub const SO_PASSCRED: u32 = 16;
+pub const SO_PEERCRED: u32 = 17;
+pub const SO_RCVLOWAT: u32 = 18;
+pub const SO_SNDLOWAT: u32 = 19;
+pub const SO_RCVTIMEO_OLD: u32 = 20;
+pub const SO_SNDTIMEO_OLD: u32 = 21;
+pub const SO_SECURITY_AUTHENTICATION: u32 = 22;
+pub const SO_SECURITY_ENCRYPTION_TRANSPORT: u32 = 23;
+pub const SO_SECURITY_ENCRYPTION_NETWORK: u32 = 24;
+pub const SO_BINDTODEVICE: u32 = 25;
+pub const SO_ATTACH_FILTER: u32 = 26;
+pub const SO_DETACH_FILTER: u32 = 27;
+pub const SO_GET_FILTER: u32 = 26;
+pub const SO_PEERNAME: u32 = 28;
+pub const SO_ACCEPTCONN: u32 = 30;
+pub const SO_PEERSEC: u32 = 31;
+pub const SO_PASSSEC: u32 = 34;
+pub const SO_MARK: u32 = 36;
+pub const SO_PROTOCOL: u32 = 38;
+pub const SO_DOMAIN: u32 = 39;
+pub const SO_RXQ_OVFL: u32 = 40;
+pub const SO_WIFI_STATUS: u32 = 41;
+pub const SCM_WIFI_STATUS: u32 = 41;
+pub const SO_PEEK_OFF: u32 = 42;
+pub const SO_NOFCS: u32 = 43;
+pub const SO_LOCK_FILTER: u32 = 44;
+pub const SO_SELECT_ERR_QUEUE: u32 = 45;
+pub const SO_BUSY_POLL: u32 = 46;
+pub const SO_MAX_PACING_RATE: u32 = 47;
+pub const SO_BPF_EXTENSIONS: u32 = 48;
+pub const SO_INCOMING_CPU: u32 = 49;
+pub const SO_ATTACH_BPF: u32 = 50;
+pub const SO_DETACH_BPF: u32 = 27;
+pub const SO_ATTACH_REUSEPORT_CBPF: u32 = 51;
+pub const SO_ATTACH_REUSEPORT_EBPF: u32 = 52;
+pub const SO_CNX_ADVICE: u32 = 53;
+pub const SCM_TIMESTAMPING_OPT_STATS: u32 = 54;
+pub const SO_MEMINFO: u32 = 55;
+pub const SO_INCOMING_NAPI_ID: u32 = 56;
+pub const SO_COOKIE: u32 = 57;
+pub const SCM_TIMESTAMPING_PKTINFO: u32 = 58;
+pub const SO_PEERGROUPS: u32 = 59;
+pub const SO_ZEROCOPY: u32 = 60;
+pub const SO_TXTIME: u32 = 61;
+pub const SCM_TXTIME: u32 = 61;
+pub const SO_BINDTOIFINDEX: u32 = 62;
+pub const SO_TIMESTAMP_OLD: u32 = 29;
+pub const SO_TIMESTAMPNS_OLD: u32 = 35;
+pub const SO_TIMESTAMPING_OLD: u32 = 37;
+pub const SO_TIMESTAMP_NEW: u32 = 63;
+pub const SO_TIMESTAMPNS_NEW: u32 = 64;
+pub const SO_TIMESTAMPING_NEW: u32 = 65;
+pub const SO_RCVTIMEO_NEW: u32 = 66;
+pub const SO_SNDTIMEO_NEW: u32 = 67;
+pub const SO_DETACH_REUSEPORT_BPF: u32 = 68;
+pub const SO_PREFER_BUSY_POLL: u32 = 69;
+pub const SO_BUSY_POLL_BUDGET: u32 = 70;
+pub const SO_NETNS_COOKIE: u32 = 71;
+pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_TIMESTAMP: u32 = 29;
+pub const SO_TIMESTAMPNS: u32 = 35;
+pub const SO_TIMESTAMPING: u32 = 37;
+pub const SO_RCVTIMEO: u32 = 20;
+pub const SO_SNDTIMEO: u32 = 21;
+pub const SCM_TIMESTAMP: u32 = 29;
+pub const SCM_TIMESTAMPNS: u32 = 35;
+pub const SCM_TIMESTAMPING: u32 = 37;
+pub const __osockaddr_defined: u32 = 1;
+pub const _NETDB_H: u32 = 1;
+pub const _NETINET_IN_H: u32 = 1;
+pub const __USE_KERNEL_IPV6_DEFS: u32 = 0;
+pub const IP_OPTIONS: u32 = 4;
+pub const IP_HDRINCL: u32 = 3;
+pub const IP_TOS: u32 = 1;
+pub const IP_TTL: u32 = 2;
+pub const IP_RECVOPTS: u32 = 6;
+pub const IP_RETOPTS: u32 = 7;
+pub const IP_MULTICAST_IF: u32 = 32;
+pub const IP_MULTICAST_TTL: u32 = 33;
+pub const IP_MULTICAST_LOOP: u32 = 34;
+pub const IP_ADD_MEMBERSHIP: u32 = 35;
+pub const IP_DROP_MEMBERSHIP: u32 = 36;
+pub const IP_UNBLOCK_SOURCE: u32 = 37;
+pub const IP_BLOCK_SOURCE: u32 = 38;
+pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 39;
+pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 40;
+pub const IP_MSFILTER: u32 = 41;
+pub const MCAST_JOIN_GROUP: u32 = 42;
+pub const MCAST_BLOCK_SOURCE: u32 = 43;
+pub const MCAST_UNBLOCK_SOURCE: u32 = 44;
+pub const MCAST_LEAVE_GROUP: u32 = 45;
+pub const MCAST_JOIN_SOURCE_GROUP: u32 = 46;
+pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 47;
+pub const MCAST_MSFILTER: u32 = 48;
+pub const IP_MULTICAST_ALL: u32 = 49;
+pub const IP_UNICAST_IF: u32 = 50;
+pub const MCAST_EXCLUDE: u32 = 0;
+pub const MCAST_INCLUDE: u32 = 1;
+pub const IP_ROUTER_ALERT: u32 = 5;
+pub const IP_PKTINFO: u32 = 8;
+pub const IP_PKTOPTIONS: u32 = 9;
+pub const IP_PMTUDISC: u32 = 10;
+pub const IP_MTU_DISCOVER: u32 = 10;
+pub const IP_RECVERR: u32 = 11;
+pub const IP_RECVTTL: u32 = 12;
+pub const IP_RECVTOS: u32 = 13;
+pub const IP_MTU: u32 = 14;
+pub const IP_FREEBIND: u32 = 15;
+pub const IP_IPSEC_POLICY: u32 = 16;
+pub const IP_XFRM_POLICY: u32 = 17;
+pub const IP_PASSSEC: u32 = 18;
+pub const IP_TRANSPARENT: u32 = 19;
+pub const IP_ORIGDSTADDR: u32 = 20;
+pub const IP_RECVORIGDSTADDR: u32 = 20;
+pub const IP_MINTTL: u32 = 21;
+pub const IP_NODEFRAG: u32 = 22;
+pub const IP_CHECKSUM: u32 = 23;
+pub const IP_BIND_ADDRESS_NO_PORT: u32 = 24;
+pub const IP_RECVFRAGSIZE: u32 = 25;
+pub const IP_RECVERR_RFC4884: u32 = 26;
+pub const IP_PMTUDISC_DONT: u32 = 0;
+pub const IP_PMTUDISC_WANT: u32 = 1;
+pub const IP_PMTUDISC_DO: u32 = 2;
+pub const IP_PMTUDISC_PROBE: u32 = 3;
+pub const IP_PMTUDISC_INTERFACE: u32 = 4;
+pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IP: u32 = 0;
+pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
+pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
+pub const IP_MAX_MEMBERSHIPS: u32 = 20;
+pub const IPV6_ADDRFORM: u32 = 1;
+pub const IPV6_2292PKTINFO: u32 = 2;
+pub const IPV6_2292HOPOPTS: u32 = 3;
+pub const IPV6_2292DSTOPTS: u32 = 4;
+pub const IPV6_2292RTHDR: u32 = 5;
+pub const IPV6_2292PKTOPTIONS: u32 = 6;
+pub const IPV6_CHECKSUM: u32 = 7;
+pub const IPV6_2292HOPLIMIT: u32 = 8;
+pub const IPV6_NEXTHOP: u32 = 9;
+pub const IPV6_AUTHHDR: u32 = 10;
+pub const IPV6_UNICAST_HOPS: u32 = 16;
+pub const IPV6_MULTICAST_IF: u32 = 17;
+pub const IPV6_MULTICAST_HOPS: u32 = 18;
+pub const IPV6_MULTICAST_LOOP: u32 = 19;
+pub const IPV6_JOIN_GROUP: u32 = 20;
+pub const IPV6_LEAVE_GROUP: u32 = 21;
+pub const IPV6_ROUTER_ALERT: u32 = 22;
+pub const IPV6_MTU_DISCOVER: u32 = 23;
+pub const IPV6_MTU: u32 = 24;
+pub const IPV6_RECVERR: u32 = 25;
+pub const IPV6_V6ONLY: u32 = 26;
+pub const IPV6_JOIN_ANYCAST: u32 = 27;
+pub const IPV6_LEAVE_ANYCAST: u32 = 28;
+pub const IPV6_MULTICAST_ALL: u32 = 29;
+pub const IPV6_ROUTER_ALERT_ISOLATE: u32 = 30;
+pub const IPV6_RECVERR_RFC4884: u32 = 31;
+pub const IPV6_IPSEC_POLICY: u32 = 34;
+pub const IPV6_XFRM_POLICY: u32 = 35;
+pub const IPV6_HDRINCL: u32 = 36;
+pub const IPV6_RECVPKTINFO: u32 = 49;
+pub const IPV6_PKTINFO: u32 = 50;
+pub const IPV6_RECVHOPLIMIT: u32 = 51;
+pub const IPV6_HOPLIMIT: u32 = 52;
+pub const IPV6_RECVHOPOPTS: u32 = 53;
+pub const IPV6_HOPOPTS: u32 = 54;
+pub const IPV6_RTHDRDSTOPTS: u32 = 55;
+pub const IPV6_RECVRTHDR: u32 = 56;
+pub const IPV6_RTHDR: u32 = 57;
+pub const IPV6_RECVDSTOPTS: u32 = 58;
+pub const IPV6_DSTOPTS: u32 = 59;
+pub const IPV6_RECVPATHMTU: u32 = 60;
+pub const IPV6_PATHMTU: u32 = 61;
+pub const IPV6_DONTFRAG: u32 = 62;
+pub const IPV6_RECVTCLASS: u32 = 66;
+pub const IPV6_TCLASS: u32 = 67;
+pub const IPV6_AUTOFLOWLABEL: u32 = 70;
+pub const IPV6_ADDR_PREFERENCES: u32 = 72;
+pub const IPV6_MINHOPCOUNT: u32 = 73;
+pub const IPV6_ORIGDSTADDR: u32 = 74;
+pub const IPV6_RECVORIGDSTADDR: u32 = 74;
+pub const IPV6_TRANSPARENT: u32 = 75;
+pub const IPV6_UNICAST_IF: u32 = 76;
+pub const IPV6_RECVFRAGSIZE: u32 = 77;
+pub const IPV6_FREEBIND: u32 = 78;
+pub const IPV6_ADD_MEMBERSHIP: u32 = 20;
+pub const IPV6_DROP_MEMBERSHIP: u32 = 21;
+pub const IPV6_RXHOPOPTS: u32 = 54;
+pub const IPV6_RXDSTOPTS: u32 = 59;
+pub const IPV6_PMTUDISC_DONT: u32 = 0;
+pub const IPV6_PMTUDISC_WANT: u32 = 1;
+pub const IPV6_PMTUDISC_DO: u32 = 2;
+pub const IPV6_PMTUDISC_PROBE: u32 = 3;
+pub const IPV6_PMTUDISC_INTERFACE: u32 = 4;
+pub const IPV6_PMTUDISC_OMIT: u32 = 5;
+pub const SOL_IPV6: u32 = 41;
+pub const SOL_ICMPV6: u32 = 58;
+pub const IPV6_RTHDR_LOOSE: u32 = 0;
+pub const IPV6_RTHDR_STRICT: u32 = 1;
+pub const IPV6_RTHDR_TYPE_0: u32 = 0;
 pub const IN_CLASSA_NET: u32 = 4278190080;
 pub const IN_CLASSA_NSHIFT: u32 = 24;
 pub const IN_CLASSA_HOST: u32 = 16777215;
@@ -2415,255 +2132,48 @@ pub const IN_CLASSB_MAX: u32 = 65536;
 pub const IN_CLASSC_NET: u32 = 4294967040;
 pub const IN_CLASSC_NSHIFT: u32 = 8;
 pub const IN_CLASSC_HOST: u32 = 255;
-pub const IN_CLASSD_NET: u32 = 4026531840;
-pub const IN_CLASSD_NSHIFT: u32 = 28;
-pub const IN_CLASSD_HOST: u32 = 268435455;
-pub const INADDR_NONE: u32 = 4294967295;
 pub const IN_LOOPBACKNET: u32 = 127;
 pub const INET_ADDRSTRLEN: u32 = 16;
-pub const IP_OPTIONS: u32 = 1;
-pub const IP_HDRINCL: u32 = 2;
-pub const IP_TOS: u32 = 3;
-pub const IP_TTL: u32 = 4;
-pub const IP_RECVOPTS: u32 = 5;
-pub const IP_RECVRETOPTS: u32 = 6;
-pub const IP_RECVDSTADDR: u32 = 7;
-pub const IP_RETOPTS: u32 = 8;
-pub const IP_MULTICAST_IF: u32 = 9;
-pub const IP_MULTICAST_TTL: u32 = 10;
-pub const IP_MULTICAST_LOOP: u32 = 11;
-pub const IP_ADD_MEMBERSHIP: u32 = 12;
-pub const IP_DROP_MEMBERSHIP: u32 = 13;
-pub const IP_MULTICAST_VIF: u32 = 14;
-pub const IP_RSVP_ON: u32 = 15;
-pub const IP_RSVP_OFF: u32 = 16;
-pub const IP_RSVP_VIF_ON: u32 = 17;
-pub const IP_RSVP_VIF_OFF: u32 = 18;
-pub const IP_PORTRANGE: u32 = 19;
-pub const IP_RECVIF: u32 = 20;
-pub const IP_IPSEC_POLICY: u32 = 21;
-pub const IP_FAITH: u32 = 22;
-pub const IP_STRIPHDR: u32 = 23;
-pub const IP_RECVTTL: u32 = 24;
-pub const IP_BOUND_IF: u32 = 25;
-pub const IP_PKTINFO: u32 = 26;
-pub const IP_RECVPKTINFO: u32 = 26;
-pub const IP_RECVTOS: u32 = 27;
-pub const IP_DONTFRAG: u32 = 28;
-pub const IP_FW_ADD: u32 = 40;
-pub const IP_FW_DEL: u32 = 41;
-pub const IP_FW_FLUSH: u32 = 42;
-pub const IP_FW_ZERO: u32 = 43;
-pub const IP_FW_GET: u32 = 44;
-pub const IP_FW_RESETLOG: u32 = 45;
-pub const IP_OLD_FW_ADD: u32 = 50;
-pub const IP_OLD_FW_DEL: u32 = 51;
-pub const IP_OLD_FW_FLUSH: u32 = 52;
-pub const IP_OLD_FW_ZERO: u32 = 53;
-pub const IP_OLD_FW_GET: u32 = 54;
-pub const IP_NAT__XXX: u32 = 55;
-pub const IP_OLD_FW_RESETLOG: u32 = 56;
-pub const IP_DUMMYNET_CONFIGURE: u32 = 60;
-pub const IP_DUMMYNET_DEL: u32 = 61;
-pub const IP_DUMMYNET_FLUSH: u32 = 62;
-pub const IP_DUMMYNET_GET: u32 = 64;
-pub const IP_TRAFFIC_MGT_BACKGROUND: u32 = 65;
-pub const IP_MULTICAST_IFINDEX: u32 = 66;
-pub const IP_ADD_SOURCE_MEMBERSHIP: u32 = 70;
-pub const IP_DROP_SOURCE_MEMBERSHIP: u32 = 71;
-pub const IP_BLOCK_SOURCE: u32 = 72;
-pub const IP_UNBLOCK_SOURCE: u32 = 73;
-pub const IP_MSFILTER: u32 = 74;
-pub const MCAST_JOIN_GROUP: u32 = 80;
-pub const MCAST_LEAVE_GROUP: u32 = 81;
-pub const MCAST_JOIN_SOURCE_GROUP: u32 = 82;
-pub const MCAST_LEAVE_SOURCE_GROUP: u32 = 83;
-pub const MCAST_BLOCK_SOURCE: u32 = 84;
-pub const MCAST_UNBLOCK_SOURCE: u32 = 85;
-pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
-pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IP_MIN_MEMBERSHIPS: u32 = 31;
-pub const IP_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IP_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IP_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IP_MAX_SOCK_MUTE_FILTER: u32 = 128;
-pub const MCAST_UNDEFINED: u32 = 0;
-pub const MCAST_INCLUDE: u32 = 1;
-pub const MCAST_EXCLUDE: u32 = 2;
-pub const IP_PORTRANGE_DEFAULT: u32 = 0;
-pub const IP_PORTRANGE_HIGH: u32 = 1;
-pub const IP_PORTRANGE_LOW: u32 = 2;
-pub const IPPROTO_MAXID: u32 = 52;
-pub const IPCTL_FORWARDING: u32 = 1;
-pub const IPCTL_SENDREDIRECTS: u32 = 2;
-pub const IPCTL_DEFTTL: u32 = 3;
-pub const IPCTL_RTEXPIRE: u32 = 5;
-pub const IPCTL_RTMINEXPIRE: u32 = 6;
-pub const IPCTL_RTMAXCACHE: u32 = 7;
-pub const IPCTL_SOURCEROUTE: u32 = 8;
-pub const IPCTL_DIRECTEDBROADCAST: u32 = 9;
-pub const IPCTL_INTRQMAXLEN: u32 = 10;
-pub const IPCTL_INTRQDROPS: u32 = 11;
-pub const IPCTL_STATS: u32 = 12;
-pub const IPCTL_ACCEPTSOURCEROUTE: u32 = 13;
-pub const IPCTL_FASTFORWARDING: u32 = 14;
-pub const IPCTL_KEEPFAITH: u32 = 15;
-pub const IPCTL_GIF_TTL: u32 = 16;
-pub const IPCTL_MAXID: u32 = 17;
-pub const __KAME_VERSION: &[u8; 18usize] = b"2009/apple-darwin\0";
-pub const IPV6PORT_RESERVED: u32 = 1024;
-pub const IPV6PORT_ANONMIN: u32 = 49152;
-pub const IPV6PORT_ANONMAX: u32 = 65535;
-pub const IPV6PORT_RESERVEDMIN: u32 = 600;
-pub const IPV6PORT_RESERVEDMAX: u32 = 1023;
 pub const INET6_ADDRSTRLEN: u32 = 46;
-pub const __IPV6_ADDR_SCOPE_NODELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_INTFACELOCAL: u32 = 1;
-pub const __IPV6_ADDR_SCOPE_LINKLOCAL: u32 = 2;
-pub const __IPV6_ADDR_SCOPE_SITELOCAL: u32 = 5;
-pub const __IPV6_ADDR_SCOPE_ORGLOCAL: u32 = 8;
-pub const __IPV6_ADDR_SCOPE_GLOBAL: u32 = 14;
-pub const IPV6_ADDR_MC_FLAGS_TRANSIENT: u32 = 16;
-pub const IPV6_ADDR_MC_FLAGS_PREFIX: u32 = 32;
-pub const IPV6_ADDR_MC_FLAGS_UNICAST_BASED: u32 = 48;
-pub const IPV6_SOCKOPT_RESERVED1: u32 = 3;
-pub const IPV6_UNICAST_HOPS: u32 = 4;
-pub const IPV6_MULTICAST_IF: u32 = 9;
-pub const IPV6_MULTICAST_HOPS: u32 = 10;
-pub const IPV6_MULTICAST_LOOP: u32 = 11;
-pub const IPV6_JOIN_GROUP: u32 = 12;
-pub const IPV6_LEAVE_GROUP: u32 = 13;
-pub const IPV6_PORTRANGE: u32 = 14;
-pub const ICMP6_FILTER: u32 = 18;
-pub const IPV6_2292PKTINFO: u32 = 19;
-pub const IPV6_2292HOPLIMIT: u32 = 20;
-pub const IPV6_2292NEXTHOP: u32 = 21;
-pub const IPV6_2292HOPOPTS: u32 = 22;
-pub const IPV6_2292DSTOPTS: u32 = 23;
-pub const IPV6_2292RTHDR: u32 = 24;
-pub const IPV6_2292PKTOPTIONS: u32 = 25;
-pub const IPV6_CHECKSUM: u32 = 26;
-pub const IPV6_V6ONLY: u32 = 27;
-pub const IPV6_BINDV6ONLY: u32 = 27;
-pub const IPV6_IPSEC_POLICY: u32 = 28;
-pub const IPV6_FAITH: u32 = 29;
-pub const IPV6_FW_ADD: u32 = 30;
-pub const IPV6_FW_DEL: u32 = 31;
-pub const IPV6_FW_FLUSH: u32 = 32;
-pub const IPV6_FW_ZERO: u32 = 33;
-pub const IPV6_FW_GET: u32 = 34;
-pub const IPV6_RECVTCLASS: u32 = 35;
-pub const IPV6_TCLASS: u32 = 36;
-pub const IPV6_BOUND_IF: u32 = 125;
-pub const IPV6_RTHDR_LOOSE: u32 = 0;
-pub const IPV6_RTHDR_STRICT: u32 = 1;
-pub const IPV6_RTHDR_TYPE_0: u32 = 0;
-pub const IPV6_DEFAULT_MULTICAST_HOPS: u32 = 1;
-pub const IPV6_DEFAULT_MULTICAST_LOOP: u32 = 1;
-pub const IPV6_MIN_MEMBERSHIPS: u32 = 31;
-pub const IPV6_MAX_MEMBERSHIPS: u32 = 4095;
-pub const IPV6_MAX_GROUP_SRC_FILTER: u32 = 512;
-pub const IPV6_MAX_SOCK_SRC_FILTER: u32 = 128;
-pub const IPV6_PORTRANGE_DEFAULT: u32 = 0;
-pub const IPV6_PORTRANGE_HIGH: u32 = 1;
-pub const IPV6_PORTRANGE_LOW: u32 = 2;
-pub const IPV6PROTO_MAXID: u32 = 104;
-pub const IPV6CTL_FORWARDING: u32 = 1;
-pub const IPV6CTL_SENDREDIRECTS: u32 = 2;
-pub const IPV6CTL_DEFHLIM: u32 = 3;
-pub const IPV6CTL_FORWSRCRT: u32 = 5;
-pub const IPV6CTL_STATS: u32 = 6;
-pub const IPV6CTL_MRTSTATS: u32 = 7;
-pub const IPV6CTL_MRTPROTO: u32 = 8;
-pub const IPV6CTL_MAXFRAGPACKETS: u32 = 9;
-pub const IPV6CTL_SOURCECHECK: u32 = 10;
-pub const IPV6CTL_SOURCECHECK_LOGINT: u32 = 11;
-pub const IPV6CTL_ACCEPT_RTADV: u32 = 12;
-pub const IPV6CTL_KEEPFAITH: u32 = 13;
-pub const IPV6CTL_LOG_INTERVAL: u32 = 14;
-pub const IPV6CTL_HDRNESTLIMIT: u32 = 15;
-pub const IPV6CTL_DAD_COUNT: u32 = 16;
-pub const IPV6CTL_AUTO_FLOWLABEL: u32 = 17;
-pub const IPV6CTL_DEFMCASTHLIM: u32 = 18;
-pub const IPV6CTL_GIF_HLIM: u32 = 19;
-pub const IPV6CTL_KAME_VERSION: u32 = 20;
-pub const IPV6CTL_USE_DEPRECATED: u32 = 21;
-pub const IPV6CTL_RR_PRUNE: u32 = 22;
-pub const IPV6CTL_V6ONLY: u32 = 24;
-pub const IPV6CTL_RTEXPIRE: u32 = 25;
-pub const IPV6CTL_RTMINEXPIRE: u32 = 26;
-pub const IPV6CTL_RTMAXCACHE: u32 = 27;
-pub const IPV6CTL_USETEMPADDR: u32 = 32;
-pub const IPV6CTL_TEMPPLTIME: u32 = 33;
-pub const IPV6CTL_TEMPVLTIME: u32 = 34;
-pub const IPV6CTL_AUTO_LINKLOCAL: u32 = 35;
-pub const IPV6CTL_RIP6STATS: u32 = 36;
-pub const IPV6CTL_PREFER_TEMPADDR: u32 = 37;
-pub const IPV6CTL_ADDRCTLPOLICY: u32 = 38;
-pub const IPV6CTL_USE_DEFAULTZONE: u32 = 39;
-pub const IPV6CTL_MAXFRAGS: u32 = 41;
-pub const IPV6CTL_MCAST_PMTU: u32 = 44;
-pub const IPV6CTL_NEIGHBORGCTHRESH: u32 = 46;
-pub const IPV6CTL_MAXIFPREFIXES: u32 = 47;
-pub const IPV6CTL_MAXIFDEFROUTERS: u32 = 48;
-pub const IPV6CTL_MAXDYNROUTES: u32 = 49;
-pub const ICMPV6CTL_ND6_ONLINKNSRFC4861: u32 = 50;
-pub const IPV6CTL_ULA_USETEMPADDR: u32 = 51;
-pub const IPV6CTL_MAXID: u32 = 51;
+pub const _RPC_NETDB_H: u32 = 1;
 pub const _PATH_HEQUIV: &[u8; 17usize] = b"/etc/hosts.equiv\0";
 pub const _PATH_HOSTS: &[u8; 11usize] = b"/etc/hosts\0";
 pub const _PATH_NETWORKS: &[u8; 14usize] = b"/etc/networks\0";
+pub const _PATH_NSSWITCH_CONF: &[u8; 19usize] = b"/etc/nsswitch.conf\0";
 pub const _PATH_PROTOCOLS: &[u8; 15usize] = b"/etc/protocols\0";
 pub const _PATH_SERVICES: &[u8; 14usize] = b"/etc/services\0";
-pub const NETDB_INTERNAL: i32 = -1;
-pub const NETDB_SUCCESS: u32 = 0;
 pub const HOST_NOT_FOUND: u32 = 1;
 pub const TRY_AGAIN: u32 = 2;
 pub const NO_RECOVERY: u32 = 3;
 pub const NO_DATA: u32 = 4;
+pub const NETDB_INTERNAL: i32 = -1;
+pub const NETDB_SUCCESS: u32 = 0;
 pub const NO_ADDRESS: u32 = 4;
-pub const EAI_ADDRFAMILY: u32 = 1;
-pub const EAI_AGAIN: u32 = 2;
-pub const EAI_BADFLAGS: u32 = 3;
-pub const EAI_FAIL: u32 = 4;
-pub const EAI_FAMILY: u32 = 5;
-pub const EAI_MEMORY: u32 = 6;
-pub const EAI_NODATA: u32 = 7;
-pub const EAI_NONAME: u32 = 8;
-pub const EAI_SERVICE: u32 = 9;
-pub const EAI_SOCKTYPE: u32 = 10;
-pub const EAI_SYSTEM: u32 = 11;
-pub const EAI_BADHINTS: u32 = 12;
-pub const EAI_PROTOCOL: u32 = 13;
-pub const EAI_OVERFLOW: u32 = 14;
-pub const EAI_MAX: u32 = 15;
 pub const AI_PASSIVE: u32 = 1;
 pub const AI_CANONNAME: u32 = 2;
 pub const AI_NUMERICHOST: u32 = 4;
-pub const AI_NUMERICSERV: u32 = 4096;
-pub const AI_ALL: u32 = 256;
-pub const AI_V4MAPPED_CFG: u32 = 512;
-pub const AI_ADDRCONFIG: u32 = 1024;
-pub const AI_V4MAPPED: u32 = 2048;
-pub const AI_DEFAULT: u32 = 1536;
-pub const AI_UNUSABLE: u32 = 268435456;
+pub const AI_V4MAPPED: u32 = 8;
+pub const AI_ALL: u32 = 16;
+pub const AI_ADDRCONFIG: u32 = 32;
+pub const AI_NUMERICSERV: u32 = 1024;
+pub const EAI_BADFLAGS: i32 = -1;
+pub const EAI_NONAME: i32 = -2;
+pub const EAI_AGAIN: i32 = -3;
+pub const EAI_FAIL: i32 = -4;
+pub const EAI_FAMILY: i32 = -6;
+pub const EAI_SOCKTYPE: i32 = -7;
+pub const EAI_SERVICE: i32 = -8;
+pub const EAI_MEMORY: i32 = -10;
+pub const EAI_SYSTEM: i32 = -11;
+pub const EAI_OVERFLOW: i32 = -12;
 pub const NI_MAXHOST: u32 = 1025;
 pub const NI_MAXSERV: u32 = 32;
-pub const NI_NOFQDN: u32 = 1;
-pub const NI_NUMERICHOST: u32 = 2;
-pub const NI_NAMEREQD: u32 = 4;
-pub const NI_NUMERICSERV: u32 = 8;
-pub const NI_NUMERICSCOPE: u32 = 256;
+pub const NI_NUMERICHOST: u32 = 1;
+pub const NI_NUMERICSERV: u32 = 2;
+pub const NI_NOFQDN: u32 = 4;
+pub const NI_NAMEREQD: u32 = 8;
 pub const NI_DGRAM: u32 = 16;
-pub const NI_WITHSCOPEID: u32 = 32;
-pub const SCOPE_DELIMITER: u8 = 37u8;
-pub const SOL_LOCAL: u32 = 0;
-pub const LOCAL_PEERCRED: u32 = 1;
-pub const LOCAL_PEERPID: u32 = 2;
-pub const LOCAL_PEEREPID: u32 = 3;
-pub const LOCAL_PEERUUID: u32 = 4;
-pub const LOCAL_PEEREUUID: u32 = 5;
-pub const LOCAL_PEERTOKEN: u32 = 6;
+pub const _SYS_UN_H: u32 = 1;
 pub const MAX_STARTUP_PACKET_LENGTH: u32 = 10000;
 pub const AUTH_REQ_OK: u32 = 0;
 pub const AUTH_REQ_KRB4: u32 = 1;
@@ -2834,7 +2344,6 @@ pub const XACT_COMPLETION_FORCE_SYNC_COMMIT: u32 = 2147483648;
 pub const EOH_HEADER_MAGIC: i32 = -1;
 pub const MAXDIM: u32 = 6;
 pub const EA_MAGIC: u32 = 689375833;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -3861,22 +3370,95 @@ pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type Oid = ::std::os::raw::c_uint;
 pub type pg_int64 = ::std::os::raw::c_long;
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
+}
+impl Default for __mbstate_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 impl Default for __mbstate_t {
     fn default() -> Self {
@@ -3887,45 +3469,13 @@ impl Default for __mbstate_t {
         }
     }
 }
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
 }
-impl Default for __darwin_pthread_handler_rec {
+impl Default for _G_fpos_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3934,13 +3484,14 @@ impl Default for __darwin_pthread_handler_rec {
         }
     }
 }
+pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
 }
-impl Default for _opaque_pthread_attr_t {
+impl Default for _G_fpos64_t {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3949,241 +3500,59 @@ impl Default for _opaque_pthread_attr_t {
         }
     }
 }
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-impl Default for _opaque_pthread_cond_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-impl Default for _opaque_pthread_rwlock_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-impl Default for _opaque_pthread_t {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-#[track_caller]
-pub unsafe fn renameat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameat(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn renamex_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renamex_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renamex_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn renameatx_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn renameatx_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        renameatx_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -4192,327 +3561,24 @@ impl Default for __sFILE {
         }
     }
 }
-pub type FILE = __sFILE;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 extern "C" {
-    pub static mut __stdinp: *mut FILE;
-}
-extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stdout: *mut FILE;
+}
+extern "C" {
+    pub static mut stderr: *mut FILE;
 }
 #[track_caller]
-pub unsafe fn clearerr(arg_arg1: *mut FILE) {
+pub unsafe fn remove(arg___filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn clearerr(arg1: *mut FILE);
+            pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        clearerr(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn feof(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        feof(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ferror(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        ferror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fflush(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fflush(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fgetc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fgetpos(arg_arg1: *mut FILE, arg_arg2: *mut fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-        }
-        fgetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fgets(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut FILE,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fgets(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut FILE,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fgets(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fopen(
-    arg___filename: *const ::std::os::raw::c_char,
-    arg___mode: *const ::std::os::raw::c_char,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fopen(
-                __filename: *const ::std::os::raw::c_char,
-                __mode: *const ::std::os::raw::c_char,
-            ) -> *mut FILE;
-        }
-        fopen(arg___filename, arg___mode)
-    })
-}
-#[track_caller]
-pub unsafe fn fprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fputc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fputs(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fputs(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut FILE,
-            ) -> ::std::os::raw::c_int;
-        }
-        fputs(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fread(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fread(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fread(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn freopen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut FILE,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freopen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut FILE,
-            ) -> *mut FILE;
-        }
-        freopen(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        fscanf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fseek(
-    arg_arg1: *mut FILE,
-    arg_arg2: ::std::os::raw::c_long,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fseek(
-                arg1: *mut FILE,
-                arg2: ::std::os::raw::c_long,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        fseek(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fsetpos(arg_arg1: *mut FILE, arg_arg2: *const fpos_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-        }
-        fsetpos(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn ftell(arg_arg1: *mut FILE) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-        }
-        ftell(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fwrite(
-    arg___ptr: *const ::std::os::raw::c_void,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___nitems: ::std::os::raw::c_ulong,
-    arg___stream: *mut FILE,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fwrite(
-                __ptr: *const ::std::os::raw::c_void,
-                __size: ::std::os::raw::c_ulong,
-                __nitems: ::std::os::raw::c_ulong,
-                __stream: *mut FILE,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        fwrite(arg___ptr, arg___size, arg___nitems, arg___stream)
-    })
-}
-#[track_caller]
-pub unsafe fn getc(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        getc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getchar() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getchar() -> ::std::os::raw::c_int;
-        }
-        getchar()
-    })
-}
-#[track_caller]
-pub unsafe fn perror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn perror(arg1: *const ::std::os::raw::c_char);
-        }
-        perror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn printf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        printf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn putc(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        putc(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn putchar(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        putchar(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn puts(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        puts(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn remove(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        remove(arg_arg1)
+        remove(arg___filename)
     })
 }
 #[track_caller]
@@ -4531,81 +3597,31 @@ pub unsafe fn rename(
     })
 }
 #[track_caller]
-pub unsafe fn rewind(arg_arg1: *mut FILE) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rewind(arg1: *mut FILE);
-        }
-        rewind(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn scanf(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-        }
-        scanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuf(arg_arg1: *mut FILE, arg_arg2: *mut ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-        }
-        setbuf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setvbuf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
+pub unsafe fn renameat(
+    arg___oldfd: ::std::os::raw::c_int,
+    arg___old: *const ::std::os::raw::c_char,
+    arg___newfd: ::std::os::raw::c_int,
+    arg___new: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setvbuf(
-                arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
+            pub fn renameat(
+                __oldfd: ::std::os::raw::c_int,
+                __old: *const ::std::os::raw::c_char,
+                __newfd: ::std::os::raw::c_int,
+                __new: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        setvbuf(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        renameat(arg___oldfd, arg___old, arg___newfd, arg___new)
     })
 }
 #[track_caller]
-pub unsafe fn sprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        sprintf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sscanf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sscanf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        sscanf(arg_arg1, arg_arg2)
+        fclose(arg___stream)
     })
 }
 #[track_caller]
@@ -4618,195 +3634,540 @@ pub unsafe fn tmpfile() -> *mut FILE {
     })
 }
 #[track_caller]
-pub unsafe fn ungetc(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ungetc(arg_arg1, arg_arg2)
+        fflush(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vfprintf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fflush_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfprintf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vfprintf(arg_arg1, arg_arg2, arg_arg3)
+        fflush_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vprintf(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vprintf(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+            ) -> *mut FILE;
         }
-        vprintf(arg_arg1, arg_arg2)
+        fopen(arg___filename, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn vsprintf(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn freopen(
+    arg___filename: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsprintf(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn freopen(
+                __filename: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> *mut FILE;
         }
-        vsprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ctermid(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        ctermid(arg_arg1)
+        freopen(arg___filename, arg___modes, arg___stream)
     })
 }
 #[track_caller]
 pub unsafe fn fdopen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
+    arg___fd: ::std::os::raw::c_int,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fdopen(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
+                __fd: ::std::os::raw::c_int,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fdopen(arg_arg1, arg_arg2)
+        fdopen(arg___fd, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn fileno(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fileno(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn pclose(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        pclose(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn popen(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
+pub unsafe fn fmemopen(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___len: usize,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn popen(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
+            pub fn fmemopen(
+                __s: *mut ::std::os::raw::c_void,
+                __len: usize,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        popen(arg_arg1, arg_arg2)
+        fmemopen(arg___s, arg___len, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn __srget(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn open_memstream(
+    arg___bufloc: *mut *mut ::std::os::raw::c_char,
+    arg___sizeloc: *mut usize,
+) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn open_memstream(
+                __bufloc: *mut *mut ::std::os::raw::c_char,
+                __sizeloc: *mut usize,
+            ) -> *mut FILE;
         }
-        __srget(arg_arg1)
+        open_memstream(arg___bufloc, arg___sizeloc)
     })
 }
 #[track_caller]
-pub unsafe fn __svfscanf(
-    arg_arg1: *mut FILE,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
+pub unsafe fn setbuf(arg___stream: *mut FILE, arg___buf: *mut ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+        }
+        setbuf(arg___stream, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setvbuf(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___modes: ::std::os::raw::c_int,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __svfscanf(
-                arg1: *mut FILE,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
+            pub fn setvbuf(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __modes: ::std::os::raw::c_int,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        __svfscanf(arg_arg1, arg_arg2, arg_arg3)
+        setvbuf(arg___stream, arg___buf, arg___modes, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn __swbuf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+pub unsafe fn setbuffer(
+    arg___stream: *mut FILE,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___size: usize,
+) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setbuffer(
+                __stream: *mut FILE,
+                __buf: *mut ::std::os::raw::c_char,
+                __size: usize,
+            );
+        }
+        setbuffer(arg___stream, arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn setlinebuf(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlinebuf(__stream: *mut FILE);
+        }
+        setlinebuf(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fprintf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn fprintf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        __swbuf(arg_arg1, arg_arg2)
+        fprintf(arg___stream, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn flockfile(arg_arg1: *mut FILE) {
+pub unsafe fn printf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flockfile(arg1: *mut FILE);
+            pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
         }
-        flockfile(arg_arg1)
+        printf(arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn ftrylockfile(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn sprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn sprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
         }
-        ftrylockfile(arg_arg1)
+        sprintf(arg___s, arg___format)
     })
 }
 #[track_caller]
-pub unsafe fn funlockfile(arg_arg1: *mut FILE) {
+pub unsafe fn vfprintf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn funlockfile(arg1: *mut FILE);
+            pub fn vfprintf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        funlockfile(arg_arg1)
+        vfprintf(arg___s, arg___format, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn getc_unlocked(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn vprintf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn vprintf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
         }
-        getc_unlocked(arg_arg1)
+        vprintf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsprintf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn snprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn snprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        snprintf(arg___s, arg___maxlen, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vsnprintf(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxlen: ::std::os::raw::c_ulong,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsnprintf(
+                __s: *mut ::std::os::raw::c_char,
+                __maxlen: ::std::os::raw::c_ulong,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsnprintf(arg___s, arg___maxlen, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vdprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vdprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vdprintf(arg___fd, arg___fmt, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn dprintf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fmt: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dprintf(
+                __fd: ::std::os::raw::c_int,
+                __fmt: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        dprintf(arg___fd, arg___fmt)
+    })
+}
+#[track_caller]
+pub unsafe fn fscanf(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fscanf(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf(arg___s, arg___format)
+    })
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+#[track_caller]
+pub unsafe fn fscanf1(
+    arg___stream: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_fscanf"]
+            pub fn fscanf1(
+                __stream: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        fscanf1(arg___stream, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn scanf1(arg___format: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_scanf"]
+            pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+        }
+        scanf1(arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn sscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_sscanf"]
+            pub fn sscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                ...
+            ) -> ::std::os::raw::c_int;
+        }
+        sscanf1(arg___s, arg___format)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vfscanf(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vscanf(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn vsscanf(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vfscanf1(
+    arg___s: *mut FILE,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vfscanf"]
+            pub fn vfscanf1(
+                __s: *mut FILE,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vfscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vscanf1(
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vscanf"]
+            pub fn vscanf1(
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vscanf1(arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn vsscanf1(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___arg: *mut __va_list_tag,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            #[link_name = "\u{1}__isoc99_vsscanf"]
+            pub fn vsscanf1(
+                __s: *const ::std::os::raw::c_char,
+                __format: *const ::std::os::raw::c_char,
+                __arg: *mut __va_list_tag,
+            ) -> ::std::os::raw::c_int;
+        }
+        vsscanf1(arg___s, arg___format, arg___arg)
+    })
+}
+#[track_caller]
+pub unsafe fn fgetc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getc(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getchar() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getchar() -> ::std::os::raw::c_int;
+        }
+        getchar()
+    })
+}
+#[track_caller]
+pub unsafe fn getc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        getc_unlocked(arg___stream)
     })
 }
 #[track_caller]
@@ -4819,1508 +4180,537 @@ pub unsafe fn getchar_unlocked() -> ::std::os::raw::c_int {
     })
 }
 #[track_caller]
+pub unsafe fn fgetc_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fgetc_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fputc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        putc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn putchar(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        putchar(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn fputc_unlocked(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputc_unlocked(
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputc_unlocked(arg___c, arg___stream)
+    })
+}
+#[track_caller]
 pub unsafe fn putc_unlocked(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut FILE,
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn putc_unlocked(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut FILE,
+                __c: ::std::os::raw::c_int,
+                __stream: *mut FILE,
             ) -> ::std::os::raw::c_int;
         }
-        putc_unlocked(arg_arg1, arg_arg2)
+        putc_unlocked(arg___c, arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putchar_unlocked(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn putchar_unlocked(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        putchar_unlocked(arg_arg1)
+        putchar_unlocked(arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn getw(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn getw(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getw(arg_arg1)
+        getw(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn putw(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut FILE) -> ::std::os::raw::c_int {
+pub unsafe fn putw(
+    arg___w: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+            pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        putw(arg_arg1, arg_arg2)
+        putw(arg___w, arg___stream)
     })
 }
-pub type off_t = __darwin_off_t;
+#[track_caller]
+pub unsafe fn fgets(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fgets(
+                __s: *mut ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fgets(arg___s, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn __getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        __getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getdelim(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___delimiter: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getdelim(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __delimiter: ::std::os::raw::c_int,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getdelim(arg___lineptr, arg___n, arg___delimiter, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn getline(
+    arg___lineptr: *mut *mut ::std::os::raw::c_char,
+    arg___n: *mut usize,
+    arg___stream: *mut FILE,
+) -> __ssize_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getline(
+                __lineptr: *mut *mut ::std::os::raw::c_char,
+                __n: *mut usize,
+                __stream: *mut FILE,
+            ) -> __ssize_t;
+        }
+        getline(arg___lineptr, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fputs(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fputs(
+                __s: *const ::std::os::raw::c_char,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_int;
+        }
+        fputs(arg___s, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn puts(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        puts(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn ungetc(
+    arg___c: ::std::os::raw::c_int,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+                -> ::std::os::raw::c_int;
+        }
+        ungetc(arg___c, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fread(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___stream: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __stream: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fread(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: ::std::os::raw::c_ulong,
+    arg___n: ::std::os::raw::c_ulong,
+    arg___s: *mut FILE,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: ::std::os::raw::c_ulong,
+                __n: ::std::os::raw::c_ulong,
+                __s: *mut FILE,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        fwrite(arg___ptr, arg___size, arg___n, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn fread_unlocked(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fread_unlocked(
+                __ptr: *mut ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fread_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fwrite_unlocked(
+    arg___ptr: *const ::std::os::raw::c_void,
+    arg___size: usize,
+    arg___n: usize,
+    arg___stream: *mut FILE,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fwrite_unlocked(
+                __ptr: *const ::std::os::raw::c_void,
+                __size: usize,
+                __n: usize,
+                __stream: *mut FILE,
+            ) -> usize;
+        }
+        fwrite_unlocked(arg___ptr, arg___size, arg___n, arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fseek(
+    arg___stream: *mut FILE,
+    arg___off: ::std::os::raw::c_long,
+    arg___whence: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fseek(
+                __stream: *mut FILE,
+                __off: ::std::os::raw::c_long,
+                __whence: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        fseek(arg___stream, arg___off, arg___whence)
+    })
+}
+#[track_caller]
+pub unsafe fn ftell(arg___stream: *mut FILE) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+        }
+        ftell(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn rewind(arg___stream: *mut FILE) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rewind(__stream: *mut FILE);
+        }
+        rewind(arg___stream)
+    })
+}
 #[track_caller]
 pub unsafe fn fseeko(
     arg___stream: *mut FILE,
-    arg___offset: off_t,
+    arg___off: __off_t,
     arg___whence: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fseeko(
                 __stream: *mut FILE,
-                __offset: off_t,
+                __off: __off_t,
                 __whence: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        fseeko(arg___stream, arg___offset, arg___whence)
+        fseeko(arg___stream, arg___off, arg___whence)
     })
 }
 #[track_caller]
-pub unsafe fn ftello(arg___stream: *mut FILE) -> off_t {
+pub unsafe fn ftello(arg___stream: *mut FILE) -> __off_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ftello(__stream: *mut FILE) -> off_t;
+            pub fn ftello(__stream: *mut FILE) -> __off_t;
         }
         ftello(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn snprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fgetpos(arg___stream: *mut FILE, arg___pos: *mut fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn snprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
         }
-        snprintf(arg___str, arg___size, arg___format)
+        fgetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vfscanf(
-    arg___stream: *mut FILE,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn fsetpos(arg___stream: *mut FILE, arg___pos: *const fpos_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vfscanf(
-                __stream: *mut FILE,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
         }
-        vfscanf(arg___stream, arg___format, arg_arg1)
+        fsetpos(arg___stream, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn vscanf(
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vscanf(
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr(__stream: *mut FILE);
         }
-        vscanf(arg___format, arg_arg1)
+        clearerr(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsnprintf(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsnprintf(
-                __str: *mut ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsnprintf(arg___str, arg___size, arg___format, arg_arg1)
+        feof(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vsscanf(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___format: *const ::std::os::raw::c_char,
-    arg_arg1: __builtin_va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ferror(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vsscanf(
-                __str: *const ::std::os::raw::c_char,
-                __format: *const ::std::os::raw::c_char,
-                arg1: __builtin_va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vsscanf(arg___str, arg___format, arg_arg1)
+        ferror(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn dprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn clearerr_unlocked(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn dprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn clearerr_unlocked(__stream: *mut FILE);
         }
-        dprintf(arg_arg1, arg_arg2)
+        clearerr_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn vdprintf(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
+pub unsafe fn feof_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn vdprintf(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
+            pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        vdprintf(arg_arg1, arg_arg2, arg_arg3)
+        feof_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getdelim(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___delimiter: ::std::os::raw::c_int,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn ferror_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdelim(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __delimiter: ::std::os::raw::c_int,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        getdelim(arg___linep, arg___linecapp, arg___delimiter, arg___stream)
+        ferror_unlocked(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn getline(
-    arg___linep: *mut *mut ::std::os::raw::c_char,
-    arg___linecapp: *mut usize,
-    arg___stream: *mut FILE,
-) -> isize {
+pub unsafe fn perror(arg___s: *const ::std::os::raw::c_char) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getline(
-                __linep: *mut *mut ::std::os::raw::c_char,
-                __linecapp: *mut usize,
-                __stream: *mut FILE,
-            ) -> isize;
+            pub fn perror(__s: *const ::std::os::raw::c_char);
         }
-        getline(arg___linep, arg___linecapp, arg___stream)
+        perror(arg___s)
     })
 }
 #[track_caller]
-pub unsafe fn fmemopen(
-    arg___buf: *mut ::std::os::raw::c_void,
-    arg___size: usize,
-    arg___mode: *const ::std::os::raw::c_char,
+pub unsafe fn fileno(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn fileno_unlocked(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        fileno_unlocked(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn pclose(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+        }
+        pclose(arg___stream)
+    })
+}
+#[track_caller]
+pub unsafe fn popen(
+    arg___command: *const ::std::os::raw::c_char,
+    arg___modes: *const ::std::os::raw::c_char,
 ) -> *mut FILE {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmemopen(
-                __buf: *mut ::std::os::raw::c_void,
-                __size: usize,
-                __mode: *const ::std::os::raw::c_char,
+            pub fn popen(
+                __command: *const ::std::os::raw::c_char,
+                __modes: *const ::std::os::raw::c_char,
             ) -> *mut FILE;
         }
-        fmemopen(arg___buf, arg___size, arg___mode)
+        popen(arg___command, arg___modes)
     })
 }
 #[track_caller]
-pub unsafe fn open_memstream(
-    arg___bufp: *mut *mut ::std::os::raw::c_char,
-    arg___sizep: *mut usize,
-) -> *mut FILE {
+pub unsafe fn ctermid(arg___s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn open_memstream(
-                __bufp: *mut *mut ::std::os::raw::c_char,
-                __sizep: *mut usize,
-            ) -> *mut FILE;
+            pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
         }
-        open_memstream(arg___bufp, arg___sizep)
+        ctermid(arg___s)
     })
 }
-extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut sys_errlist: [*const ::std::os::raw::c_char; 0usize];
-}
 #[track_caller]
-pub unsafe fn asprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn flockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
+            pub fn flockfile(__stream: *mut FILE);
         }
-        asprintf(arg_arg1, arg_arg2)
+        flockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn ctermid_r(arg_arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ftrylockfile(arg___stream: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
         }
-        ctermid_r(arg_arg1)
+        ftrylockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fgetln(arg_arg1: *mut FILE, arg_arg2: *mut usize) -> *mut ::std::os::raw::c_char {
+pub unsafe fn funlockfile(arg___stream: *mut FILE) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+            pub fn funlockfile(__stream: *mut FILE);
         }
-        fgetln(arg_arg1, arg_arg2)
+        funlockfile(arg___stream)
     })
 }
 #[track_caller]
-pub unsafe fn fmtcheck(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *const ::std::os::raw::c_char {
+pub unsafe fn __uflow(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fmtcheck(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *const ::std::os::raw::c_char;
+            pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
         }
-        fmtcheck(arg_arg1, arg_arg2)
+        __uflow(arg_arg1)
     })
 }
 #[track_caller]
-pub unsafe fn fpurge(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        fpurge(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setbuffer(
+pub unsafe fn __overflow(
     arg_arg1: *mut FILE,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) {
+    arg_arg2: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setbuffer(
+            pub fn __overflow(
                 arg1: *mut FILE,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            );
-        }
-        setbuffer(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setlinebuf(arg_arg1: *mut FILE) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-        }
-        setlinebuf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn vasprintf(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn vasprintf(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        vasprintf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn funopen(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg3: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    arg_arg4: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    arg_arg5: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-) -> *mut FILE {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn funopen(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *mut ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg3: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_char,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> ::std::os::raw::c_int,
-                >,
-                arg4: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: fpos_t,
-                        arg3: ::std::os::raw::c_int,
-                    ) -> fpos_t,
-                >,
-                arg5: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> *mut FILE;
-        }
-        funopen(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __sprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __sprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __snprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __snprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        __snprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: usize,
-    arg_arg4: *const ::std::os::raw::c_char,
-    arg_arg5: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: usize,
-                arg4: *const ::std::os::raw::c_char,
-                arg5: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn __vsnprintf_chk(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: usize,
-    arg_arg5: *const ::std::os::raw::c_char,
-    arg_arg6: va_list,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __vsnprintf_chk(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: usize,
-                arg5: *const ::std::os::raw::c_char,
-                arg6: va_list,
-            ) -> ::std::os::raw::c_int;
-        }
-        __vsnprintf_chk(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
-}
-impl Default for __darwin_arm_vfp_state {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
-}
-impl Default for __darwin_mcontext32 {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
-}
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-impl Default for __darwin_sigaltstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-impl Default for __darwin_ucontext {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-}
-impl Default for sigval {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-impl Default for sigevent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-impl Default for __siginfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-impl Default for __sigaction_u {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for __sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-impl Default for sigaction {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-impl Default for sigstack {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
-        }
-        signal(arg_arg1, arg_arg2)
-    })
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_reserved: [u64; 14usize],
-}
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[track_caller]
-pub unsafe fn getpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
-        }
-        getpriority(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getiopolicy_np(
-                arg1: ::std::os::raw::c_int,
                 arg2: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        getiopolicy_np(arg_arg1, arg_arg2)
+        __overflow(arg_arg1, arg_arg2)
     })
 }
-#[track_caller]
-pub unsafe fn getrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getrusage(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut rusage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrusage(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut rusage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getrusage(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn setpriority(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: id_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setpriority(
-                arg1: ::std::os::raw::c_int,
-                arg2: id_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setpriority(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setiopolicy_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setiopolicy_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setiopolicy_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn setrlimit(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const rlimit,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrlimit(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const rlimit,
-            ) -> ::std::os::raw::c_int;
-        }
-        setrlimit(arg_arg1, arg_arg2)
-    })
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-impl Default for wait {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn wait(arg_arg1: *mut ::std::os::raw::c_int) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-        }
-        wait(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn waitpid(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitpid(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-            ) -> pid_t;
-        }
-        waitpid(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn waitid(
-    arg_arg1: idtype_t,
-    arg_arg2: id_t,
-    arg_arg3: *mut siginfo_t,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn waitid(
-                arg1: idtype_t,
-                arg2: id_t,
-                arg3: *mut siginfo_t,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        waitid(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn wait3(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait3(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut rusage,
-            ) -> pid_t;
-        }
-        wait3(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn wait4(
-    arg_arg1: pid_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut rusage,
-) -> pid_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wait4(
-                arg1: pid_t,
-                arg2: *mut ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut rusage,
-            ) -> pid_t;
-        }
-        wait4(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn alloca(arg_arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-        }
-        alloca(arg_arg1)
-    })
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct div_t {
@@ -6339,8 +4729,1000 @@ pub struct lldiv_t {
     pub quot: ::std::os::raw::c_longlong,
     pub rem: ::std::os::raw::c_longlong,
 }
-extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
+#[track_caller]
+pub unsafe fn __ctype_get_mb_cur_max() -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ctype_get_mb_cur_max() -> usize;
+        }
+        __ctype_get_mb_cur_max()
+    })
+}
+#[track_caller]
+pub unsafe fn atof(arg___nptr: *const ::std::os::raw::c_char) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
+        }
+        atof(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoi(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        atoi(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atol(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        atol(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn atoll(arg___nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+        }
+        atoll(arg___nptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtod(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtod(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f64;
+        }
+        strtod(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtof(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtof(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> f32;
+        }
+        strtof(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtold(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtold(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+            ) -> u128;
+        }
+        strtold(arg___nptr, arg___endptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strtol(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtol(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_long;
+        }
+        strtol(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoul(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoul(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strtoul(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtouq(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtouq(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtouq(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoll(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoll(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_longlong;
+        }
+        strtoll(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn strtoull(
+    arg___nptr: *const ::std::os::raw::c_char,
+    arg___endptr: *mut *mut ::std::os::raw::c_char,
+    arg___base: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_ulonglong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strtoull(
+                __nptr: *const ::std::os::raw::c_char,
+                __endptr: *mut *mut ::std::os::raw::c_char,
+                __base: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_ulonglong;
+        }
+        strtoull(arg___nptr, arg___endptr, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn l64a(arg___n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+        }
+        l64a(arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn a64l(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+        }
+        a64l(arg___s)
+    })
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+pub type fd_mask = __fd_mask;
+#[track_caller]
+pub unsafe fn select(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *mut timeval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn select(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *mut timeval,
+            ) -> ::std::os::raw::c_int;
+        }
+        select(arg___nfds, arg___readfds, arg___writefds, arg___exceptfds, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn pselect(
+    arg___nfds: ::std::os::raw::c_int,
+    arg___readfds: *mut fd_set,
+    arg___writefds: *mut fd_set,
+    arg___exceptfds: *mut fd_set,
+    arg___timeout: *const timespec,
+    arg___sigmask: *const __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pselect(
+                __nfds: ::std::os::raw::c_int,
+                __readfds: *mut fd_set,
+                __writefds: *mut fd_set,
+                __exceptfds: *mut fd_set,
+                __timeout: *const timespec,
+                __sigmask: *const __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pselect(
+            arg___nfds,
+            arg___readfds,
+            arg___writefds,
+            arg___exceptfds,
+            arg___timeout,
+            arg___sigmask,
+        )
+    })
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __atomic_wide_counter {
+    pub __value64: ::std::os::raw::c_ulonglong,
+    pub __value32: __atomic_wide_counter__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __atomic_wide_counter__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
+}
+impl Default for __atomic_wide_counter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+impl Default for __pthread_internal_list {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+impl Default for __pthread_internal_slist {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+impl Default for __pthread_mutex_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __wseq: __atomic_wide_counter,
+    pub __g1_start: __atomic_wide_counter,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+impl Default for __pthread_cond_s {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_mutexattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_condattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_attr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_mutex_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+}
+impl Default for pthread_cond_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlock_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_rwlockattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+}
+impl Default for pthread_barrier_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+impl Default for pthread_barrierattr_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random() -> ::std::os::raw::c_long;
+        }
+        random()
+    })
+}
+#[track_caller]
+pub unsafe fn srandom(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom(__seed: ::std::os::raw::c_uint);
+        }
+        srandom(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        initstate(arg___seed, arg___statebuf, arg___statelen)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate(arg___statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate(__statebuf: *mut ::std::os::raw::c_char)
+                -> *mut ::std::os::raw::c_char;
+        }
+        setstate(arg___statebuf)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+impl Default for random_data {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn random_r(
+    arg___buf: *mut random_data,
+    arg___result: *mut i32,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
+        }
+        random_r(arg___buf, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srandom_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srandom_r(
+                __seed: ::std::os::raw::c_uint,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srandom_r(arg___seed, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn initstate_r(
+    arg___seed: ::std::os::raw::c_uint,
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___statelen: usize,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn initstate_r(
+                __seed: ::std::os::raw::c_uint,
+                __statebuf: *mut ::std::os::raw::c_char,
+                __statelen: usize,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        initstate_r(arg___seed, arg___statebuf, arg___statelen, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn setstate_r(
+    arg___statebuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut random_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setstate_r(
+                __statebuf: *mut ::std::os::raw::c_char,
+                __buf: *mut random_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        setstate_r(arg___statebuf, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn rand() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand() -> ::std::os::raw::c_int;
+        }
+        rand()
+    })
+}
+#[track_caller]
+pub unsafe fn srand(arg___seed: ::std::os::raw::c_uint) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand(__seed: ::std::os::raw::c_uint);
+        }
+        srand(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn rand_r(arg___seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+        }
+        rand_r(arg___seed)
+    })
+}
+#[track_caller]
+pub unsafe fn drand48() -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48() -> f64;
+        }
+        drand48()
+    })
+}
+#[track_caller]
+pub unsafe fn erand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+        }
+        erand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48() -> ::std::os::raw::c_long;
+        }
+        lrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        nrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48() -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48() -> ::std::os::raw::c_long;
+        }
+        mrand48()
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48(arg___xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+        }
+        jrand48(arg___xsubi)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48(arg___seedval: ::std::os::raw::c_long) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48(__seedval: ::std::os::raw::c_long);
+        }
+        srand48(arg___seedval)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+) -> *mut ::std::os::raw::c_ushort {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+            ) -> *mut ::std::os::raw::c_ushort;
+        }
+        seed48(arg___seed16v)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48(arg___param: *mut ::std::os::raw::c_ushort) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+        }
+        lcong48(arg___param)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[track_caller]
+pub unsafe fn drand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn drand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        drand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn erand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut f64,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut f64,
+            ) -> ::std::os::raw::c_int;
+        }
+        erand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn lrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        lrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn nrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        nrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn mrand48_r(
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mrand48_r(
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        mrand48_r(arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn jrand48_r(
+    arg___xsubi: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+    arg___result: *mut ::std::os::raw::c_long,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jrand48_r(
+                __xsubi: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+                __result: *mut ::std::os::raw::c_long,
+            ) -> ::std::os::raw::c_int;
+        }
+        jrand48_r(arg___xsubi, arg___buffer, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn srand48_r(
+    arg___seedval: ::std::os::raw::c_long,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn srand48_r(
+                __seedval: ::std::os::raw::c_long,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        srand48_r(arg___seedval, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn seed48_r(
+    arg___seed16v: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn seed48_r(
+                __seed16v: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        seed48_r(arg___seed16v, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn lcong48_r(
+    arg___param: *mut ::std::os::raw::c_ushort,
+    arg___buffer: *mut drand48_data,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lcong48_r(
+                __param: *mut ::std::os::raw::c_ushort,
+                __buffer: *mut drand48_data,
+            ) -> ::std::os::raw::c_int;
+        }
+        lcong48_r(arg___param, arg___buffer)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random() -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random() -> __uint32_t;
+        }
+        arc4random()
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___size: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+        }
+        arc4random_buf(arg___buf, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn arc4random_uniform(arg___upper_bound: __uint32_t) -> __uint32_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+        }
+        arc4random_uniform(arg___upper_bound)
+    })
 }
 #[track_caller]
 pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
@@ -6353,26 +5735,17 @@ pub unsafe fn malloc(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw
 }
 #[track_caller]
 pub unsafe fn calloc(
-    arg___count: ::std::os::raw::c_ulong,
+    arg___nmemb: ::std::os::raw::c_ulong,
     arg___size: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn calloc(
-                __count: ::std::os::raw::c_ulong,
+                __nmemb: ::std::os::raw::c_ulong,
                 __size: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        calloc(arg___count, arg___size)
-    })
-}
-#[track_caller]
-pub unsafe fn free(arg_arg1: *mut ::std::os::raw::c_void) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn free(arg1: *mut ::std::os::raw::c_void);
-        }
-        free(arg_arg1)
+        calloc(arg___nmemb, arg___size)
     })
 }
 #[track_caller]
@@ -6391,27 +5764,47 @@ pub unsafe fn realloc(
     })
 }
 #[track_caller]
-pub unsafe fn valloc(arg_arg1: usize) -> *mut ::std::os::raw::c_void {
+pub unsafe fn free(arg___ptr: *mut ::std::os::raw::c_void) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+            pub fn free(__ptr: *mut ::std::os::raw::c_void);
         }
-        valloc(arg_arg1)
+        free(arg___ptr)
     })
 }
 #[track_caller]
-pub unsafe fn aligned_alloc(
-    arg___alignment: ::std::os::raw::c_ulong,
-    arg___size: ::std::os::raw::c_ulong,
+pub unsafe fn reallocarray(
+    arg___ptr: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn aligned_alloc(
-                __alignment: ::std::os::raw::c_ulong,
-                __size: ::std::os::raw::c_ulong,
+            pub fn reallocarray(
+                __ptr: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
             ) -> *mut ::std::os::raw::c_void;
         }
-        aligned_alloc(arg___alignment, arg___size)
+        reallocarray(arg___ptr, arg___nmemb, arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn alloca(arg___size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+        }
+        alloca(arg___size)
+    })
+}
+#[track_caller]
+pub unsafe fn valloc(arg___size: usize) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
+        }
+        valloc(arg___size)
     })
 }
 #[track_caller]
@@ -6432,6 +5825,21 @@ pub unsafe fn posix_memalign(
     })
 }
 #[track_caller]
+pub unsafe fn aligned_alloc(
+    arg___alignment: ::std::os::raw::c_ulong,
+    arg___size: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn aligned_alloc(
+                __alignment: ::std::os::raw::c_ulong,
+                __size: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        aligned_alloc(arg___alignment, arg___size)
+    })
+}
+#[track_caller]
 pub unsafe fn abort() {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -6441,161 +5849,500 @@ pub unsafe fn abort() {
     })
 }
 #[track_caller]
-pub unsafe fn abs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        abs(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn atexit(
-    arg_arg1: ::std::option::Option<unsafe extern "C" fn()>,
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn atexit(
-                arg1: ::std::option::Option<unsafe extern "C" fn()>,
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
             ) -> ::std::os::raw::c_int;
         }
-        atexit(arg_arg1)
+        atexit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atof(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
+pub unsafe fn at_quick_exit(
+    arg___func: ::std::option::Option<unsafe extern "C" fn()>,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+            pub fn at_quick_exit(
+                __func: ::std::option::Option<unsafe extern "C" fn()>,
+            ) -> ::std::os::raw::c_int;
         }
-        atof(arg_arg1)
+        at_quick_exit(arg___func)
     })
 }
 #[track_caller]
-pub unsafe fn atoi(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+pub unsafe fn on_exit(
+    arg___func: ::std::option::Option<
+        unsafe extern "C" fn(__status: ::std::os::raw::c_int, __arg: *mut ::std::os::raw::c_void),
+    >,
+    arg___arg: *mut ::std::os::raw::c_void,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+            pub fn on_exit(
+                __func: ::std::option::Option<
+                    unsafe extern "C" fn(
+                        __status: ::std::os::raw::c_int,
+                        __arg: *mut ::std::os::raw::c_void,
+                    ),
+                >,
+                __arg: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int;
         }
-        atoi(arg_arg1)
+        on_exit(arg___func, arg___arg)
     })
 }
 #[track_caller]
-pub unsafe fn atol(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn exit(__status: ::std::os::raw::c_int);
         }
-        atol(arg_arg1)
+        exit(arg___status)
     })
 }
 #[track_caller]
-pub unsafe fn atoll(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong {
+pub unsafe fn quick_exit(arg___status: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+            pub fn quick_exit(__status: ::std::os::raw::c_int);
         }
-        atoll(arg_arg1)
+        quick_exit(arg___status)
     })
 }
+#[track_caller]
+pub unsafe fn _Exit(arg___status: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _Exit(__status: ::std::os::raw::c_int);
+        }
+        _Exit(arg___status)
+    })
+}
+#[track_caller]
+pub unsafe fn getenv(arg___name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        getenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn putenv(arg___string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        putenv(arg___string)
+    })
+}
+#[track_caller]
+pub unsafe fn setenv(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___value: *const ::std::os::raw::c_char,
+    arg___replace: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setenv(
+                __name: *const ::std::os::raw::c_char,
+                __value: *const ::std::os::raw::c_char,
+                __replace: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        setenv(arg___name, arg___value, arg___replace)
+    })
+}
+#[track_caller]
+pub unsafe fn unsetenv(arg___name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        unsetenv(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn clearenv() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clearenv() -> ::std::os::raw::c_int;
+        }
+        clearenv()
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemp(arg___template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        mkstemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn mkstemps(
+    arg___template: *mut ::std::os::raw::c_char,
+    arg___suffixlen: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkstemps(
+                __template: *mut ::std::os::raw::c_char,
+                __suffixlen: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        mkstemps(arg___template, arg___suffixlen)
+    })
+}
+#[track_caller]
+pub unsafe fn mkdtemp(arg___template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        mkdtemp(arg___template)
+    })
+}
+#[track_caller]
+pub unsafe fn system(arg___command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        system(arg___command)
+    })
+}
+#[track_caller]
+pub unsafe fn realpath(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___resolved: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn realpath(
+                __name: *const ::std::os::raw::c_char,
+                __resolved: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        realpath(arg___name, arg___resolved)
+    })
+}
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 #[track_caller]
 pub unsafe fn bsearch(
     arg___key: *const ::std::os::raw::c_void,
     arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bsearch(
                 __key: *const ::std::os::raw::c_void,
                 __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
             ) -> *mut ::std::os::raw::c_void;
         }
-        bsearch(arg___key, arg___base, arg___nel, arg___width, arg___compar)
+        bsearch(arg___key, arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn div(arg_arg1: ::std::os::raw::c_int, arg_arg2: ::std::os::raw::c_int) -> div_t {
+pub unsafe fn qsort(
+    arg___base: *mut ::std::os::raw::c_void,
+    arg___nmemb: usize,
+    arg___size: usize,
+    arg___compar: __compar_fn_t,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+            pub fn qsort(
+                __base: *mut ::std::os::raw::c_void,
+                __nmemb: usize,
+                __size: usize,
+                __compar: __compar_fn_t,
+            );
         }
-        div(arg_arg1, arg_arg2)
+        qsort(arg___base, arg___nmemb, arg___size, arg___compar)
     })
 }
 #[track_caller]
-pub unsafe fn exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn abs(arg___x: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exit(arg1: ::std::os::raw::c_int);
+            pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        exit(arg_arg1)
+        abs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn getenv(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn labs(arg___x: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
         }
-        getenv(arg_arg1)
+        labs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn labs(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long {
+pub unsafe fn llabs(arg___x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+            pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
         }
-        labs(arg_arg1)
+        llabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ldiv(arg_arg1: ::std::os::raw::c_long, arg_arg2: ::std::os::raw::c_long) -> ldiv_t {
+pub unsafe fn div(arg___numer: ::std::os::raw::c_int, arg___denom: ::std::os::raw::c_int) -> div_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
+            pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
         }
-        ldiv(arg_arg1, arg_arg2)
+        div(arg___numer, arg___denom)
     })
 }
 #[track_caller]
-pub unsafe fn llabs(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong {
+pub unsafe fn ldiv(
+    arg___numer: ::std::os::raw::c_long,
+    arg___denom: ::std::os::raw::c_long,
+) -> ldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+            pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long)
+                -> ldiv_t;
         }
-        llabs(arg_arg1)
+        ldiv(arg___numer, arg___denom)
     })
 }
 #[track_caller]
 pub unsafe fn lldiv(
-    arg_arg1: ::std::os::raw::c_longlong,
-    arg_arg2: ::std::os::raw::c_longlong,
+    arg___numer: ::std::os::raw::c_longlong,
+    arg___denom: ::std::os::raw::c_longlong,
 ) -> lldiv_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn lldiv(
-                arg1: ::std::os::raw::c_longlong,
-                arg2: ::std::os::raw::c_longlong,
+                __numer: ::std::os::raw::c_longlong,
+                __denom: ::std::os::raw::c_longlong,
             ) -> lldiv_t;
         }
-        lldiv(arg_arg1, arg_arg2)
+        lldiv(arg___numer, arg___denom)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        ecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        fcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn gcvt(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gcvt(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        gcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qecvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qfcvt(arg___value, arg___ndigit, arg___decpt, arg___sign)
+    })
+}
+#[track_caller]
+pub unsafe fn qgcvt(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qgcvt(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        qgcvt(arg___value, arg___ndigit, arg___buf)
+    })
+}
+#[track_caller]
+pub unsafe fn ecvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ecvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        ecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn fcvt_r(
+    arg___value: f64,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fcvt_r(
+                __value: f64,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        fcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qecvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qecvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qecvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn qfcvt_r(
+    arg___value: u128,
+    arg___ndigit: ::std::os::raw::c_int,
+    arg___decpt: *mut ::std::os::raw::c_int,
+    arg___sign: *mut ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___len: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn qfcvt_r(
+                __value: u128,
+                __ndigit: ::std::os::raw::c_int,
+                __decpt: *mut ::std::os::raw::c_int,
+                __sign: *mut ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __len: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        qfcvt_r(arg___value, arg___ndigit, arg___decpt, arg___sign, arg___buf, arg___len)
     })
 }
 #[track_caller]
@@ -6611,1295 +6358,180 @@ pub unsafe fn mblen(
     })
 }
 #[track_caller]
-pub unsafe fn mbstowcs(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mbstowcs(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> usize;
-        }
-        mbstowcs(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
 pub unsafe fn mbtowc(
-    arg_arg1: *mut wchar_t,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: usize,
+    arg___pwc: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn mbtowc(
-                arg1: *mut wchar_t,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: usize,
+                __pwc: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
             ) -> ::std::os::raw::c_int;
         }
-        mbtowc(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn rand() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand() -> ::std::os::raw::c_int;
-        }
-        rand()
-    })
-}
-#[track_caller]
-pub unsafe fn srand(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand(arg1: ::std::os::raw::c_uint);
-        }
-        srand(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn strtod(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtod(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtof(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtof(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f32;
-        }
-        strtof(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtol(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtol(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_long;
-        }
-        strtol(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtold(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtold(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> f64;
-        }
-        strtold(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoll(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoll(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoll(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoul(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoul(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strtoul(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtoull(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoull(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtoull(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn system(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        system(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn wcstombs(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const wchar_t,
-    arg_arg3: usize,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn wcstombs(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const wchar_t,
-                arg3: usize,
-            ) -> usize;
-        }
-        wcstombs(arg_arg1, arg_arg2, arg_arg3)
+        mbtowc(arg___pwc, arg___s, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn wctomb(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: wchar_t,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___wchar: wchar_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn wctomb(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: wchar_t,
+                __s: *mut ::std::os::raw::c_char,
+                __wchar: wchar_t,
             ) -> ::std::os::raw::c_int;
         }
-        wctomb(arg_arg1, arg_arg2)
+        wctomb(arg___s, arg___wchar)
     })
 }
 #[track_caller]
-pub unsafe fn _Exit(arg_arg1: ::std::os::raw::c_int) {
+pub unsafe fn mbstowcs(
+    arg___pwcs: *mut wchar_t,
+    arg___s: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn _Exit(arg1: ::std::os::raw::c_int);
+            pub fn mbstowcs(
+                __pwcs: *mut wchar_t,
+                __s: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> usize;
         }
-        _Exit(arg_arg1)
+        mbstowcs(arg___pwcs, arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn a64l(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long {
+pub unsafe fn wcstombs(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___pwcs: *const wchar_t,
+    arg___n: usize,
+) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+            pub fn wcstombs(
+                __s: *mut ::std::os::raw::c_char,
+                __pwcs: *const wchar_t,
+                __n: usize,
+            ) -> usize;
         }
-        a64l(arg_arg1)
+        wcstombs(arg___s, arg___pwcs, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn drand48() -> f64 {
+pub unsafe fn rpmatch(arg___response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn drand48() -> f64;
+            pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
         }
-        drand48()
-    })
-}
-#[track_caller]
-pub unsafe fn ecvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ecvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        ecvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn erand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-        }
-        erand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        fcvt(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gcvt(
-    arg_arg1: f64,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gcvt(
-                arg1: f64,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        gcvt(arg_arg1, arg_arg2, arg_arg3)
+        rpmatch(arg___response)
     })
 }
 #[track_caller]
 pub unsafe fn getsubopt(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *const *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+    arg___optionp: *mut *mut ::std::os::raw::c_char,
+    arg___tokens: *const *mut ::std::os::raw::c_char,
+    arg___valuep: *mut *mut ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn getsubopt(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *const *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+                __optionp: *mut *mut ::std::os::raw::c_char,
+                __tokens: *const *mut ::std::os::raw::c_char,
+                __valuep: *mut *mut ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_int;
         }
-        getsubopt(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn grantpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        grantpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn initstate(
-    arg_arg1: ::std::os::raw::c_uint,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: usize,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn initstate(
-                arg1: ::std::os::raw::c_uint,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: usize,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        initstate(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn jrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        jrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn l64a(arg_arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-        }
-        l64a(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lcong48(arg_arg1: *mut ::std::os::raw::c_ushort) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-        }
-        lcong48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrand48() -> ::std::os::raw::c_long;
-        }
-        lrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn mkstemp(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        mkstemp(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mrand48() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mrand48() -> ::std::os::raw::c_long;
-        }
-        mrand48()
-    })
-}
-#[track_caller]
-pub unsafe fn nrand48(arg_arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-        }
-        nrand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn posix_openpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        posix_openpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname(arg_arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        ptsname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ptsname_r(
-    arg_fildes: ::std::os::raw::c_int,
-    arg_buffer: *mut ::std::os::raw::c_char,
-    arg_buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ptsname_r(
-                fildes: ::std::os::raw::c_int,
-                buffer: *mut ::std::os::raw::c_char,
-                buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        ptsname_r(arg_fildes, arg_buffer, arg_buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn putenv(arg_arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        putenv(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn random() -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn random() -> ::std::os::raw::c_long;
-        }
-        random()
-    })
-}
-#[track_caller]
-pub unsafe fn rand_r(arg_arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-        }
-        rand_r(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn realpath(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-            pub fn realpath(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        realpath(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn seed48(arg_arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-        }
-        seed48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setenv(
-    arg___name: *const ::std::os::raw::c_char,
-    arg___value: *const ::std::os::raw::c_char,
-    arg___overwrite: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setenv(
-                __name: *const ::std::os::raw::c_char,
-                __value: *const ::std::os::raw::c_char,
-                __overwrite: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        setenv(arg___name, arg___value, arg___overwrite)
-    })
-}
-#[track_caller]
-pub unsafe fn setkey(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setkey(arg1: *const ::std::os::raw::c_char);
-        }
-        setkey(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setstate(arg_arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-        }
-        setstate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srand48(arg_arg1: ::std::os::raw::c_long) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srand48(arg1: ::std::os::raw::c_long);
-        }
-        srand48(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn srandom(arg_arg1: ::std::os::raw::c_uint) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandom(arg1: ::std::os::raw::c_uint);
-        }
-        srandom(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unlockpt(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        unlockpt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn unsetenv(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        unsetenv(arg_arg1)
-    })
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-#[track_caller]
-pub unsafe fn arc4random() -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random() -> u32;
-        }
-        arc4random()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_addrandom(
-    arg_arg1: *mut ::std::os::raw::c_uchar,
-    arg_arg2: ::std::os::raw::c_int,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_addrandom(
-                arg1: *mut ::std::os::raw::c_uchar,
-                arg2: ::std::os::raw::c_int,
-            );
-        }
-        arc4random_addrandom(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_buf(arg___buf: *mut ::std::os::raw::c_void, arg___nbytes: usize) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-        }
-        arc4random_buf(arg___buf, arg___nbytes)
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_stir() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_stir();
-        }
-        arc4random_stir()
-    })
-}
-#[track_caller]
-pub unsafe fn arc4random_uniform(arg___upper_bound: u32) -> u32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-        }
-        arc4random_uniform(arg___upper_bound)
-    })
-}
-#[track_caller]
-pub unsafe fn atexit_b(arg_arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-        }
-        atexit_b(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn bsearch_b(
-    arg___key: *const ::std::os::raw::c_void,
-    arg___base: *const ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bsearch_b(
-                __key: *const ::std::os::raw::c_void,
-                __base: *const ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        bsearch_b(arg___key, arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetcap(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetcap(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        cgetcap(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetclose() -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetclose() -> ::std::os::raw::c_int;
-        }
-        cgetclose()
-    })
-}
-#[track_caller]
-pub unsafe fn cgetent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetent(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetfirst(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetfirst(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetfirst(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetmatch(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetmatch(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetmatch(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnext(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnext(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnext(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetnum(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetnum(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetnum(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetset(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        cgetset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetstr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetstr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetstr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn cgetustr(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cgetustr(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        cgetustr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn daemon(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn daemon(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        daemon(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname(arg_arg1: dev_t, arg_arg2: mode_t) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-        }
-        devname(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn devname_r(
-    arg_arg1: dev_t,
-    arg_arg2: mode_t,
-    arg_buf: *mut ::std::os::raw::c_char,
-    arg_len: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn devname_r(
-                arg1: dev_t,
-                arg2: mode_t,
-                buf: *mut ::std::os::raw::c_char,
-                len: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        devname_r(arg_arg1, arg_arg2, arg_buf, arg_len)
-    })
-}
-#[track_caller]
-pub unsafe fn getbsize(
-    arg_arg1: *mut ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_long,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getbsize(
-                arg1: *mut ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_long,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        getbsize(arg_arg1, arg_arg2)
+        getsubopt(arg___optionp, arg___tokens, arg___valuep)
     })
 }
 #[track_caller]
 pub unsafe fn getloadavg(
-    arg_arg1: *mut f64,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___loadavg: *mut f64,
+    arg___nelem: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int)
-                -> ::std::os::raw::c_int;
-        }
-        getloadavg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getprogname() -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprogname() -> *const ::std::os::raw::c_char;
-        }
-        getprogname()
-    })
-}
-#[track_caller]
-pub unsafe fn setprogname(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-        }
-        setprogname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn heapsort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
+            pub fn getloadavg(
+                __loadavg: *mut f64,
+                __nelem: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        heapsort(arg___base, arg___nel, arg___width, arg___compar)
+        getloadavg(arg___loadavg, arg___nelem)
     })
 }
 #[track_caller]
-pub unsafe fn heapsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn heapsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        heapsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn mergesort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mergesort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        mergesort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *const ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        psort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn psort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        psort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_b(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg___compar: *mut ::std::os::raw::c_void,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_b(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                __compar: *mut ::std::os::raw::c_void,
-            );
-        }
-        qsort_b(arg___base, arg___nel, arg___width, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn qsort_r(
-    arg___base: *mut ::std::os::raw::c_void,
-    arg___nel: usize,
-    arg___width: usize,
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg___compar: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_void,
-            arg3: *const ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-    >,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn qsort_r(
-                __base: *mut ::std::os::raw::c_void,
-                __nel: usize,
-                __width: usize,
-                arg1: *mut ::std::os::raw::c_void,
-                __compar: ::std::option::Option<
-                    unsafe extern "C" fn(
-                        arg1: *mut ::std::os::raw::c_void,
-                        arg2: *const ::std::os::raw::c_void,
-                        arg3: *const ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int,
-                >,
-            );
-        }
-        qsort_r(arg___base, arg___nel, arg___width, arg_arg1, arg___compar)
-    })
-}
-#[track_caller]
-pub unsafe fn radixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn radixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        radixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn rpmatch(arg_arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-        }
-        rpmatch(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sradixsort(
-    arg___base: *mut *const ::std::os::raw::c_uchar,
-    arg___nel: ::std::os::raw::c_int,
-    arg___table: *const ::std::os::raw::c_uchar,
-    arg___endbyte: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sradixsort(
-                __base: *mut *const ::std::os::raw::c_uchar,
-                __nel: ::std::os::raw::c_int,
-                __table: *const ::std::os::raw::c_uchar,
-                __endbyte: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        sradixsort(arg___base, arg___nel, arg___table, arg___endbyte)
-    })
-}
-#[track_caller]
-pub unsafe fn sranddev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sranddev();
-        }
-        sranddev()
-    })
-}
-#[track_caller]
-pub unsafe fn srandomdev() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn srandomdev();
-        }
-        srandomdev()
-    })
-}
-#[track_caller]
-pub unsafe fn reallocf(
-    arg___ptr: *mut ::std::os::raw::c_void,
-    arg___size: usize,
+pub unsafe fn memcpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn reallocf(
-                __ptr: *mut ::std::os::raw::c_void,
-                __size: usize,
+            pub fn memcpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        reallocf(arg___ptr, arg___size)
+        memcpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtonum(
-    arg___numstr: *const ::std::os::raw::c_char,
-    arg___minval: ::std::os::raw::c_longlong,
-    arg___maxval: ::std::os::raw::c_longlong,
-    arg___errstrp: *mut *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_longlong {
+pub unsafe fn memmove(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strtonum(
-                __numstr: *const ::std::os::raw::c_char,
-                __minval: ::std::os::raw::c_longlong,
-                __maxval: ::std::os::raw::c_longlong,
-                __errstrp: *mut *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_longlong;
+            pub fn memmove(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
         }
-        strtonum(arg___numstr, arg___minval, arg___maxval, arg___errstrp)
+        memmove(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strtoq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtoq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_longlong;
-        }
-        strtoq(arg___str, arg___endptr, arg___base)
-    })
-}
-#[track_caller]
-pub unsafe fn strtouq(
-    arg___str: *const ::std::os::raw::c_char,
-    arg___endptr: *mut *mut ::std::os::raw::c_char,
-    arg___base: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_ulonglong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strtouq(
-                __str: *const ::std::os::raw::c_char,
-                __endptr: *mut *mut ::std::os::raw::c_char,
-                __base: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_ulonglong;
-        }
-        strtouq(arg___str, arg___endptr, arg___base)
-    })
-}
-extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-#[track_caller]
-pub unsafe fn memchr(
-    arg___s: *const ::std::os::raw::c_void,
+pub unsafe fn memccpy(
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___src: *const ::std::os::raw::c_void,
     arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memchr(
-                __s: *const ::std::os::raw::c_void,
+            pub fn memccpy(
+                __dest: *mut ::std::os::raw::c_void,
+                __src: *const ::std::os::raw::c_void,
                 __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memchr(arg___s, arg___c, arg___n)
+        memccpy(arg___dest, arg___src, arg___c, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memset(
+    arg___s: *mut ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_void {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn memset(
+                __s: *mut ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_void;
+        }
+        memset(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
@@ -7920,84 +6552,101 @@ pub unsafe fn memcmp(
     })
 }
 #[track_caller]
-pub unsafe fn memcpy(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
+pub unsafe fn __memcmpeq(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __memcmpeq(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        __memcmpeq(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn memchr(
+    arg___s: *const ::std::os::raw::c_void,
+    arg___c: ::std::os::raw::c_int,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_void {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memcpy(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
+            pub fn memchr(
+                __s: *const ::std::os::raw::c_void,
+                __c: ::std::os::raw::c_int,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_void;
         }
-        memcpy(arg___dst, arg___src, arg___n)
+        memchr(arg___s, arg___c, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn memmove(
-    arg___dst: *mut ::std::os::raw::c_void,
-    arg___src: *const ::std::os::raw::c_void,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memmove(
-                __dst: *mut ::std::os::raw::c_void,
-                __src: *const ::std::os::raw::c_void,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memmove(arg___dst, arg___src, arg___len)
+        strcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn memset(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___len: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+pub unsafe fn strncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset(
-                __b: *mut ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __len: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+            pub fn strncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset(arg___b, arg___c, arg___len)
+        strncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
 pub unsafe fn strcat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strcat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcat(arg___s1, arg___s2)
+        strcat(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn strchr(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___c: ::std::os::raw::c_int,
+pub unsafe fn strncat(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strchr(
-                __s: *const ::std::os::raw::c_char,
-                __c: ::std::os::raw::c_int,
+            pub fn strncat(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strchr(arg___s, arg___c)
+        strncat(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
@@ -8013,86 +6662,6 @@ pub unsafe fn strcmp(
             ) -> ::std::os::raw::c_int;
         }
         strcmp(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcoll(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcoll(
-                __s1: *const ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
-        }
-        strcoll(arg___s1, arg___s2)
-    })
-}
-#[track_caller]
-pub unsafe fn strcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strcpy(arg___dst, arg___src)
-    })
-}
-#[track_caller]
-pub unsafe fn strcspn(
-    arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strcspn(
-                __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_ulong;
-        }
-        strcspn(arg___s, arg___charset)
-    })
-}
-#[track_caller]
-pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strerror(arg___errnum)
-    })
-}
-#[track_caller]
-pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-        }
-        strlen(arg___s)
-    })
-}
-#[track_caller]
-pub unsafe fn strncat(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncat(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strncat(arg___s1, arg___s2, arg___n)
     })
 }
 #[track_caller]
@@ -8113,35 +6682,130 @@ pub unsafe fn strncmp(
     })
 }
 #[track_caller]
-pub unsafe fn strncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
+pub unsafe fn strcoll(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm(
+    arg___dest: *mut ::std::os::raw::c_char,
     arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strxfrm(arg___dest, arg___src, arg___n)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+impl Default for __locale_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+#[track_caller]
+pub unsafe fn strcoll_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcoll_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __l: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcoll_l(arg___s1, arg___s2, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strxfrm_l(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___l: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strxfrm_l(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+                __l: locale_t,
+            ) -> usize;
+        }
+        strxfrm_l(arg___dest, arg___src, arg___n, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn strdup(arg___s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+        }
+        strdup(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strndup(
+    arg___string: *const ::std::os::raw::c_char,
     arg___n: ::std::os::raw::c_ulong,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
+            pub fn strndup(
+                __string: *const ::std::os::raw::c_char,
                 __n: ::std::os::raw::c_ulong,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strncpy(arg___dst, arg___src, arg___n)
+        strndup(arg___string, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strpbrk(
+pub unsafe fn strchr(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strpbrk(
+            pub fn strchr(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strpbrk(arg___s, arg___charset)
+        strchr(arg___s, arg___c)
     })
 }
 #[track_caller]
@@ -8160,358 +6824,349 @@ pub unsafe fn strrchr(
     })
 }
 #[track_caller]
+pub unsafe fn strcspn(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___reject: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcspn(
+                __s: *const ::std::os::raw::c_char,
+                __reject: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strcspn(arg___s, arg___reject)
+    })
+}
+#[track_caller]
 pub unsafe fn strspn(
     arg___s: *const ::std::os::raw::c_char,
-    arg___charset: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
 ) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strspn(
                 __s: *const ::std::os::raw::c_char,
-                __charset: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
             ) -> ::std::os::raw::c_ulong;
         }
-        strspn(arg___s, arg___charset)
+        strspn(arg___s, arg___accept)
+    })
+}
+#[track_caller]
+pub unsafe fn strpbrk(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___accept: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strpbrk(
+                __s: *const ::std::os::raw::c_char,
+                __accept: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        strpbrk(arg___s, arg___accept)
     })
 }
 #[track_caller]
 pub unsafe fn strstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+    arg___haystack: *const ::std::os::raw::c_char,
+    arg___needle: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+                __haystack: *const ::std::os::raw::c_char,
+                __needle: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strstr(arg___big, arg___little)
+        strstr(arg___haystack, arg___needle)
     })
 }
 #[track_caller]
 pub unsafe fn strtok(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok(arg___str, arg___sep)
+        strtok(arg___s, arg___delim)
     })
 }
 #[track_caller]
-pub unsafe fn strxfrm(
-    arg___s1: *mut ::std::os::raw::c_char,
-    arg___s2: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn __strtok_r(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strxfrm(
-                __s1: *mut ::std::os::raw::c_char,
-                __s2: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn __strtok_r(
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strxfrm(arg___s1, arg___s2, arg___n)
+        __strtok_r(arg___s, arg___delim, arg___save_ptr)
     })
 }
 #[track_caller]
 pub unsafe fn strtok_r(
-    arg___str: *mut ::std::os::raw::c_char,
-    arg___sep: *const ::std::os::raw::c_char,
-    arg___lasts: *mut *mut ::std::os::raw::c_char,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___delim: *const ::std::os::raw::c_char,
+    arg___save_ptr: *mut *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strtok_r(
-                __str: *mut ::std::os::raw::c_char,
-                __sep: *const ::std::os::raw::c_char,
-                __lasts: *mut *mut ::std::os::raw::c_char,
+                __s: *mut ::std::os::raw::c_char,
+                __delim: *const ::std::os::raw::c_char,
+                __save_ptr: *mut *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strtok_r(arg___str, arg___sep, arg___lasts)
+        strtok_r(arg___s, arg___delim, arg___save_ptr)
+    })
+}
+#[track_caller]
+pub unsafe fn strlen(arg___s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+        }
+        strlen(arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn strnlen(arg___string: *const ::std::os::raw::c_char, arg___maxlen: usize) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+        }
+        strnlen(arg___string, arg___maxlen)
+    })
+}
+#[track_caller]
+pub unsafe fn strerror(arg___errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+        }
+        strerror(arg___errnum)
     })
 }
 #[track_caller]
 pub unsafe fn strerror_r(
     arg___errnum: ::std::os::raw::c_int,
-    arg___strerrbuf: *mut ::std::os::raw::c_char,
+    arg___buf: *mut ::std::os::raw::c_char,
     arg___buflen: usize,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
+            #[link_name = "\u{1}__xpg_strerror_r"]
             pub fn strerror_r(
                 __errnum: ::std::os::raw::c_int,
-                __strerrbuf: *mut ::std::os::raw::c_char,
+                __buf: *mut ::std::os::raw::c_char,
                 __buflen: usize,
             ) -> ::std::os::raw::c_int;
         }
-        strerror_r(arg___errnum, arg___strerrbuf, arg___buflen)
+        strerror_r(arg___errnum, arg___buf, arg___buflen)
     })
 }
 #[track_caller]
-pub unsafe fn strdup(arg___s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char {
+pub unsafe fn strerror_l(
+    arg___errnum: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+            pub fn strerror_l(
+                __errnum: ::std::os::raw::c_int,
+                __l: locale_t,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strdup(arg___s1)
+        strerror_l(arg___errnum, arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn memccpy(
-    arg___dst: *mut ::std::os::raw::c_void,
+pub unsafe fn bcmp(
+    arg___s1: *const ::std::os::raw::c_void,
+    arg___s2: *const ::std::os::raw::c_void,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn bcmp(
+                __s1: *const ::std::os::raw::c_void,
+                __s2: *const ::std::os::raw::c_void,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        bcmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn bcopy(
     arg___src: *const ::std::os::raw::c_void,
-    arg___c: ::std::os::raw::c_int,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_void {
+    arg___dest: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memccpy(
-                __dst: *mut ::std::os::raw::c_void,
+            pub fn bcopy(
                 __src: *const ::std::os::raw::c_void,
-                __c: ::std::os::raw::c_int,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_void;
+                __dest: *mut ::std::os::raw::c_void,
+                __n: usize,
+            );
         }
-        memccpy(arg___dst, arg___src, arg___c, arg___n)
+        bcopy(arg___src, arg___dest, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: ::std::os::raw::c_ulong) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn stpcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
         }
-        stpcpy(arg___dst, arg___src)
+        bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn stpncpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___src: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn stpncpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __src: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        stpncpy(arg___dst, arg___src, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strndup(
-    arg___s1: *const ::std::os::raw::c_char,
-    arg___n: ::std::os::raw::c_ulong,
-) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strndup(
-                __s1: *const ::std::os::raw::c_char,
-                __n: ::std::os::raw::c_ulong,
-            ) -> *mut ::std::os::raw::c_char;
-        }
-        strndup(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strnlen(arg___s1: *const ::std::os::raw::c_char, arg___n: usize) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
-        }
-        strnlen(arg___s1, arg___n)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-        }
-        strsignal(arg___sig)
-    })
-}
-pub type rsize_t = __darwin_size_t;
-pub type errno_t = ::std::os::raw::c_int;
-#[track_caller]
-pub unsafe fn memset_s(
-    arg___s: *mut ::std::os::raw::c_void,
-    arg___smax: rsize_t,
+pub unsafe fn index(
+    arg___s: *const ::std::os::raw::c_char,
     arg___c: ::std::os::raw::c_int,
-    arg___n: rsize_t,
-) -> errno_t {
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn memset_s(
-                __s: *mut ::std::os::raw::c_void,
-                __smax: rsize_t,
+            pub fn index(
+                __s: *const ::std::os::raw::c_char,
                 __c: ::std::os::raw::c_int,
-                __n: rsize_t,
-            ) -> errno_t;
+            ) -> *mut ::std::os::raw::c_char;
         }
-        memset_s(arg___s, arg___smax, arg___c, arg___n)
+        index(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn memmem(
-    arg___big: *const ::std::os::raw::c_void,
-    arg___big_len: usize,
-    arg___little: *const ::std::os::raw::c_void,
-    arg___little_len: usize,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memmem(
-                __big: *const ::std::os::raw::c_void,
-                __big_len: usize,
-                __little: *const ::std::os::raw::c_void,
-                __little_len: usize,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        memmem(arg___big, arg___big_len, arg___little, arg___little_len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern4(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern4: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern4(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern4: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern4(arg___b, arg___pattern4, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern8(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern8: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern8(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern8: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern8(arg___b, arg___pattern8, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn memset_pattern16(
-    arg___b: *mut ::std::os::raw::c_void,
-    arg___pattern16: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn memset_pattern16(
-                __b: *mut ::std::os::raw::c_void,
-                __pattern16: *const ::std::os::raw::c_void,
-                __len: usize,
-            );
-        }
-        memset_pattern16(arg___b, arg___pattern16, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strcasestr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
+pub unsafe fn rindex(
+    arg___s: *const ::std::os::raw::c_char,
+    arg___c: ::std::os::raw::c_int,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasestr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
+            pub fn rindex(
+                __s: *const ::std::os::raw::c_char,
+                __c: ::std::os::raw::c_int,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strcasestr(arg___big, arg___little)
+        rindex(arg___s, arg___c)
     })
 }
 #[track_caller]
-pub unsafe fn strnstr(
-    arg___big: *const ::std::os::raw::c_char,
-    arg___little: *const ::std::os::raw::c_char,
-    arg___len: usize,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn ffs(arg___i: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strnstr(
-                __big: *const ::std::os::raw::c_char,
-                __little: *const ::std::os::raw::c_char,
-                __len: usize,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        strnstr(arg___big, arg___little, arg___len)
+        ffs(arg___i)
     })
 }
 #[track_caller]
-pub unsafe fn strlcat(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsl(arg___l: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcat(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
         }
-        strlcat(arg___dst, arg___source, arg___size)
+        ffsl(arg___l)
     })
 }
 #[track_caller]
-pub unsafe fn strlcpy(
-    arg___dst: *mut ::std::os::raw::c_char,
-    arg___source: *const ::std::os::raw::c_char,
-    arg___size: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_ulong {
+pub unsafe fn ffsll(arg___ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strlcpy(
-                __dst: *mut ::std::os::raw::c_char,
-                __source: *const ::std::os::raw::c_char,
-                __size: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_ulong;
+            pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
         }
-        strlcpy(arg___dst, arg___source, arg___size)
+        ffsll(arg___ll)
     })
 }
 #[track_caller]
-pub unsafe fn strmode(arg___mode: ::std::os::raw::c_int, arg___bp: *mut ::std::os::raw::c_char) {
+pub unsafe fn strcasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+            pub fn strcasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        strmode(arg___mode, arg___bp)
+        strcasecmp(arg___s1, arg___s2)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp(arg___s1, arg___s2, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn strcasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strcasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strcasecmp_l(arg___s1, arg___s2, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn strncasecmp_l(
+    arg___s1: *const ::std::os::raw::c_char,
+    arg___s2: *const ::std::os::raw::c_char,
+    arg___n: usize,
+    arg___loc: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strncasecmp_l(
+                __s1: *const ::std::os::raw::c_char,
+                __s2: *const ::std::os::raw::c_char,
+                __n: usize,
+                __loc: locale_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        strncasecmp_l(arg___s1, arg___s2, arg___n, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn explicit_bzero(arg___s: *mut ::std::os::raw::c_void, arg___n: usize) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
+        }
+        explicit_bzero(arg___s, arg___n)
     })
 }
 #[track_caller]
@@ -8530,285 +7185,111 @@ pub unsafe fn strsep(
     })
 }
 #[track_caller]
-pub unsafe fn swab(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: isize,
-) {
+pub unsafe fn strsignal(arg___sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn swab(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: isize,
-            );
+            pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
         }
-        swab(arg_arg1, arg_arg2, arg_arg3)
+        strsignal(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn timingsafe_bcmp(
-    arg___b1: *const ::std::os::raw::c_void,
-    arg___b2: *const ::std::os::raw::c_void,
-    arg___len: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timingsafe_bcmp(
-                __b1: *const ::std::os::raw::c_void,
-                __b2: *const ::std::os::raw::c_void,
-                __len: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        timingsafe_bcmp(arg___b1, arg___b2, arg___len)
-    })
-}
-#[track_caller]
-pub unsafe fn strsignal_r(
-    arg___sig: ::std::os::raw::c_int,
-    arg___strsignalbuf: *mut ::std::os::raw::c_char,
-    arg___buflen: usize,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strsignal_r(
-                __sig: ::std::os::raw::c_int,
-                __strsignalbuf: *mut ::std::os::raw::c_char,
-                __buflen: usize,
-            ) -> ::std::os::raw::c_int;
-        }
-        strsignal_r(arg___sig, arg___strsignalbuf, arg___buflen)
-    })
-}
-#[track_caller]
-pub unsafe fn bcmp(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcmp(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        bcmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bcopy(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bcopy(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-            );
-        }
-        bcopy(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bzero(arg_arg1: *mut ::std::os::raw::c_void, arg_arg2: ::std::os::raw::c_ulong) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-        }
-        bzero(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn index(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn __stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn index(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn __stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        index(arg_arg1, arg_arg2)
+        __stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn rindex(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn stpcpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rindex(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
+            pub fn stpcpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        rindex(arg_arg1, arg_arg2)
+        stpcpy(arg___dest, arg___src)
     })
 }
 #[track_caller]
-pub unsafe fn ffs(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: usize,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: usize,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        ffs(arg_arg1)
+        __stpncpy(arg___dest, arg___src, arg___n)
     })
 }
 #[track_caller]
-pub unsafe fn strcasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> ::std::os::raw::c_int {
+pub unsafe fn stpncpy(
+    arg___dest: *mut ::std::os::raw::c_char,
+    arg___src: *const ::std::os::raw::c_char,
+    arg___n: ::std::os::raw::c_ulong,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strcasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> ::std::os::raw::c_int;
+            pub fn stpncpy(
+                __dest: *mut ::std::os::raw::c_char,
+                __src: *const ::std::os::raw::c_char,
+                __n: ::std::os::raw::c_ulong,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        strcasecmp(arg_arg1, arg_arg2)
+        stpncpy(arg___dest, arg___src, arg___n)
     })
 }
-#[track_caller]
-pub unsafe fn strncasecmp(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_ulong,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn strncasecmp(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
-        }
-        strncasecmp(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        ffsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ffsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        ffsll(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fls(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        fls(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsl(arg_arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-        }
-        flsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn flsll(arg_arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-        }
-        flsll(arg_arg1)
-    })
-}
-pub type max_align_t = f64;
-pub type __gnuc_va_list = __builtin_va_list;
-pub type u_char = ::std::os::raw::c_uchar;
-pub type u_short = ::std::os::raw::c_ushort;
-pub type u_int = ::std::os::raw::c_uint;
-pub type u_long = ::std::os::raw::c_ulong;
-pub type ushort = ::std::os::raw::c_ushort;
-pub type uint = ::std::os::raw::c_uint;
-pub type u_quad_t = u_int64_t;
-pub type quad_t = i64;
-pub type qaddr_t = *mut quad_t;
-pub type caddr_t = *mut ::std::os::raw::c_char;
-pub type daddr_t = i32;
-pub type fixpt_t = u_int32_t;
-pub type blkcnt_t = __darwin_blkcnt_t;
-pub type blksize_t = __darwin_blksize_t;
-pub type gid_t = __darwin_gid_t;
-pub type in_addr_t = __uint32_t;
-pub type in_port_t = __uint16_t;
-pub type ino_t = __darwin_ino_t;
-pub type ino64_t = __darwin_ino64_t;
-pub type key_t = __int32_t;
-pub type nlink_t = __uint16_t;
-pub type segsz_t = i32;
-pub type swblk_t = i32;
-pub type clock_t = __darwin_clock_t;
-pub type time_t = __darwin_time_t;
-pub type useconds_t = __darwin_useconds_t;
-pub type suseconds_t = __darwin_suseconds_t;
 #[repr(C)]
+#[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct fd_set {
-    pub fds_bits: [__int32_t; 32usize],
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[track_caller]
-pub unsafe fn __darwin_check_fd_set_overflow(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn __errno_location() -> *mut ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __darwin_check_fd_set_overflow(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn __errno_location() -> *mut ::std::os::raw::c_int;
         }
-        __darwin_check_fd_set_overflow(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-pub type fd_mask = __int32_t;
-pub type pthread_cond_t = __darwin_pthread_cond_t;
-pub type pthread_condattr_t = __darwin_pthread_condattr_t;
-pub type pthread_mutex_t = __darwin_pthread_mutex_t;
-pub type pthread_mutexattr_t = __darwin_pthread_mutexattr_t;
-pub type pthread_once_t = __darwin_pthread_once_t;
-pub type pthread_rwlock_t = __darwin_pthread_rwlock_t;
-pub type pthread_rwlockattr_t = __darwin_pthread_rwlockattr_t;
-pub type pthread_t = __darwin_pthread_t;
-pub type pthread_key_t = __darwin_pthread_key_t;
-pub type fsblkcnt_t = __darwin_fsblkcnt_t;
-pub type fsfilcnt_t = __darwin_fsfilcnt_t;
-#[track_caller]
-pub unsafe fn __error() -> *mut ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __error() -> *mut ::std::os::raw::c_int;
-        }
-        __error()
+        __errno_location()
     })
 }
 #[repr(C)]
@@ -8833,8 +7314,8 @@ pub struct lconv {
     pub p_sign_posn: ::std::os::raw::c_char,
     pub n_sign_posn: ::std::os::raw::c_char,
     pub int_p_cs_precedes: ::std::os::raw::c_char,
-    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_p_sep_by_space: ::std::os::raw::c_char,
+    pub int_n_cs_precedes: ::std::os::raw::c_char,
     pub int_n_sep_by_space: ::std::os::raw::c_char,
     pub int_p_sign_posn: ::std::os::raw::c_char,
     pub int_n_sign_posn: ::std::os::raw::c_char,
@@ -8849,6 +7330,21 @@ impl Default for lconv {
     }
 }
 #[track_caller]
+pub unsafe fn setlocale(
+    arg___category: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setlocale(
+                __category: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
+        }
+        setlocale(arg___category, arg___locale)
+    })
+}
+#[track_caller]
 pub unsafe fn localeconv() -> *mut lconv {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -8858,18 +7354,47 @@ pub unsafe fn localeconv() -> *mut lconv {
     })
 }
 #[track_caller]
-pub unsafe fn setlocale(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn newlocale(
+    arg___category_mask: ::std::os::raw::c_int,
+    arg___locale: *const ::std::os::raw::c_char,
+    arg___base: locale_t,
+) -> locale_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setlocale(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn newlocale(
+                __category_mask: ::std::os::raw::c_int,
+                __locale: *const ::std::os::raw::c_char,
+                __base: locale_t,
+            ) -> locale_t;
         }
-        setlocale(arg_arg1, arg_arg2)
+        newlocale(arg___category_mask, arg___locale, arg___base)
+    })
+}
+#[track_caller]
+pub unsafe fn duplocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn duplocale(__dataset: locale_t) -> locale_t;
+        }
+        duplocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn freelocale(arg___dataset: locale_t) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freelocale(__dataset: locale_t);
+        }
+        freelocale(arg___dataset)
+    })
+}
+#[track_caller]
+pub unsafe fn uselocale(arg___dataset: locale_t) -> locale_t {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn uselocale(__dataset: locale_t) -> locale_t;
+        }
+        uselocale(arg___dataset)
     })
 }
 pub type pg_funcptr_t = ::std::option::Option<unsafe extern "C" fn()>;
@@ -8999,159 +7524,399 @@ impl Default for PGAlignedXLogBlock {
         }
     }
 }
+pub const _ISupper: _bindgen_ty_1 = 256;
+pub const _ISlower: _bindgen_ty_1 = 512;
+pub const _ISalpha: _bindgen_ty_1 = 1024;
+pub const _ISdigit: _bindgen_ty_1 = 2048;
+pub const _ISxdigit: _bindgen_ty_1 = 4096;
+pub const _ISspace: _bindgen_ty_1 = 8192;
+pub const _ISprint: _bindgen_ty_1 = 16384;
+pub const _ISgraph: _bindgen_ty_1 = 32768;
+pub const _ISblank: _bindgen_ty_1 = 1;
+pub const _IScntrl: _bindgen_ty_1 = 2;
+pub const _ISpunct: _bindgen_ty_1 = 4;
+pub const _ISalnum: _bindgen_ty_1 = 8;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn fdatasync(arg_fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdatasync(fildes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __ctype_b_loc() -> *mut *const ::std::os::raw::c_ushort;
         }
-        fdatasync(arg_fildes)
-    })
-}
-pub type wint_t = __darwin_wint_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneEntry {
-    pub __min: __darwin_rune_t,
-    pub __max: __darwin_rune_t,
-    pub __map: __darwin_rune_t,
-    pub __types: *mut __uint32_t,
-}
-impl Default for _RuneEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneRange {
-    pub __nranges: ::std::os::raw::c_int,
-    pub __ranges: *mut _RuneEntry,
-}
-impl Default for _RuneRange {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _RuneCharClass {
-    pub __name: [::std::os::raw::c_char; 14usize],
-    pub __mask: __uint32_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _RuneLocale {
-    pub __magic: [::std::os::raw::c_char; 8usize],
-    pub __encoding: [::std::os::raw::c_char; 32usize],
-    pub __sgetrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *const ::std::os::raw::c_char,
-            arg2: __darwin_size_t,
-            arg3: *mut *const ::std::os::raw::c_char,
-        ) -> __darwin_rune_t,
-    >,
-    pub __sputrune: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: __darwin_rune_t,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: __darwin_size_t,
-            arg4: *mut *mut ::std::os::raw::c_char,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub __invalid_rune: __darwin_rune_t,
-    pub __runetype: [__uint32_t; 256usize],
-    pub __maplower: [__darwin_rune_t; 256usize],
-    pub __mapupper: [__darwin_rune_t; 256usize],
-    pub __runetype_ext: _RuneRange,
-    pub __maplower_ext: _RuneRange,
-    pub __mapupper_ext: _RuneRange,
-    pub __variable: *mut ::std::os::raw::c_void,
-    pub __variable_len: ::std::os::raw::c_int,
-    pub __ncharclasses: ::std::os::raw::c_int,
-    pub __charclasses: *mut _RuneCharClass,
-}
-impl Default for _RuneLocale {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static mut _DefaultRuneLocale: _RuneLocale;
-}
-extern "C" {
-    pub static mut _CurrentRuneLocale: *mut _RuneLocale;
-}
-#[track_caller]
-pub unsafe fn ___runetype(arg_arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ___runetype(arg1: __darwin_ct_rune_t) -> ::std::os::raw::c_ulong;
-        }
-        ___runetype(arg_arg1)
+        __ctype_b_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_tolower_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_tolower_loc() -> *mut *const __int32_t;
         }
-        ___tolower(arg_arg1)
+        __ctype_tolower_loc()
     })
 }
 #[track_caller]
-pub unsafe fn ___toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn __ctype_toupper_loc() -> *mut *const __int32_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ___toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn __ctype_toupper_loc() -> *mut *const __int32_t;
         }
-        ___toupper(arg_arg1)
+        __ctype_toupper_loc()
     })
 }
 #[track_caller]
-pub unsafe fn __maskrune(
-    arg_arg1: __darwin_ct_rune_t,
-    arg_arg2: ::std::os::raw::c_ulong,
+pub unsafe fn isalnum(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalnum(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalnum(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalpha(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isalpha(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isalpha(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn iscntrl(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iscntrl(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        iscntrl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn islower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        islower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isgraph(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isprint(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        ispunct(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isspace(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isxdigit(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        tolower(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toupper(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isblank(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        isascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn toascii(arg___c: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toascii(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        toascii(arg___c)
+    })
+}
+#[track_caller]
+pub unsafe fn _toupper(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _toupper(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _toupper(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn _tolower(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn _tolower(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        _tolower(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn isalnum_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __maskrune(
-                arg1: __darwin_ct_rune_t,
-                arg2: ::std::os::raw::c_ulong,
-            ) -> ::std::os::raw::c_int;
+            pub fn isalnum_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __maskrune(arg_arg1, arg_arg2)
+        isalnum_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __toupper(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn isalpha_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __toupper(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn isalpha_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __toupper(arg_arg1)
+        isalpha_l(arg_arg1, arg_arg2)
     })
 }
 #[track_caller]
-pub unsafe fn __tolower(arg_arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t {
+pub unsafe fn iscntrl_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __tolower(arg1: __darwin_ct_rune_t) -> __darwin_ct_rune_t;
+            pub fn iscntrl_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
         }
-        __tolower(arg_arg1)
+        iscntrl_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn islower_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn islower_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        islower_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isgraph_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isgraph_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isgraph_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isprint_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isprint_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isprint_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn ispunct_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ispunct_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        ispunct_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isspace_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isspace_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isspace_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isupper_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isupper_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isupper_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isxdigit_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isxdigit_l(arg1: ::std::os::raw::c_int, arg2: locale_t)
+                -> ::std::os::raw::c_int;
+        }
+        isxdigit_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn isblank_l(
+    arg_arg1: ::std::os::raw::c_int,
+    arg_arg2: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isblank_l(arg1: ::std::os::raw::c_int, arg2: locale_t) -> ::std::os::raw::c_int;
+        }
+        isblank_l(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn tolower_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tolower_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        tolower_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn __toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        __toupper_l(arg___c, arg___l)
+    })
+}
+#[track_caller]
+pub unsafe fn toupper_l(
+    arg___c: ::std::os::raw::c_int,
+    arg___l: locale_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn toupper_l(__c: ::std::os::raw::c_int, __l: locale_t) -> ::std::os::raw::c_int;
+        }
+        toupper_l(arg___c, arg___l)
     })
 }
 pub type pgsocket = ::std::os::raw::c_int;
@@ -9812,1692 +8577,761 @@ pub unsafe fn rmtree(arg_path: *const ::std::os::raw::c_char, arg_rmtopdir: bool
         rmtree(arg_path, arg_rmtopdir)
     })
 }
+#[track_caller]
+pub unsafe fn fls(arg_mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fls(mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        fls(arg_mask)
+    })
+}
+#[track_caller]
+pub unsafe fn getpeereid(
+    arg_sock: ::std::os::raw::c_int,
+    arg_uid: *mut uid_t,
+    arg_gid: *mut gid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeereid(
+                sock: ::std::os::raw::c_int,
+                uid: *mut uid_t,
+                gid: *mut gid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeereid(arg_sock, arg_uid, arg_gid)
+    })
+}
 pub type float_t = f32;
 pub type double_t = f64;
 #[track_caller]
-pub unsafe fn __math_errhandling() -> ::std::os::raw::c_int {
+pub unsafe fn __fpclassify(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __math_errhandling() -> ::std::os::raw::c_int;
+            pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
         }
-        __math_errhandling()
+        __fpclassify(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __signbit(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyf(arg_arg1)
+        __signbit(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyd(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyd(arg_arg1)
+        __isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn __fpclassifyl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        __fpclassifyl(arg_arg1)
+        __finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosf(arg1: f32) -> f32;
+            pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosf(arg_arg1)
+        __isnan(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn acos(arg_arg1: f64) -> f64 {
+pub unsafe fn __iseqsig(arg___x: f64, arg___y: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acos(arg1: f64) -> f64;
+            pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
         }
-        acos(arg_arg1)
+        __iseqsig(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn acosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __issignaling(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosl(arg1: f64) -> f64;
+            pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
         }
-        acosl(arg_arg1)
+        __issignaling(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn asinf(arg_arg1: f32) -> f32 {
+pub unsafe fn acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinf(arg1: f32) -> f32;
+            pub fn acos(__x: f64) -> f64;
         }
-        asinf(arg_arg1)
+        acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asin(arg_arg1: f64) -> f64 {
+pub unsafe fn __acos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asin(arg1: f64) -> f64;
+            pub fn __acos(__x: f64) -> f64;
         }
-        asin(arg_arg1)
+        __acos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinl(arg_arg1: f64) -> f64 {
+pub unsafe fn asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinl(arg1: f64) -> f64;
+            pub fn asin(__x: f64) -> f64;
         }
-        asinl(arg_arg1)
+        asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __asin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanf(arg1: f32) -> f32;
+            pub fn __asin(__x: f64) -> f64;
         }
-        atanf(arg_arg1)
+        __asin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan(arg_arg1: f64) -> f64 {
+pub unsafe fn atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan(arg1: f64) -> f64;
+            pub fn atan(__x: f64) -> f64;
         }
-        atan(arg_arg1)
+        atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __atan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanl(arg1: f64) -> f64;
+            pub fn __atan(__x: f64) -> f64;
         }
-        atanl(arg_arg1)
+        __atan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2f(arg_arg1: f32, arg_arg2: f32) -> f32 {
+pub unsafe fn atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+            pub fn atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2f(arg_arg1, arg_arg2)
+        atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __atan2(arg___y: f64, arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2(arg1: f64, arg2: f64) -> f64;
+            pub fn __atan2(__y: f64, __x: f64) -> f64;
         }
-        atan2(arg_arg1, arg_arg2)
+        __atan2(arg___y, arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atan2l(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+            pub fn cos(__x: f64) -> f64;
         }
-        atan2l(arg_arg1, arg_arg2)
+        cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cos(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosf(arg1: f32) -> f32;
+            pub fn __cos(__x: f64) -> f64;
         }
-        cosf(arg_arg1)
+        __cos(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cos(arg_arg1: f64) -> f64 {
+pub unsafe fn sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cos(arg1: f64) -> f64;
+            pub fn sin(__x: f64) -> f64;
         }
-        cos(arg_arg1)
+        sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sin(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosl(arg1: f64) -> f64;
+            pub fn __sin(__x: f64) -> f64;
         }
-        cosl(arg_arg1)
+        __sin(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinf(arg_arg1: f32) -> f32 {
+pub unsafe fn tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinf(arg1: f32) -> f32;
+            pub fn tan(__x: f64) -> f64;
         }
-        sinf(arg_arg1)
+        tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sin(arg_arg1: f64) -> f64 {
+pub unsafe fn __tan(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sin(arg1: f64) -> f64;
+            pub fn __tan(__x: f64) -> f64;
         }
-        sin(arg_arg1)
+        __tan(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn sinl(arg_arg1: f64) -> f64 {
+pub unsafe fn cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinl(arg1: f64) -> f64;
+            pub fn cosh(__x: f64) -> f64;
         }
-        sinl(arg_arg1)
+        cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanf(arg_arg1: f32) -> f32 {
+pub unsafe fn __cosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanf(arg1: f32) -> f32;
+            pub fn __cosh(__x: f64) -> f64;
         }
-        tanf(arg_arg1)
+        __cosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tan(arg_arg1: f64) -> f64 {
+pub unsafe fn sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tan(arg1: f64) -> f64;
+            pub fn sinh(__x: f64) -> f64;
         }
-        tan(arg_arg1)
+        sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanl(arg_arg1: f64) -> f64 {
+pub unsafe fn __sinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanl(arg1: f64) -> f64;
+            pub fn __sinh(__x: f64) -> f64;
         }
-        tanl(arg_arg1)
+        __sinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshf(arg_arg1: f32) -> f32 {
+pub unsafe fn tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshf(arg1: f32) -> f32;
+            pub fn tanh(__x: f64) -> f64;
         }
-        acoshf(arg_arg1)
+        tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acosh(arg_arg1: f64) -> f64 {
+pub unsafe fn __tanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acosh(arg1: f64) -> f64;
+            pub fn __tanh(__x: f64) -> f64;
         }
-        acosh(arg_arg1)
+        __tanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn acoshl(arg_arg1: f64) -> f64 {
+pub unsafe fn acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn acoshl(arg1: f64) -> f64;
+            pub fn acosh(__x: f64) -> f64;
         }
-        acoshl(arg_arg1)
+        acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn __acosh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhf(arg1: f32) -> f32;
+            pub fn __acosh(__x: f64) -> f64;
         }
-        asinhf(arg_arg1)
+        __acosh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinh(arg_arg1: f64) -> f64 {
+pub unsafe fn asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinh(arg1: f64) -> f64;
+            pub fn asinh(__x: f64) -> f64;
         }
-        asinh(arg_arg1)
+        asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn asinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __asinh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asinhl(arg1: f64) -> f64;
+            pub fn __asinh(__x: f64) -> f64;
         }
-        asinhl(arg_arg1)
+        __asinh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhf(arg1: f32) -> f32;
+            pub fn atanh(__x: f64) -> f64;
         }
-        atanhf(arg_arg1)
+        atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __atanh(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanh(arg1: f64) -> f64;
+            pub fn __atanh(__x: f64) -> f64;
         }
-        atanh(arg_arg1)
+        __atanh(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn atanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn atanhl(arg1: f64) -> f64;
+            pub fn exp(__x: f64) -> f64;
         }
-        atanhl(arg_arg1)
+        exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn coshf(arg_arg1: f32) -> f32 {
+pub unsafe fn __exp(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshf(arg1: f32) -> f32;
+            pub fn __exp(__x: f64) -> f64;
         }
-        coshf(arg_arg1)
+        __exp(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn cosh(arg_arg1: f64) -> f64 {
+pub unsafe fn frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn cosh(arg1: f64) -> f64;
+            pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        cosh(arg_arg1)
+        frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn coshl(arg_arg1: f64) -> f64 {
+pub unsafe fn __frexp(arg___x: f64, arg___exponent: *mut ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn coshl(arg1: f64) -> f64;
+            pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
         }
-        coshl(arg_arg1)
+        __frexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhf(arg_arg1: f32) -> f32 {
+pub unsafe fn ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhf(arg1: f32) -> f32;
+            pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinhf(arg_arg1)
+        ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinh(arg_arg1: f64) -> f64 {
+pub unsafe fn __ldexp(arg___x: f64, arg___exponent: ::std::os::raw::c_int) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinh(arg1: f64) -> f64;
+            pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
         }
-        sinh(arg_arg1)
+        __ldexp(arg___x, arg___exponent)
     })
 }
 #[track_caller]
-pub unsafe fn sinhl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sinhl(arg1: f64) -> f64;
+            pub fn __log(__x: f64) -> f64;
         }
-        sinhl(arg_arg1)
+        __log(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhf(arg_arg1: f32) -> f32 {
+pub unsafe fn log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhf(arg1: f32) -> f32;
+            pub fn log10(__x: f64) -> f64;
         }
-        tanhf(arg_arg1)
+        log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanh(arg_arg1: f64) -> f64 {
+pub unsafe fn __log10(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanh(arg1: f64) -> f64;
+            pub fn __log10(__x: f64) -> f64;
         }
-        tanh(arg_arg1)
+        __log10(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn tanhl(arg_arg1: f64) -> f64 {
+pub unsafe fn modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn tanhl(arg1: f64) -> f64;
+            pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        tanhl(arg_arg1)
+        modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn expf(arg_arg1: f32) -> f32 {
+pub unsafe fn __modf(arg___x: f64, arg___iptr: *mut f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expf(arg1: f32) -> f32;
+            pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
         }
-        expf(arg_arg1)
+        __modf(arg___x, arg___iptr)
     })
 }
 #[track_caller]
-pub unsafe fn exp(arg_arg1: f64) -> f64 {
+pub unsafe fn expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp(arg1: f64) -> f64;
+            pub fn expm1(__x: f64) -> f64;
         }
-        exp(arg_arg1)
+        expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expl(arg_arg1: f64) -> f64 {
+pub unsafe fn __expm1(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expl(arg1: f64) -> f64;
+            pub fn __expm1(__x: f64) -> f64;
         }
-        expl(arg_arg1)
+        __expm1(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2f(arg_arg1: f32) -> f32 {
+pub unsafe fn log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2f(arg1: f32) -> f32;
+            pub fn log1p(__x: f64) -> f64;
         }
-        exp2f(arg_arg1)
+        log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2(arg_arg1: f64) -> f64 {
+pub unsafe fn __log1p(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2(arg1: f64) -> f64;
+            pub fn __log1p(__x: f64) -> f64;
         }
-        exp2(arg_arg1)
+        __log1p(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn exp2l(arg_arg1: f64) -> f64 {
+pub unsafe fn logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn exp2l(arg1: f64) -> f64;
+            pub fn logb(__x: f64) -> f64;
         }
-        exp2l(arg_arg1)
+        logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1f(arg_arg1: f32) -> f32 {
+pub unsafe fn __logb(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1f(arg1: f32) -> f32;
+            pub fn __logb(__x: f64) -> f64;
         }
-        expm1f(arg_arg1)
+        __logb(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1(arg_arg1: f64) -> f64 {
+pub unsafe fn exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1(arg1: f64) -> f64;
+            pub fn exp2(__x: f64) -> f64;
         }
-        expm1(arg_arg1)
+        exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn expm1l(arg_arg1: f64) -> f64 {
+pub unsafe fn __exp2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn expm1l(arg1: f64) -> f64;
+            pub fn __exp2(__x: f64) -> f64;
         }
-        expm1l(arg_arg1)
+        __exp2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logf(arg_arg1: f32) -> f32 {
+pub unsafe fn log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logf(arg1: f32) -> f32;
+            pub fn log2(__x: f64) -> f64;
         }
-        logf(arg_arg1)
+        log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logl(arg_arg1: f64) -> f64 {
+pub unsafe fn __log2(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logl(arg1: f64) -> f64;
+            pub fn __log2(__x: f64) -> f64;
         }
-        logl(arg_arg1)
+        __log2(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log10f(arg_arg1: f32) -> f32 {
+pub unsafe fn pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10f(arg1: f32) -> f32;
+            pub fn pow(__x: f64, __y: f64) -> f64;
         }
-        log10f(arg_arg1)
+        pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10(arg_arg1: f64) -> f64 {
+pub unsafe fn __pow(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10(arg1: f64) -> f64;
+            pub fn __pow(__x: f64, __y: f64) -> f64;
         }
-        log10(arg_arg1)
+        __pow(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log10l(arg_arg1: f64) -> f64 {
+pub unsafe fn sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log10l(arg1: f64) -> f64;
+            pub fn sqrt(__x: f64) -> f64;
         }
-        log10l(arg_arg1)
+        sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2f(arg_arg1: f32) -> f32 {
+pub unsafe fn __sqrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2f(arg1: f32) -> f32;
+            pub fn __sqrt(__x: f64) -> f64;
         }
-        log2f(arg_arg1)
+        __sqrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log2(arg_arg1: f64) -> f64 {
+pub unsafe fn hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2(arg1: f64) -> f64;
+            pub fn hypot(__x: f64, __y: f64) -> f64;
         }
-        log2(arg_arg1)
+        hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log2l(arg_arg1: f64) -> f64 {
+pub unsafe fn __hypot(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log2l(arg1: f64) -> f64;
+            pub fn __hypot(__x: f64, __y: f64) -> f64;
         }
-        log2l(arg_arg1)
+        __hypot(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn log1pf(arg_arg1: f32) -> f32 {
+pub unsafe fn cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pf(arg1: f32) -> f32;
+            pub fn cbrt(__x: f64) -> f64;
         }
-        log1pf(arg_arg1)
+        cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1p(arg_arg1: f64) -> f64 {
+pub unsafe fn __cbrt(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1p(arg1: f64) -> f64;
+            pub fn __cbrt(__x: f64) -> f64;
         }
-        log1p(arg_arg1)
+        __cbrt(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn log1pl(arg_arg1: f64) -> f64 {
+pub unsafe fn ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn log1pl(arg1: f64) -> f64;
+            pub fn ceil(__x: f64) -> f64;
         }
-        log1pl(arg_arg1)
+        ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbf(arg_arg1: f32) -> f32 {
+pub unsafe fn __ceil(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbf(arg1: f32) -> f32;
+            pub fn __ceil(__x: f64) -> f64;
         }
-        logbf(arg_arg1)
+        __ceil(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logb(arg_arg1: f64) -> f64 {
+pub unsafe fn fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logb(arg1: f64) -> f64;
+            pub fn fabs(__x: f64) -> f64;
         }
-        logb(arg_arg1)
+        fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn logbl(arg_arg1: f64) -> f64 {
+pub unsafe fn __fabs(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn logbl(arg1: f64) -> f64;
+            pub fn __fabs(__x: f64) -> f64;
         }
-        logbl(arg_arg1)
+        __fabs(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modff(arg_arg1: f32, arg_arg2: *mut f32) -> f32 {
+pub unsafe fn floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+            pub fn floor(__x: f64) -> f64;
         }
-        modff(arg_arg1, arg_arg2)
+        floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modf(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn __floor(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn __floor(__x: f64) -> f64;
         }
-        modf(arg_arg1, arg_arg2)
+        __floor(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn modfl(arg_arg1: f64, arg_arg2: *mut f64) -> f64 {
+pub unsafe fn fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+            pub fn fmod(__x: f64, __y: f64) -> f64;
         }
-        modfl(arg_arg1, arg_arg2)
+        fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn __fmod(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn __fmod(__x: f64, __y: f64) -> f64;
         }
-        ldexpf(arg_arg1, arg_arg2)
+        __fmod(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ldexp(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isinf(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexp(arg_arg1, arg_arg2)
+        isinf(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn ldexpl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn finite(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn finite(__value: f64) -> ::std::os::raw::c_int;
         }
-        ldexpl(arg_arg1, arg_arg2)
+        finite(arg___value)
     })
 }
 #[track_caller]
-pub unsafe fn frexpf(arg_arg1: f32, arg_arg2: *mut ::std::os::raw::c_int) -> f32 {
+pub unsafe fn drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+            pub fn drem(__x: f64, __y: f64) -> f64;
         }
-        frexpf(arg_arg1, arg_arg2)
+        drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexp(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __drem(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn __drem(__x: f64, __y: f64) -> f64;
         }
-        frexp(arg_arg1, arg_arg2)
+        __drem(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn frexpl(arg_arg1: f64, arg_arg2: *mut ::std::os::raw::c_int) -> f64 {
+pub unsafe fn significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+            pub fn significand(__x: f64) -> f64;
         }
-        frexpl(arg_arg1, arg_arg2)
+        significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbf(arg_arg1: f32) -> ::std::os::raw::c_int {
+pub unsafe fn __significand(arg___x: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+            pub fn __significand(__x: f64) -> f64;
         }
-        ilogbf(arg_arg1)
+        __significand(arg___x)
     })
 }
 #[track_caller]
-pub unsafe fn ilogb(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogb(arg_arg1)
+        copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn ilogbl(arg_arg1: f64) -> ::std::os::raw::c_int {
+pub unsafe fn __copysign(arg___x: f64, arg___y: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+            pub fn __copysign(__x: f64, __y: f64) -> f64;
         }
-        ilogbl(arg_arg1)
+        __copysign(arg___x, arg___y)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_int) -> f32 {
+pub unsafe fn nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+            pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbnf(arg_arg1, arg_arg2)
+        nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbn(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn __nan(arg___tagb: *const ::std::os::raw::c_char) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
         }
-        scalbn(arg_arg1, arg_arg2)
+        __nan(arg___tagb)
     })
 }
 #[track_caller]
-pub unsafe fn scalbnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_int) -> f64 {
+pub unsafe fn isnan(arg___value: f64) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+            pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
         }
-        scalbnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnf(arg_arg1: f32, arg_arg2: ::std::os::raw::c_long) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-        }
-        scalblnf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalbln(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalbln(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn scalblnl(arg_arg1: f64, arg_arg2: ::std::os::raw::c_long) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-        }
-        scalblnl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsf(arg1: f32) -> f32;
-        }
-        fabsf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabs(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabs(arg1: f64) -> f64;
-        }
-        fabs(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fabsl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fabsl(arg1: f64) -> f64;
-        }
-        fabsl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtf(arg1: f32) -> f32;
-        }
-        cbrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrt(arg1: f64) -> f64;
-        }
-        cbrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn cbrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn cbrtl(arg1: f64) -> f64;
-        }
-        cbrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-        }
-        hypotf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypot(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypot(arg1: f64, arg2: f64) -> f64;
-        }
-        hypot(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn hypotl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-        }
-        hypotl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powf(arg1: f32, arg2: f32) -> f32;
-        }
-        powf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pow(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pow(arg1: f64, arg2: f64) -> f64;
-        }
-        pow(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn powl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn powl(arg1: f64, arg2: f64) -> f64;
-        }
-        powl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtf(arg1: f32) -> f32;
-        }
-        sqrtf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrt(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrt(arg1: f64) -> f64;
-        }
-        sqrt(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sqrtl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sqrtl(arg1: f64) -> f64;
-        }
-        sqrtl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erff(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erff(arg1: f32) -> f32;
-        }
-        erff(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erf(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erf(arg1: f64) -> f64;
-        }
-        erf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfl(arg1: f64) -> f64;
-        }
-        erfl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcf(arg1: f32) -> f32;
-        }
-        erfcf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfc(arg1: f64) -> f64;
-        }
-        erfc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn erfcl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn erfcl(arg1: f64) -> f64;
-        }
-        erfcl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammaf(arg1: f32) -> f32;
-        }
-        lgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgamma(arg1: f64) -> f64;
-        }
-        lgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lgammal(arg1: f64) -> f64;
-        }
-        lgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammaf(arg1: f32) -> f32;
-        }
-        tgammaf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgamma(arg1: f64) -> f64;
-        }
-        tgamma(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tgammal(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tgammal(arg1: f64) -> f64;
-        }
-        tgammal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceilf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceilf(arg1: f32) -> f32;
-        }
-        ceilf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceil(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceil(arg1: f64) -> f64;
-        }
-        ceil(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn ceill(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn ceill(arg1: f64) -> f64;
-        }
-        ceill(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorf(arg1: f32) -> f32;
-        }
-        floorf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floor(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floor(arg1: f64) -> f64;
-        }
-        floor(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn floorl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn floorl(arg1: f64) -> f64;
-        }
-        floorl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintf(arg1: f32) -> f32;
-        }
-        nearbyintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyint(arg1: f64) -> f64;
-        }
-        nearbyint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nearbyintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nearbyintl(arg1: f64) -> f64;
-        }
-        nearbyintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintf(arg1: f32) -> f32;
-        }
-        rintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rint(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rint(arg1: f64) -> f64;
-        }
-        rint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn rintl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn rintl(arg1: f64) -> f64;
-        }
-        rintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrint(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lrintl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundf(arg1: f32) -> f32;
-        }
-        roundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn round(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn round(arg1: f64) -> f64;
-        }
-        round(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn roundl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn roundl(arg1: f64) -> f64;
-        }
-        roundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundf(arg_arg1: f32) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-        }
-        lroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lround(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn lroundl(arg_arg1: f64) -> ::std::os::raw::c_long {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-        }
-        lroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llrintf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrint(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrint(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llrintl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llrintl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundf(arg_arg1: f32) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-        }
-        llroundf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llround(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llround(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn llroundl(arg_arg1: f64) -> ::std::os::raw::c_longlong {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-        }
-        llroundl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncf(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncf(arg1: f32) -> f32;
-        }
-        truncf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn trunc(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn trunc(arg1: f64) -> f64;
-        }
-        trunc(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn truncl(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn truncl(arg1: f64) -> f64;
-        }
-        truncl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmodf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmod(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmod(arg1: f64, arg2: f64) -> f64;
-        }
-        fmod(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmodl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmodl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-        }
-        remainderf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainder(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainder(arg1: f64, arg2: f64) -> f64;
-        }
-        remainder(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remainderl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-        }
-        remainderl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn remquof(arg_arg1: f32, arg_arg2: f32, arg_arg3: *mut ::std::os::raw::c_int) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-        }
-        remquof(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquo(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquo(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn remquol(arg_arg1: f64, arg_arg2: f64, arg_arg3: *mut ::std::os::raw::c_int) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-        }
-        remquol(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-        }
-        copysignf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysign(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysign(arg1: f64, arg2: f64) -> f64;
-        }
-        copysign(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn copysignl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-        }
-        copysignl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nanf(arg_arg1: *const ::std::os::raw::c_char) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-        }
-        nanf(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nan(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nan(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nanl(arg_arg1: *const ::std::os::raw::c_char) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-        }
-        nanl(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-        }
-        nextafterf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafter(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafter(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nextafterl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-        }
-        nextafterl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttoward(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttoward(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardf(arg_arg1: f32, arg_arg2: f64) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-        }
-        nexttowardf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn nexttowardl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-        }
-        nexttowardl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdimf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-        }
-        fdimf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdim(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdim(arg1: f64, arg2: f64) -> f64;
-        }
-        fdim(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fdiml(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-        }
-        fdiml(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-        }
-        fmaxf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmax(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmax(arg1: f64, arg2: f64) -> f64;
-        }
-        fmax(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaxl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-        }
-        fmaxl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminf(arg_arg1: f32, arg_arg2: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminf(arg1: f32, arg2: f32) -> f32;
-        }
-        fminf(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmin(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmin(arg1: f64, arg2: f64) -> f64;
-        }
-        fmin(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fminl(arg_arg1: f64, arg_arg2: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fminl(arg1: f64, arg2: f64) -> f64;
-        }
-        fminl(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn fmaf(arg_arg1: f32, arg_arg2: f32, arg_arg3: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-        }
-        fmaf(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fma(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fma(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn fmal(arg_arg1: f64, arg_arg2: f64, arg_arg3: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-        }
-        fmal(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10f(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10f(arg1: f32) -> f32;
-        }
-        __exp10f(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __exp10(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __exp10(arg1: f64) -> f64;
-        }
-        __exp10(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospif(arg1: f32) -> f32;
-        }
-        __cospif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __cospi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __cospi(arg1: f64) -> f64;
-        }
-        __cospi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpif(arg1: f32) -> f32;
-        }
-        __sinpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sinpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sinpi(arg1: f64) -> f64;
-        }
-        __sinpi(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpif(arg_arg1: f32) -> f32 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpif(arg1: f32) -> f32;
-        }
-        __tanpif(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __tanpi(arg_arg1: f64) -> f64 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __tanpi(arg1: f64) -> f64;
-        }
-        __tanpi(arg_arg1)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[track_caller]
-pub unsafe fn __sincosf_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincosf_stret(arg1: f32) -> __float2;
-        }
-        __sincosf_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincos_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincos_stret(arg1: f64) -> __double2;
-        }
-        __sincos_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospif_stret(arg_arg1: f32) -> __float2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospif_stret(arg1: f32) -> __float2;
-        }
-        __sincospif_stret(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn __sincospi_stret(arg_arg1: f64) -> __double2 {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __sincospi_stret(arg1: f64) -> __double2;
-        }
-        __sincospi_stret(arg_arg1)
+        isnan(arg___value)
     })
 }
 #[track_caller]
@@ -11510,12 +9344,30 @@ pub unsafe fn j0(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __j0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0(arg1: f64) -> f64;
+        }
+        __j0(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn j1(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn j1(arg1: f64) -> f64;
         }
         j1(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1(arg1: f64) -> f64;
+        }
+        __j1(arg_arg1)
     })
 }
 #[track_caller]
@@ -11528,12 +9380,30 @@ pub unsafe fn jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __jn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+        }
+        __jn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
 pub unsafe fn y0(arg_arg1: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn y0(arg1: f64) -> f64;
         }
         y0(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0(arg1: f64) -> f64;
+        }
+        __y0(arg_arg1)
     })
 }
 #[track_caller]
@@ -11546,6 +9416,15 @@ pub unsafe fn y1(arg_arg1: f64) -> f64 {
     })
 }
 #[track_caller]
+pub unsafe fn __y1(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1(arg1: f64) -> f64;
+        }
+        __y1(arg_arg1)
+    })
+}
+#[track_caller]
 pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -11555,42 +9434,3155 @@ pub unsafe fn yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     })
 }
 #[track_caller]
-pub unsafe fn scalb(arg_arg1: f64, arg_arg2: f64) -> f64 {
+pub unsafe fn __yn(arg_arg1: ::std::os::raw::c_int, arg_arg2: f64) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scalb(arg1: f64, arg2: f64) -> f64;
+            pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
         }
-        scalb(arg_arg1, arg_arg2)
+        __yn(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erf(arg1: f64) -> f64;
+        }
+        erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erf(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erf(arg1: f64) -> f64;
+        }
+        __erf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfc(arg1: f64) -> f64;
+        }
+        erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfc(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfc(arg1: f64) -> f64;
+        }
+        __erfc(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma(arg1: f64) -> f64;
+        }
+        lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma(arg1: f64) -> f64;
+        }
+        __lgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgamma(arg1: f64) -> f64;
+        }
+        tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgamma(arg1: f64) -> f64;
+        }
+        __tgamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gamma(arg1: f64) -> f64;
+        }
+        gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gamma(arg_arg1: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gamma(arg1: f64) -> f64;
+        }
+        __gamma(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgamma_r(arg_arg1: f64, arg___signgamp: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __lgamma_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rint(__x: f64) -> f64;
+        }
+        rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rint(__x: f64) -> f64;
+        }
+        __rint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafter(__x: f64, __y: f64) -> f64;
+        }
+        nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafter(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafter(__x: f64, __y: f64) -> f64;
+        }
+        __nextafter(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttoward(arg___x: f64, arg___y: u128) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+        }
+        __nexttoward(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainder(__x: f64, __y: f64) -> f64;
+        }
+        remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainder(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainder(__x: f64, __y: f64) -> f64;
+        }
+        __remainder(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbn(arg___x: f64, arg___n: ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+        }
+        __scalbn(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogb(arg___x: f64) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+        }
+        __ilogb(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbln(arg___x: f64, arg___n: ::std::os::raw::c_long) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+        }
+        __scalbln(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyint(__x: f64) -> f64;
+        }
+        nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyint(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyint(__x: f64) -> f64;
+        }
+        __nearbyint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn round(__x: f64) -> f64;
+        }
+        round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __round(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __round(__x: f64) -> f64;
+        }
+        __round(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn trunc(__x: f64) -> f64;
+        }
+        trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __trunc(arg___x: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __trunc(__x: f64) -> f64;
+        }
+        __trunc(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquo(arg___x: f64, arg___y: f64, arg___quo: *mut ::std::os::raw::c_int) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+        }
+        __remquo(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrint(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrint(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llrint(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lround(arg___x: f64) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+        }
+        __lround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llround(arg___x: f64) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+        }
+        __llround(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdim(__x: f64, __y: f64) -> f64;
+        }
+        fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdim(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdim(__x: f64, __y: f64) -> f64;
+        }
+        __fdim(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmax(__x: f64, __y: f64) -> f64;
+        }
+        fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmax(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmax(__x: f64, __y: f64) -> f64;
+        }
+        __fmax(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmin(__x: f64, __y: f64) -> f64;
+        }
+        fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmin(arg___x: f64, arg___y: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmin(__x: f64, __y: f64) -> f64;
+        }
+        __fmin(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fma(arg___x: f64, arg___y: f64, arg___z: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+        }
+        __fma(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalb(__x: f64, __n: f64) -> f64;
+        }
+        scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalb(arg___x: f64, arg___n: f64) -> f64 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalb(__x: f64, __n: f64) -> f64;
+        }
+        __scalb(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __signbitf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigf(arg___x: f32, arg___y: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+        }
+        __iseqsigf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        __issignalingf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosf(__x: f32) -> f32;
+        }
+        acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosf(__x: f32) -> f32;
+        }
+        __acosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinf(__x: f32) -> f32;
+        }
+        asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinf(__x: f32) -> f32;
+        }
+        __asinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanf(__x: f32) -> f32;
+        }
+        atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanf(__x: f32) -> f32;
+        }
+        __atanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2f(__y: f32, __x: f32) -> f32;
+        }
+        atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2f(arg___y: f32, arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2f(__y: f32, __x: f32) -> f32;
+        }
+        __atan2f(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosf(__x: f32) -> f32;
+        }
+        cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosf(__x: f32) -> f32;
+        }
+        __cosf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinf(__x: f32) -> f32;
+        }
+        sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinf(__x: f32) -> f32;
+        }
+        __sinf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanf(__x: f32) -> f32;
+        }
+        tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanf(__x: f32) -> f32;
+        }
+        __tanf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshf(__x: f32) -> f32;
+        }
+        coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshf(__x: f32) -> f32;
+        }
+        __coshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhf(__x: f32) -> f32;
+        }
+        sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhf(__x: f32) -> f32;
+        }
+        __sinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhf(__x: f32) -> f32;
+        }
+        tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhf(__x: f32) -> f32;
+        }
+        __tanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshf(__x: f32) -> f32;
+        }
+        acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshf(__x: f32) -> f32;
+        }
+        __acoshf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhf(__x: f32) -> f32;
+        }
+        asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhf(__x: f32) -> f32;
+        }
+        __asinhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhf(__x: f32) -> f32;
+        }
+        atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhf(__x: f32) -> f32;
+        }
+        __atanhf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expf(__x: f32) -> f32;
+        }
+        expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expf(__x: f32) -> f32;
+        }
+        __expf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpf(arg___x: f32, arg___exponent: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __frexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpf(arg___x: f32, arg___exponent: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+        }
+        __ldexpf(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logf(__x: f32) -> f32;
+        }
+        logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logf(__x: f32) -> f32;
+        }
+        __logf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10f(__x: f32) -> f32;
+        }
+        log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10f(__x: f32) -> f32;
+        }
+        __log10f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modff(arg___x: f32, arg___iptr: *mut f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+        }
+        __modff(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1f(__x: f32) -> f32;
+        }
+        expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1f(__x: f32) -> f32;
+        }
+        __expm1f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pf(__x: f32) -> f32;
+        }
+        log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pf(__x: f32) -> f32;
+        }
+        __log1pf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbf(__x: f32) -> f32;
+        }
+        logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbf(__x: f32) -> f32;
+        }
+        __logbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2f(__x: f32) -> f32;
+        }
+        exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2f(__x: f32) -> f32;
+        }
+        __exp2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2f(__x: f32) -> f32;
+        }
+        log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2f(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2f(__x: f32) -> f32;
+        }
+        __log2f(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powf(__x: f32, __y: f32) -> f32;
+        }
+        powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powf(__x: f32, __y: f32) -> f32;
+        }
+        __powf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtf(__x: f32) -> f32;
+        }
+        sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtf(__x: f32) -> f32;
+        }
+        __sqrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotf(__x: f32, __y: f32) -> f32;
+        }
+        hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotf(__x: f32, __y: f32) -> f32;
+        }
+        __hypotf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtf(__x: f32) -> f32;
+        }
+        cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtf(__x: f32) -> f32;
+        }
+        __cbrtf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceilf(__x: f32) -> f32;
+        }
+        ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceilf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceilf(__x: f32) -> f32;
+        }
+        __ceilf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsf(__x: f32) -> f32;
+        }
+        fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsf(__x: f32) -> f32;
+        }
+        __fabsf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorf(__x: f32) -> f32;
+        }
+        floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorf(__x: f32) -> f32;
+        }
+        __floorf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodf(__x: f32, __y: f32) -> f32;
+        }
+        fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodf(__x: f32, __y: f32) -> f32;
+        }
+        __fmodf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinff(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isinff(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitef(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+        }
+        finitef(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dremf(__x: f32, __y: f32) -> f32;
+        }
+        dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dremf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dremf(__x: f32, __y: f32) -> f32;
+        }
+        __dremf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandf(__x: f32) -> f32;
+        }
+        significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandf(__x: f32) -> f32;
+        }
+        __significandf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignf(__x: f32, __y: f32) -> f32;
+        }
+        copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignf(__x: f32, __y: f32) -> f32;
+        }
+        __copysignf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanf(arg___tagb: *const ::std::os::raw::c_char) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+        }
+        __nanf(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanf(arg___value: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+        }
+        isnanf(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0f(arg1: f32) -> f32;
+        }
+        j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0f(arg1: f32) -> f32;
+        }
+        __j0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1f(arg1: f32) -> f32;
+        }
+        j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1f(arg1: f32) -> f32;
+        }
+        __j1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __jnf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0f(arg1: f32) -> f32;
+        }
+        y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0f(arg1: f32) -> f32;
+        }
+        __y0f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1f(arg1: f32) -> f32;
+        }
+        y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1f(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1f(arg1: f32) -> f32;
+        }
+        __y1f(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynf(arg_arg1: ::std::os::raw::c_int, arg_arg2: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+        }
+        __ynf(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erff(arg1: f32) -> f32;
+        }
+        erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erff(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erff(arg1: f32) -> f32;
+        }
+        __erff(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcf(arg1: f32) -> f32;
+        }
+        erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcf(arg1: f32) -> f32;
+        }
+        __erfcf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf(arg1: f32) -> f32;
+        }
+        lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf(arg1: f32) -> f32;
+        }
+        __lgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammaf(arg1: f32) -> f32;
+        }
+        tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammaf(arg1: f32) -> f32;
+        }
+        __tgammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammaf(arg1: f32) -> f32;
+        }
+        gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammaf(arg_arg1: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammaf(arg1: f32) -> f32;
+        }
+        __gammaf(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammaf_r(arg_arg1: f32, arg___signgamp: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __lgammaf_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintf(__x: f32) -> f32;
+        }
+        rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintf(__x: f32) -> f32;
+        }
+        __rintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+        }
+        __nextafterf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardf(arg___x: f32, arg___y: u128) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+        }
+        __nexttowardf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderf(__x: f32, __y: f32) -> f32;
+        }
+        remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderf(__x: f32, __y: f32) -> f32;
+        }
+        __remainderf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnf(arg___x: f32, arg___n: ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+        }
+        __scalbnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbf(arg___x: f32) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+        }
+        __ilogbf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnf(arg___x: f32, arg___n: ::std::os::raw::c_long) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+        }
+        __scalblnf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintf(__x: f32) -> f32;
+        }
+        nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintf(__x: f32) -> f32;
+        }
+        __nearbyintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundf(__x: f32) -> f32;
+        }
+        roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundf(__x: f32) -> f32;
+        }
+        __roundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncf(__x: f32) -> f32;
+        }
+        truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncf(arg___x: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncf(__x: f32) -> f32;
+        }
+        __truncf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquof(arg___x: f32, arg___y: f32, arg___quo: *mut ::std::os::raw::c_int) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+        }
+        __remquof(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llrintf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundf(arg___x: f32) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+        }
+        __lroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundf(arg___x: f32) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+        }
+        __llroundf(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdimf(__x: f32, __y: f32) -> f32;
+        }
+        fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdimf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdimf(__x: f32, __y: f32) -> f32;
+        }
+        __fdimf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+        }
+        __fmaxf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminf(__x: f32, __y: f32) -> f32;
+        }
+        fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminf(arg___x: f32, arg___y: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminf(__x: f32, __y: f32) -> f32;
+        }
+        __fminf(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaf(arg___x: f32, arg___y: f32, arg___z: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+        }
+        __fmaf(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbf(__x: f32, __n: f32) -> f32;
+        }
+        scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbf(arg___x: f32, arg___n: f32) -> f32 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbf(__x: f32, __n: f32) -> f32;
+        }
+        __scalbf(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __fpclassifyl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __fpclassifyl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __signbitl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __signbitl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn __iseqsigl(arg___x: u128, arg___y: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+        }
+        __iseqsigl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __issignalingl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        __issignalingl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acosl(__x: u128) -> u128;
+        }
+        acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acosl(__x: u128) -> u128;
+        }
+        __acosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinl(__x: u128) -> u128;
+        }
+        asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinl(__x: u128) -> u128;
+        }
+        __asinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanl(__x: u128) -> u128;
+        }
+        atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanl(__x: u128) -> u128;
+        }
+        __atanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atan2l(__y: u128, __x: u128) -> u128;
+        }
+        atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atan2l(arg___y: u128, arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atan2l(__y: u128, __x: u128) -> u128;
+        }
+        __atan2l(arg___y, arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cosl(__x: u128) -> u128;
+        }
+        cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cosl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cosl(__x: u128) -> u128;
+        }
+        __cosl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinl(__x: u128) -> u128;
+        }
+        sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinl(__x: u128) -> u128;
+        }
+        __sinl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanl(__x: u128) -> u128;
+        }
+        tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanl(__x: u128) -> u128;
+        }
+        __tanl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn coshl(__x: u128) -> u128;
+        }
+        coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __coshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __coshl(__x: u128) -> u128;
+        }
+        __coshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sinhl(__x: u128) -> u128;
+        }
+        sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sinhl(__x: u128) -> u128;
+        }
+        __sinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tanhl(__x: u128) -> u128;
+        }
+        tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __tanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tanhl(__x: u128) -> u128;
+        }
+        __tanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn acoshl(__x: u128) -> u128;
+        }
+        acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __acoshl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __acoshl(__x: u128) -> u128;
+        }
+        __acoshl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asinhl(__x: u128) -> u128;
+        }
+        asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __asinhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __asinhl(__x: u128) -> u128;
+        }
+        __asinhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn atanhl(__x: u128) -> u128;
+        }
+        atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __atanhl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __atanhl(__x: u128) -> u128;
+        }
+        __atanhl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expl(__x: u128) -> u128;
+        }
+        expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expl(__x: u128) -> u128;
+        }
+        __expl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __frexpl(arg___x: u128, arg___exponent: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __frexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn __ldexpl(arg___x: u128, arg___exponent: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+        }
+        __ldexpl(arg___x, arg___exponent)
+    })
+}
+#[track_caller]
+pub unsafe fn logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logl(__x: u128) -> u128;
+        }
+        logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logl(__x: u128) -> u128;
+        }
+        __logl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log10l(__x: u128) -> u128;
+        }
+        log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log10l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log10l(__x: u128) -> u128;
+        }
+        __log10l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn __modfl(arg___x: u128, arg___iptr: *mut u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+        }
+        __modfl(arg___x, arg___iptr)
+    })
+}
+#[track_caller]
+pub unsafe fn expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn expm1l(__x: u128) -> u128;
+        }
+        expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __expm1l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __expm1l(__x: u128) -> u128;
+        }
+        __expm1l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log1pl(__x: u128) -> u128;
+        }
+        log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log1pl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log1pl(__x: u128) -> u128;
+        }
+        __log1pl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn logbl(__x: u128) -> u128;
+        }
+        logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __logbl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __logbl(__x: u128) -> u128;
+        }
+        __logbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn exp2l(__x: u128) -> u128;
+        }
+        exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __exp2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __exp2l(__x: u128) -> u128;
+        }
+        __exp2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn log2l(__x: u128) -> u128;
+        }
+        log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __log2l(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __log2l(__x: u128) -> u128;
+        }
+        __log2l(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn powl(__x: u128, __y: u128) -> u128;
+        }
+        powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __powl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __powl(__x: u128, __y: u128) -> u128;
+        }
+        __powl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sqrtl(__x: u128) -> u128;
+        }
+        sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __sqrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __sqrtl(__x: u128) -> u128;
+        }
+        __sqrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hypotl(__x: u128, __y: u128) -> u128;
+        }
+        hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __hypotl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __hypotl(__x: u128, __y: u128) -> u128;
+        }
+        __hypotl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn cbrtl(__x: u128) -> u128;
+        }
+        cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __cbrtl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cbrtl(__x: u128) -> u128;
+        }
+        __cbrtl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ceill(__x: u128) -> u128;
+        }
+        ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ceill(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ceill(__x: u128) -> u128;
+        }
+        __ceill(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fabsl(__x: u128) -> u128;
+        }
+        fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __fabsl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fabsl(__x: u128) -> u128;
+        }
+        __fabsl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn floorl(__x: u128) -> u128;
+        }
+        floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __floorl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __floorl(__x: u128) -> u128;
+        }
+        __floorl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmodl(__x: u128, __y: u128) -> u128;
+        }
+        fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmodl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmodl(__x: u128, __y: u128) -> u128;
+        }
+        __fmodl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn isinfl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isinfl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn finitel(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+        }
+        finitel(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn dreml(__x: u128, __y: u128) -> u128;
+        }
+        dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __dreml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __dreml(__x: u128, __y: u128) -> u128;
+        }
+        __dreml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn significandl(__x: u128) -> u128;
+        }
+        significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __significandl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __significandl(__x: u128) -> u128;
+        }
+        __significandl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn copysignl(__x: u128, __y: u128) -> u128;
+        }
+        copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __copysignl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __copysignl(__x: u128, __y: u128) -> u128;
+        }
+        __copysignl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn __nanl(arg___tagb: *const ::std::os::raw::c_char) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+        }
+        __nanl(arg___tagb)
+    })
+}
+#[track_caller]
+pub unsafe fn isnanl(arg___value: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+        }
+        isnanl(arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j0l(arg1: u128) -> u128;
+        }
+        j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j0l(arg1: u128) -> u128;
+        }
+        __j0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn j1l(arg1: u128) -> u128;
+        }
+        j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __j1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __j1l(arg1: u128) -> u128;
+        }
+        __j1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __jnl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __jnl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y0l(arg1: u128) -> u128;
+        }
+        y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y0l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y0l(arg1: u128) -> u128;
+        }
+        __y0l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn y1l(arg1: u128) -> u128;
+        }
+        y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __y1l(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __y1l(arg1: u128) -> u128;
+        }
+        __y1l(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn __ynl(arg_arg1: ::std::os::raw::c_int, arg_arg2: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+        }
+        __ynl(arg_arg1, arg_arg2)
+    })
+}
+#[track_caller]
+pub unsafe fn erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfl(arg1: u128) -> u128;
+        }
+        erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfl(arg1: u128) -> u128;
+        }
+        __erfl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn erfcl(arg1: u128) -> u128;
+        }
+        erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __erfcl(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __erfcl(arg1: u128) -> u128;
+        }
+        __erfcl(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal(arg1: u128) -> u128;
+        }
+        lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal(arg1: u128) -> u128;
+        }
+        __lgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn tgammal(arg1: u128) -> u128;
+        }
+        tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __tgammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __tgammal(arg1: u128) -> u128;
+        }
+        __tgammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gammal(arg1: u128) -> u128;
+        }
+        gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn __gammal(arg_arg1: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __gammal(arg1: u128) -> u128;
+        }
+        __gammal(arg_arg1)
+    })
+}
+#[track_caller]
+pub unsafe fn lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn __lgammal_r(arg_arg1: u128, arg___signgamp: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __lgammal_r(arg_arg1, arg___signgamp)
+    })
+}
+#[track_caller]
+pub unsafe fn rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rintl(__x: u128) -> u128;
+        }
+        rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __rintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __rintl(__x: u128) -> u128;
+        }
+        __rintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nextafterl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+        }
+        __nextafterl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __nexttowardl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+        }
+        __nexttowardl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remainderl(__x: u128, __y: u128) -> u128;
+        }
+        remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __remainderl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remainderl(__x: u128, __y: u128) -> u128;
+        }
+        __remainderl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbnl(arg___x: u128, arg___n: ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+        }
+        __scalbnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __ilogbl(arg___x: u128) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+        }
+        __ilogbl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalblnl(arg___x: u128, arg___n: ::std::os::raw::c_long) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+        }
+        __scalblnl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn nearbyintl(__x: u128) -> u128;
+        }
+        nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __nearbyintl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __nearbyintl(__x: u128) -> u128;
+        }
+        __nearbyintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn roundl(__x: u128) -> u128;
+        }
+        roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __roundl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __roundl(__x: u128) -> u128;
+        }
+        __roundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn truncl(__x: u128) -> u128;
+        }
+        truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __truncl(arg___x: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __truncl(__x: u128) -> u128;
+        }
+        __truncl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn remquol(arg___x: u128, arg___y: u128, arg___quo: *mut ::std::os::raw::c_int) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn __remquol(
+    arg___x: u128,
+    arg___y: u128,
+    arg___quo: *mut ::std::os::raw::c_int,
+) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+        }
+        __remquol(arg___x, arg___y, arg___quo)
+    })
+}
+#[track_caller]
+pub unsafe fn lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lrintl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llrintl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llrintl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __lroundl(arg___x: u128) -> ::std::os::raw::c_long {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+        }
+        __lroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn __llroundl(arg___x: u128) -> ::std::os::raw::c_longlong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+        }
+        __llroundl(arg___x)
+    })
+}
+#[track_caller]
+pub unsafe fn fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fdiml(__x: u128, __y: u128) -> u128;
+        }
+        fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fdiml(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fdiml(__x: u128, __y: u128) -> u128;
+        }
+        __fdiml(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmaxl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+        }
+        __fmaxl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fminl(__x: u128, __y: u128) -> u128;
+        }
+        fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn __fminl(arg___x: u128, arg___y: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fminl(__x: u128, __y: u128) -> u128;
+        }
+        __fminl(arg___x, arg___y)
+    })
+}
+#[track_caller]
+pub unsafe fn fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn __fmal(arg___x: u128, arg___y: u128, arg___z: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+        }
+        __fmal(arg___x, arg___y, arg___z)
+    })
+}
+#[track_caller]
+pub unsafe fn scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn scalbl(__x: u128, __n: u128) -> u128;
+        }
+        scalbl(arg___x, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn __scalbl(arg___x: u128, arg___n: u128) -> u128 {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __scalbl(__x: u128, __n: u128) -> u128;
+        }
+        __scalbl(arg___x, arg___n)
     })
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-impl Default for exception {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub const FP_NAN: _bindgen_ty_2 = 0;
+pub const FP_INFINITE: _bindgen_ty_2 = 1;
+pub const FP_ZERO: _bindgen_ty_2 = 2;
+pub const FP_SUBNORMAL: _bindgen_ty_2 = 3;
+pub const FP_NORMAL: _bindgen_ty_2 = 4;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
 #[track_caller]
-pub unsafe fn explicit_bzero(arg_buf: *mut ::std::os::raw::c_void, arg_len: usize) {
+pub unsafe fn strlcat(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn explicit_bzero(buf: *mut ::std::os::raw::c_void, len: usize);
+            pub fn strlcat(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
         }
-        explicit_bzero(arg_buf, arg_len)
+        strlcat(arg_dst, arg_src, arg_siz)
+    })
+}
+#[track_caller]
+pub unsafe fn strlcpy(
+    arg_dst: *mut ::std::os::raw::c_char,
+    arg_src: *const ::std::os::raw::c_char,
+    arg_siz: ::std::os::raw::c_ulong,
+) -> ::std::os::raw::c_ulong {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strlcpy(
+                dst: *mut ::std::os::raw::c_char,
+                src: *const ::std::os::raw::c_char,
+                siz: ::std::os::raw::c_ulong,
+            ) -> ::std::os::raw::c_ulong;
+        }
+        strlcpy(arg_dst, arg_src, arg_siz)
     })
 }
 #[track_caller]
@@ -11899,17 +12891,16 @@ pub unsafe fn wait_result_is_any_signal(
         wait_result_is_any_signal(arg_exit_status, arg_include_command_not_found)
     })
 }
-pub type jmp_buf = [::std::os::raw::c_int; 48usize];
-pub type sigjmp_buf = [::std::os::raw::c_int; 49usize];
-#[track_caller]
-pub unsafe fn longjmperror() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn longjmperror();
-        }
-        longjmperror()
-    })
+pub type __jmp_buf = [::std::os::raw::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::std::os::raw::c_int,
+    pub __saved_mask: __sigset_t,
 }
+pub type jmp_buf = [__jmp_buf_tag; 1usize];
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[track_caller]
 pub unsafe fn message_level_is_interesting(arg_elevel: ::std::os::raw::c_int) -> bool {
     crate::ffi::pg_guard_ffi_boundary(move || {
@@ -14905,390 +15896,147 @@ pub unsafe fn HeapTupleGetUpdateXid(arg_tuple: HeapTupleHeader) -> TransactionId
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct flock {
-    pub l_start: off_t,
-    pub l_len: off_t,
-    pub l_pid: pid_t,
     pub l_type: ::std::os::raw::c_short,
     pub l_whence: ::std::os::raw::c_short,
+    pub l_start: __off_t,
+    pub l_len: __off_t,
+    pub l_pid: __pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __darwin_time_t,
-    pub tv_nsec: ::std::os::raw::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct flocktimeout {
-    pub fl: flock,
-    pub timeout: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct radvisory {
-    pub ra_offset: off_t,
-    pub ra_count: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fsignatures {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: *mut ::std::os::raw::c_void,
-    pub fs_blob_size: usize,
-    pub fs_fsignatures_size: usize,
-    pub fs_cdhash: [::std::os::raw::c_char; 20usize],
-    pub fs_hash_type: ::std::os::raw::c_int,
-}
-impl Default for fsignatures {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fsignatures_t = fsignatures;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fsupplement {
-    pub fs_file_start: off_t,
-    pub fs_blob_start: off_t,
-    pub fs_blob_size: usize,
-    pub fs_orig_fd: ::std::os::raw::c_int,
-}
-pub type fsupplement_t = fsupplement;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct fchecklv {
-    pub lv_file_start: off_t,
-    pub lv_error_message_size: usize,
-    pub lv_error_message: *mut ::std::os::raw::c_void,
-}
-impl Default for fchecklv {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type fchecklv_t = fchecklv;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fgetsigsinfo {
-    pub fg_file_start: off_t,
-    pub fg_info_request: ::std::os::raw::c_int,
-    pub fg_sig_is_platform: ::std::os::raw::c_int,
-}
-pub type fgetsigsinfo_t = fgetsigsinfo;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fstore {
-    pub fst_flags: ::std::os::raw::c_uint,
-    pub fst_posmode: ::std::os::raw::c_int,
-    pub fst_offset: off_t,
-    pub fst_length: off_t,
-    pub fst_bytesalloc: off_t,
-}
-pub type fstore_t = fstore;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fpunchhole {
-    pub fp_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fp_offset: off_t,
-    pub fp_length: off_t,
-}
-pub type fpunchhole_t = fpunchhole;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ftrimactivefile {
-    pub fta_offset: off_t,
-    pub fta_length: off_t,
-}
-pub type ftrimactivefile_t = ftrimactivefile;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct fspecread {
-    pub fsr_flags: ::std::os::raw::c_uint,
-    pub reserved: ::std::os::raw::c_uint,
-    pub fsr_offset: off_t,
-    pub fsr_length: off_t,
-}
-pub type fspecread_t = fspecread;
-#[repr(C, packed(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct log2phys {
-    pub l2p_flags: ::std::os::raw::c_uint,
-    pub l2p_contigbytes: off_t,
-    pub l2p_devoffset: off_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _filesec {
-    _unused: [u8; 0],
-}
-pub type filesec_t = *mut _filesec;
-pub const filesec_property_t_FILESEC_OWNER: filesec_property_t = 1;
-pub const filesec_property_t_FILESEC_GROUP: filesec_property_t = 2;
-pub const filesec_property_t_FILESEC_UUID: filesec_property_t = 3;
-pub const filesec_property_t_FILESEC_MODE: filesec_property_t = 4;
-pub const filesec_property_t_FILESEC_ACL: filesec_property_t = 5;
-pub const filesec_property_t_FILESEC_GRPUUID: filesec_property_t = 6;
-pub const filesec_property_t_FILESEC_ACL_RAW: filesec_property_t = 100;
-pub const filesec_property_t_FILESEC_ACL_ALLOCSIZE: filesec_property_t = 101;
-pub type filesec_property_t = ::std::os::raw::c_uint;
-#[track_caller]
-pub unsafe fn open(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        open(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn openat(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn openat(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                ...
-            ) -> ::std::os::raw::c_int;
-        }
-        openat(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn creat(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: mode_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn creat(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: mode_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        creat(arg_arg1, arg_arg2)
-    })
+pub struct stat {
+    pub st_dev: __dev_t,
+    pub st_ino: __ino_t,
+    pub st_nlink: __nlink_t,
+    pub st_mode: __mode_t,
+    pub st_uid: __uid_t,
+    pub st_gid: __gid_t,
+    pub __pad0: ::std::os::raw::c_int,
+    pub st_rdev: __dev_t,
+    pub st_size: __off_t,
+    pub st_blksize: __blksize_t,
+    pub st_blocks: __blkcnt_t,
+    pub st_atim: timespec,
+    pub st_mtim: timespec,
+    pub st_ctim: timespec,
+    pub __glibc_reserved: [__syscall_slong_t; 3usize],
 }
 #[track_caller]
 pub unsafe fn fcntl(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn fcntl(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        fcntl(arg_arg1, arg_arg2)
+        fcntl(arg___fd, arg___cmd)
     })
 }
 #[track_caller]
-pub unsafe fn openx_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: filesec_t,
+pub unsafe fn open(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openx_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: filesec_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        openx_np(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn open_dprotected_np(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn open_dprotected_np(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn open(
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        open_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        open(arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_dprotected_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: ::std::os::raw::c_int,
+pub unsafe fn openat(
+    arg___fd: ::std::os::raw::c_int,
+    arg___file: *const ::std::os::raw::c_char,
+    arg___oflag: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_dprotected_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-                arg5: ::std::os::raw::c_int,
+            pub fn openat(
+                __fd: ::std::os::raw::c_int,
+                __file: *const ::std::os::raw::c_char,
+                __oflag: ::std::os::raw::c_int,
                 ...
             ) -> ::std::os::raw::c_int;
         }
-        openat_dprotected_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
+        openat(arg___fd, arg___file, arg___oflag)
     })
 }
 #[track_caller]
-pub unsafe fn openat_authenticated_np(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
+pub unsafe fn creat(
+    arg___file: *const ::std::os::raw::c_char,
+    arg___mode: mode_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn openat_authenticated_np(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
+            pub fn creat(
+                __file: *const ::std::os::raw::c_char,
+                __mode: mode_t,
             ) -> ::std::os::raw::c_int;
         }
-        openat_authenticated_np(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        creat(arg___file, arg___mode)
     })
 }
 #[track_caller]
-pub unsafe fn flock(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn lockf(
+    arg___fd: ::std::os::raw::c_int,
+    arg___cmd: ::std::os::raw::c_int,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn flock(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
+            pub fn lockf(
+                __fd: ::std::os::raw::c_int,
+                __cmd: ::std::os::raw::c_int,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        flock(arg_arg1, arg_arg2)
+        lockf(arg___fd, arg___cmd, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_init() -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_init() -> filesec_t;
-        }
-        filesec_init()
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_dup(arg_arg1: filesec_t) -> filesec_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_dup(arg1: filesec_t) -> filesec_t;
-        }
-        filesec_dup(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_free(arg_arg1: filesec_t) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_free(arg1: filesec_t);
-        }
-        filesec_free(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_get_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_void,
+pub unsafe fn posix_fadvise(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
+    arg___advise: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_get_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_void,
+            pub fn posix_fadvise(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
+                __advise: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_get_property(arg_arg1, arg_arg2, arg_arg3)
+        posix_fadvise(arg___fd, arg___offset, arg___len, arg___advise)
     })
 }
 #[track_caller]
-pub unsafe fn filesec_query_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *mut ::std::os::raw::c_int,
+pub unsafe fn posix_fallocate(
+    arg___fd: ::std::os::raw::c_int,
+    arg___offset: off_t,
+    arg___len: off_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn filesec_query_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *mut ::std::os::raw::c_int,
+            pub fn posix_fallocate(
+                __fd: ::std::os::raw::c_int,
+                __offset: off_t,
+                __len: off_t,
             ) -> ::std::os::raw::c_int;
         }
-        filesec_query_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_set_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-    arg_arg3: *const ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_set_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_set_property(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn filesec_unset_property(
-    arg_arg1: filesec_t,
-    arg_arg2: filesec_property_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn filesec_unset_property(
-                arg1: filesec_t,
-                arg2: filesec_property_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        filesec_unset_property(arg_arg1, arg_arg2)
+        posix_fallocate(arg___fd, arg___offset, arg___len)
     })
 }
 pub type XLogRecPtr = uint64;
@@ -17093,7 +17841,7 @@ pub struct tm {
     pub tm_yday: ::std::os::raw::c_int,
     pub tm_isdst: ::std::os::raw::c_int,
     pub tm_gmtoff: ::std::os::raw::c_long,
-    pub tm_zone: *mut ::std::os::raw::c_char,
+    pub tm_zone: *const ::std::os::raw::c_char,
 }
 impl Default for tm {
     fn default() -> Self {
@@ -17104,26 +17852,11 @@ impl Default for tm {
         }
     }
 }
-extern "C" {
-    pub static mut tzname: [*mut ::std::os::raw::c_char; 0usize];
-}
-extern "C" {
-    pub static mut getdate_err: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut timezone: ::std::os::raw::c_long;
-}
-extern "C" {
-    pub static mut daylight: ::std::os::raw::c_int;
-}
-#[track_caller]
-pub unsafe fn asctime(arg_arg1: *const tm) -> *mut ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn asctime(arg1: *const tm) -> *mut ::std::os::raw::c_char;
-        }
-        asctime(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct itimerspec {
+    pub it_interval: timespec,
+    pub it_value: timespec,
 }
 #[track_caller]
 pub unsafe fn clock() -> clock_t {
@@ -17135,103 +17868,167 @@ pub unsafe fn clock() -> clock_t {
     })
 }
 #[track_caller]
-pub unsafe fn ctime(arg_arg1: *const time_t) -> *mut ::std::os::raw::c_char {
+pub unsafe fn time(arg___timer: *mut time_t) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime(arg1: *const time_t) -> *mut ::std::os::raw::c_char;
+            pub fn time(__timer: *mut time_t) -> time_t;
         }
-        ctime(arg_arg1)
+        time(arg___timer)
     })
 }
 #[track_caller]
-pub unsafe fn difftime(arg_arg1: time_t, arg_arg2: time_t) -> f64 {
+pub unsafe fn difftime(arg___time1: time_t, arg___time0: time_t) -> f64 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn difftime(arg1: time_t, arg2: time_t) -> f64;
+            pub fn difftime(__time1: time_t, __time0: time_t) -> f64;
         }
-        difftime(arg_arg1, arg_arg2)
+        difftime(arg___time1, arg___time0)
     })
 }
 #[track_caller]
-pub unsafe fn getdate(arg_arg1: *const ::std::os::raw::c_char) -> *mut tm {
+pub unsafe fn mktime(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getdate(arg1: *const ::std::os::raw::c_char) -> *mut tm;
+            pub fn mktime(__tp: *mut tm) -> time_t;
         }
-        getdate(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gmtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gmtime(arg1: *const time_t) -> *mut tm;
-        }
-        gmtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime(arg_arg1: *const time_t) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime(arg1: *const time_t) -> *mut tm;
-        }
-        localtime(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn mktime(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn mktime(arg1: *mut tm) -> time_t;
-        }
-        mktime(arg_arg1)
+        mktime(arg___tp)
     })
 }
 #[track_caller]
 pub unsafe fn strftime(
-    arg_arg1: *mut ::std::os::raw::c_char,
-    arg_arg2: usize,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const tm,
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
 ) -> usize {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn strftime(
-                arg1: *mut ::std::os::raw::c_char,
-                arg2: usize,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const tm,
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
             ) -> usize;
         }
-        strftime(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        strftime(arg___s, arg___maxsize, arg___format, arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn strptime(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *mut tm,
+pub unsafe fn strftime_l(
+    arg___s: *mut ::std::os::raw::c_char,
+    arg___maxsize: usize,
+    arg___format: *const ::std::os::raw::c_char,
+    arg___tp: *const tm,
+    arg___loc: locale_t,
+) -> usize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn strftime_l(
+                __s: *mut ::std::os::raw::c_char,
+                __maxsize: usize,
+                __format: *const ::std::os::raw::c_char,
+                __tp: *const tm,
+                __loc: locale_t,
+            ) -> usize;
+        }
+        strftime_l(arg___s, arg___maxsize, arg___format, arg___tp, arg___loc)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime(__timer: *const time_t) -> *mut tm;
+        }
+        gmtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime(arg___timer: *const time_t) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime(__timer: *const time_t) -> *mut tm;
+        }
+        localtime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn gmtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gmtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        gmtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn localtime_r(arg___timer: *const time_t, arg___tp: *mut tm) -> *mut tm {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn localtime_r(__timer: *const time_t, __tp: *mut tm) -> *mut tm;
+        }
+        localtime_r(arg___timer, arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime(arg___tp: *const tm) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn asctime(__tp: *const tm) -> *mut ::std::os::raw::c_char;
+        }
+        asctime(arg___tp)
+    })
+}
+#[track_caller]
+pub unsafe fn ctime(arg___timer: *const time_t) -> *mut ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ctime(__timer: *const time_t) -> *mut ::std::os::raw::c_char;
+        }
+        ctime(arg___timer)
+    })
+}
+#[track_caller]
+pub unsafe fn asctime_r(
+    arg___tp: *const tm,
+    arg___buf: *mut ::std::os::raw::c_char,
 ) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn strptime(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *mut tm,
+            pub fn asctime_r(
+                __tp: *const tm,
+                __buf: *mut ::std::os::raw::c_char,
             ) -> *mut ::std::os::raw::c_char;
         }
-        strptime(arg_arg1, arg_arg2, arg_arg3)
+        asctime_r(arg___tp, arg___buf)
     })
 }
 #[track_caller]
-pub unsafe fn time(arg_arg1: *mut time_t) -> time_t {
+pub unsafe fn ctime_r(
+    arg___timer: *const time_t,
+    arg___buf: *mut ::std::os::raw::c_char,
+) -> *mut ::std::os::raw::c_char {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn time(arg1: *mut time_t) -> time_t;
+            pub fn ctime_r(
+                __timer: *const time_t,
+                __buf: *mut ::std::os::raw::c_char,
+            ) -> *mut ::std::os::raw::c_char;
         }
-        time(arg_arg1)
+        ctime_r(arg___timer, arg___buf)
     })
+}
+extern "C" {
+    pub static mut __tzname: [*mut ::std::os::raw::c_char; 2usize];
+}
+extern "C" {
+    pub static mut __daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut __timezone: ::std::os::raw::c_long;
+}
+extern "C" {
+    pub static mut tzname: [*mut ::std::os::raw::c_char; 2usize];
 }
 #[track_caller]
 pub unsafe fn tzset() {
@@ -17242,123 +18039,54 @@ pub unsafe fn tzset() {
         tzset()
     })
 }
+extern "C" {
+    pub static mut daylight: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut timezone: ::std::os::raw::c_long;
+}
 #[track_caller]
-pub unsafe fn asctime_r(
-    arg_arg1: *const tm,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timegm(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn asctime_r(
-                arg1: *const tm,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timegm(__tp: *mut tm) -> time_t;
         }
-        asctime_r(arg_arg1, arg_arg2)
+        timegm(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn ctime_r(
-    arg_arg1: *const time_t,
-    arg_arg2: *mut ::std::os::raw::c_char,
-) -> *mut ::std::os::raw::c_char {
+pub unsafe fn timelocal(arg___tp: *mut tm) -> time_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn ctime_r(
-                arg1: *const time_t,
-                arg2: *mut ::std::os::raw::c_char,
-            ) -> *mut ::std::os::raw::c_char;
+            pub fn timelocal(__tp: *mut tm) -> time_t;
         }
-        ctime_r(arg_arg1, arg_arg2)
+        timelocal(arg___tp)
     })
 }
 #[track_caller]
-pub unsafe fn gmtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
+pub unsafe fn dysize(arg___year: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn gmtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
+            pub fn dysize(__year: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        gmtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn localtime_r(arg_arg1: *const time_t, arg_arg2: *mut tm) -> *mut tm {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn localtime_r(arg1: *const time_t, arg2: *mut tm) -> *mut tm;
-        }
-        localtime_r(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn posix2time(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn posix2time(arg1: time_t) -> time_t;
-        }
-        posix2time(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn tzsetwall() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn tzsetwall();
-        }
-        tzsetwall()
-    })
-}
-#[track_caller]
-pub unsafe fn time2posix(arg_arg1: time_t) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn time2posix(arg1: time_t) -> time_t;
-        }
-        time2posix(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timelocal(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timelocal(arg1: *mut tm) -> time_t;
-        }
-        timelocal(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn timegm(arg_arg1: *mut tm) -> time_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn timegm(arg1: *mut tm) -> time_t;
-        }
-        timegm(arg_arg1)
+        dysize(arg___year)
     })
 }
 #[track_caller]
 pub unsafe fn nanosleep(
-    arg___rqtp: *const timespec,
-    arg___rmtp: *mut timespec,
+    arg___requested_time: *const timespec,
+    arg___remaining: *mut timespec,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn nanosleep(
-                __rqtp: *const timespec,
-                __rmtp: *mut timespec,
+                __requested_time: *const timespec,
+                __remaining: *mut timespec,
             ) -> ::std::os::raw::c_int;
         }
-        nanosleep(arg___rqtp, arg___rmtp)
+        nanosleep(arg___requested_time, arg___remaining)
     })
 }
-pub const clockid_t__CLOCK_REALTIME: clockid_t = 0;
-pub const clockid_t__CLOCK_MONOTONIC: clockid_t = 6;
-pub const clockid_t__CLOCK_MONOTONIC_RAW: clockid_t = 4;
-pub const clockid_t__CLOCK_MONOTONIC_RAW_APPROX: clockid_t = 5;
-pub const clockid_t__CLOCK_UPTIME_RAW: clockid_t = 8;
-pub const clockid_t__CLOCK_UPTIME_RAW_APPROX: clockid_t = 9;
-pub const clockid_t__CLOCK_PROCESS_CPUTIME_ID: clockid_t = 12;
-pub const clockid_t__CLOCK_THREAD_CPUTIME_ID: clockid_t = 16;
-pub type clockid_t = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn clock_getres(
     arg___clock_id: clockid_t,
@@ -17390,15 +18118,6 @@ pub unsafe fn clock_gettime(
     })
 }
 #[track_caller]
-pub unsafe fn clock_gettime_nsec_np(arg___clock_id: clockid_t) -> __uint64_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn clock_gettime_nsec_np(__clock_id: clockid_t) -> __uint64_t;
-        }
-        clock_gettime_nsec_np(arg___clock_id)
-    })
-}
-#[track_caller]
 pub unsafe fn clock_settime(
     arg___clock_id: clockid_t,
     arg___tp: *const timespec,
@@ -17414,18 +18133,121 @@ pub unsafe fn clock_settime(
     })
 }
 #[track_caller]
+pub unsafe fn clock_nanosleep(
+    arg___clock_id: clockid_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___req: *const timespec,
+    arg___rem: *mut timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_nanosleep(
+                __clock_id: clockid_t,
+                __flags: ::std::os::raw::c_int,
+                __req: *const timespec,
+                __rem: *mut timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_nanosleep(arg___clock_id, arg___flags, arg___req, arg___rem)
+    })
+}
+#[track_caller]
+pub unsafe fn clock_getcpuclockid(
+    arg___pid: pid_t,
+    arg___clock_id: *mut clockid_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn clock_getcpuclockid(
+                __pid: pid_t,
+                __clock_id: *mut clockid_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        clock_getcpuclockid(arg___pid, arg___clock_id)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_create(
+    arg___clock_id: clockid_t,
+    arg___evp: *mut sigevent,
+    arg___timerid: *mut timer_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_create(
+                __clock_id: clockid_t,
+                __evp: *mut sigevent,
+                __timerid: *mut timer_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_create(arg___clock_id, arg___evp, arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_delete(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_delete(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_delete(arg___timerid)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_settime(
+    arg___timerid: timer_t,
+    arg___flags: ::std::os::raw::c_int,
+    arg___value: *const itimerspec,
+    arg___ovalue: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_settime(
+                __timerid: timer_t,
+                __flags: ::std::os::raw::c_int,
+                __value: *const itimerspec,
+                __ovalue: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_settime(arg___timerid, arg___flags, arg___value, arg___ovalue)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_gettime(
+    arg___timerid: timer_t,
+    arg___value: *mut itimerspec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_gettime(
+                __timerid: timer_t,
+                __value: *mut itimerspec,
+            ) -> ::std::os::raw::c_int;
+        }
+        timer_gettime(arg___timerid, arg___value)
+    })
+}
+#[track_caller]
+pub unsafe fn timer_getoverrun(arg___timerid: timer_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn timer_getoverrun(__timerid: timer_t) -> ::std::os::raw::c_int;
+        }
+        timer_getoverrun(arg___timerid)
+    })
+}
+#[track_caller]
 pub unsafe fn timespec_get(
-    arg_ts: *mut timespec,
-    arg_base: ::std::os::raw::c_int,
+    arg___ts: *mut timespec,
+    arg___base: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn timespec_get(
-                ts: *mut timespec,
-                base: ::std::os::raw::c_int,
+                __ts: *mut timespec,
+                __base: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        timespec_get(arg_ts, arg_base)
+        timespec_get(arg___ts, arg___base)
     })
 }
 pub type instr_time = timespec;
@@ -25656,7 +26478,7 @@ pub type MonotonicFunction = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct pg_atomic_flag {
-    pub value: ::std::os::raw::c_int,
+    pub value: ::std::os::raw::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -26369,7 +27191,7 @@ pub struct proclist_mutable_iter {
     pub cur: ::std::os::raw::c_int,
     pub next: ::std::os::raw::c_int,
 }
-pub type slock_t = ::std::os::raw::c_int;
+pub type slock_t = ::std::os::raw::c_uchar;
 extern "C" {
     pub static mut dummy_spinlock: slock_t;
 }
@@ -27046,12 +27868,11 @@ impl Default for TriggerDesc {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::std::os::raw::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::std::os::raw::c_ushort,
+    pub d_type: ::std::os::raw::c_uchar,
+    pub d_name: [::std::os::raw::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
@@ -27062,146 +27883,119 @@ impl Default for dirent {
         }
     }
 }
+pub const DT_UNKNOWN: _bindgen_ty_3 = 0;
+pub const DT_FIFO: _bindgen_ty_3 = 1;
+pub const DT_CHR: _bindgen_ty_3 = 2;
+pub const DT_DIR: _bindgen_ty_3 = 4;
+pub const DT_BLK: _bindgen_ty_3 = 6;
+pub const DT_REG: _bindgen_ty_3 = 8;
+pub const DT_LNK: _bindgen_ty_3 = 10;
+pub const DT_SOCK: _bindgen_ty_3 = 12;
+pub const DT_WHT: _bindgen_ty_3 = 14;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::std::os::raw::c_int,
-    pub __dd_loc: ::std::os::raw::c_long,
-    pub __dd_size: ::std::os::raw::c_long,
-    pub __dd_buf: *mut ::std::os::raw::c_char,
-    pub __dd_len: ::std::os::raw::c_int,
-    pub __dd_seek: ::std::os::raw::c_long,
-    pub __padding: ::std::os::raw::c_long,
-    pub __dd_flags: ::std::os::raw::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type DIR = __dirstream;
 #[track_caller]
-pub unsafe fn closedir(arg_arg1: *mut DIR) -> ::std::os::raw::c_int {
+pub unsafe fn closedir(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn closedir(arg1: *mut DIR) -> ::std::os::raw::c_int;
+            pub fn closedir(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        closedir(arg_arg1)
+        closedir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn opendir(arg_arg1: *const ::std::os::raw::c_char) -> *mut DIR {
+pub unsafe fn opendir(arg___name: *const ::std::os::raw::c_char) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn opendir(arg1: *const ::std::os::raw::c_char) -> *mut DIR;
+            pub fn opendir(__name: *const ::std::os::raw::c_char) -> *mut DIR;
         }
-        opendir(arg_arg1)
+        opendir(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn readdir(arg_arg1: *mut DIR) -> *mut dirent {
+pub unsafe fn fdopendir(arg___fd: ::std::os::raw::c_int) -> *mut DIR {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn readdir(arg1: *mut DIR) -> *mut dirent;
+            pub fn fdopendir(__fd: ::std::os::raw::c_int) -> *mut DIR;
         }
-        readdir(arg_arg1)
+        fdopendir(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn readdir(arg___dirp: *mut DIR) -> *mut dirent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn readdir(__dirp: *mut DIR) -> *mut dirent;
+        }
+        readdir(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn readdir_r(
-    arg_arg1: *mut DIR,
-    arg_arg2: *mut dirent,
-    arg_arg3: *mut *mut dirent,
+    arg___dirp: *mut DIR,
+    arg___entry: *mut dirent,
+    arg___result: *mut *mut dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn readdir_r(
-                arg1: *mut DIR,
-                arg2: *mut dirent,
-                arg3: *mut *mut dirent,
+                __dirp: *mut DIR,
+                __entry: *mut dirent,
+                __result: *mut *mut dirent,
             ) -> ::std::os::raw::c_int;
         }
-        readdir_r(arg_arg1, arg_arg2, arg_arg3)
+        readdir_r(arg___dirp, arg___entry, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn rewinddir(arg_arg1: *mut DIR) {
+pub unsafe fn rewinddir(arg___dirp: *mut DIR) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn rewinddir(arg1: *mut DIR);
+            pub fn rewinddir(__dirp: *mut DIR);
         }
-        rewinddir(arg_arg1)
+        rewinddir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn seekdir(arg_arg1: *mut DIR, arg_arg2: ::std::os::raw::c_long) {
+pub unsafe fn seekdir(arg___dirp: *mut DIR, arg___pos: ::std::os::raw::c_long) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn seekdir(arg1: *mut DIR, arg2: ::std::os::raw::c_long);
+            pub fn seekdir(__dirp: *mut DIR, __pos: ::std::os::raw::c_long);
         }
-        seekdir(arg_arg1, arg_arg2)
+        seekdir(arg___dirp, arg___pos)
     })
 }
 #[track_caller]
-pub unsafe fn telldir(arg_arg1: *mut DIR) -> ::std::os::raw::c_long {
+pub unsafe fn telldir(arg___dirp: *mut DIR) -> ::std::os::raw::c_long {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn telldir(arg1: *mut DIR) -> ::std::os::raw::c_long;
+            pub fn telldir(__dirp: *mut DIR) -> ::std::os::raw::c_long;
         }
-        telldir(arg_arg1)
+        telldir(arg___dirp)
     })
 }
 #[track_caller]
-pub unsafe fn fdopendir(arg_arg1: ::std::os::raw::c_int) -> *mut DIR {
+pub unsafe fn dirfd(arg___dirp: *mut DIR) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn fdopendir(arg1: ::std::os::raw::c_int) -> *mut DIR;
+            pub fn dirfd(__dirp: *mut DIR) -> ::std::os::raw::c_int;
         }
-        fdopendir(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn alphasort(
-    arg_arg1: *mut *const dirent,
-    arg_arg2: *mut *const dirent,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn alphasort(
-                arg1: *mut *const dirent,
-                arg2: *mut *const dirent,
-            ) -> ::std::os::raw::c_int;
-        }
-        alphasort(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn dirfd(arg_dirp: *mut DIR) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn dirfd(dirp: *mut DIR) -> ::std::os::raw::c_int;
-        }
-        dirfd(arg_dirp)
+        dirfd(arg___dirp)
     })
 }
 #[track_caller]
 pub unsafe fn scandir(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: ::std::option::Option<
+    arg___dir: *const ::std::os::raw::c_char,
+    arg___namelist: *mut *mut *mut dirent,
+    arg___selector: ::std::option::Option<
         unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
     >,
-    arg_arg4: ::std::option::Option<
+    arg___cmp: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut *const dirent,
             arg2: *mut *const dirent,
@@ -27211,12 +28005,12 @@ pub unsafe fn scandir(
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn scandir(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: ::std::option::Option<
+                __dir: *const ::std::os::raw::c_char,
+                __namelist: *mut *mut *mut dirent,
+                __selector: ::std::option::Option<
                     unsafe extern "C" fn(arg1: *const dirent) -> ::std::os::raw::c_int,
                 >,
-                arg4: ::std::option::Option<
+                __cmp: ::std::option::Option<
                     unsafe extern "C" fn(
                         arg1: *mut *const dirent,
                         arg2: *mut *const dirent,
@@ -27224,61 +28018,41 @@ pub unsafe fn scandir(
                 >,
             ) -> ::std::os::raw::c_int;
         }
-        scandir(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        scandir(arg___dir, arg___namelist, arg___selector, arg___cmp)
     })
 }
 #[track_caller]
-pub unsafe fn scandir_b(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *mut *mut *mut dirent,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: *mut ::std::os::raw::c_void,
+pub unsafe fn alphasort(
+    arg___e1: *mut *const dirent,
+    arg___e2: *mut *const dirent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn scandir_b(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *mut *mut *mut dirent,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: *mut ::std::os::raw::c_void,
+            pub fn alphasort(
+                __e1: *mut *const dirent,
+                __e2: *mut *const dirent,
             ) -> ::std::os::raw::c_int;
         }
-        scandir_b(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        alphasort(arg___e1, arg___e2)
     })
 }
 #[track_caller]
 pub unsafe fn getdirentries(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_char,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_long,
-) -> ::std::os::raw::c_int {
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___nbytes: usize,
+    arg___basep: *mut __off_t,
+) -> __ssize_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            #[link_name = "\u{1}_getdirentries_is_not_available_when_64_bit_inodes_are_in_effect"]
             pub fn getdirentries(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_long,
-            ) -> ::std::os::raw::c_int;
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_char,
+                __nbytes: usize,
+                __basep: *mut __off_t,
+            ) -> __ssize_t;
         }
-        getdirentries(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn __opendir2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut DIR {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn __opendir2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut DIR;
-        }
-        __opendir2(arg_arg1, arg_arg2)
+        getdirentries(arg___fd, arg___buf, arg___nbytes, arg___basep)
     })
 }
 pub const RecoveryInitSyncMethod_RECOVERY_INIT_SYNC_METHOD_FSYNC: RecoveryInitSyncMethod = 0;
@@ -30328,23 +31102,13 @@ extern "C" {
 extern "C" {
     pub static pg_number_of_ones: [uint8; 256usize];
 }
-#[track_caller]
-pub unsafe fn pg_popcount32(arg_word: uint32) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pg_popcount32(word: uint32) -> ::std::os::raw::c_int;
-        }
-        pg_popcount32(arg_word)
-    })
+extern "C" {
+    pub static mut pg_popcount32:
+        ::std::option::Option<unsafe extern "C" fn(word: uint32) -> ::std::os::raw::c_int>;
 }
-#[track_caller]
-pub unsafe fn pg_popcount64(arg_word: uint64) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pg_popcount64(word: uint64) -> ::std::os::raw::c_int;
-        }
-        pg_popcount64(arg_word)
-    })
+extern "C" {
+    pub static mut pg_popcount64:
+        ::std::option::Option<unsafe extern "C" fn(word: uint64) -> ::std::os::raw::c_int>;
 }
 #[track_caller]
 pub unsafe fn pg_popcount(
@@ -35451,6 +36215,15 @@ pub unsafe fn HeapTupleHeaderGetDatum(arg_tuple: HeapTupleHeader) -> Datum {
     })
 }
 #[track_caller]
+pub unsafe fn InitMaterializedSRF(arg_fcinfo: FunctionCallInfo, arg_flags: bits32) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn InitMaterializedSRF(fcinfo: FunctionCallInfo, flags: bits32);
+        }
+        InitMaterializedSRF(arg_fcinfo, arg_flags)
+    })
+}
+#[track_caller]
 pub unsafe fn SetSingleFuncCall(arg_fcinfo: FunctionCallInfo, arg_flags: bits32) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -35516,356 +36289,943 @@ pub unsafe fn extract_variadic_args(
         )
     })
 }
-extern "C" {
-    pub static sys_signame: [*const ::std::os::raw::c_char; 32usize];
+pub type sig_atomic_t = __sig_atomic_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigval {
+    pub sival_int: ::std::os::raw::c_int,
+    pub sival_ptr: *mut ::std::os::raw::c_void,
 }
-extern "C" {
-    pub static sys_siglist: [*const ::std::os::raw::c_char; 32usize];
+impl Default for sigval {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
+pub type __sigval_t = sigval;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t {
+    pub si_signo: ::std::os::raw::c_int,
+    pub si_errno: ::std::os::raw::c_int,
+    pub si_code: ::std::os::raw::c_int,
+    pub __pad0: ::std::os::raw::c_int,
+    pub _sifields: siginfo_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 28usize],
+    pub _kill: siginfo_t__bindgen_ty_1__bindgen_ty_1,
+    pub _timer: siginfo_t__bindgen_ty_1__bindgen_ty_2,
+    pub _rt: siginfo_t__bindgen_ty_1__bindgen_ty_3,
+    pub _sigchld: siginfo_t__bindgen_ty_1__bindgen_ty_4,
+    pub _sigfault: siginfo_t__bindgen_ty_1__bindgen_ty_5,
+    pub _sigpoll: siginfo_t__bindgen_ty_1__bindgen_ty_6,
+    pub _sigsys: siginfo_t__bindgen_ty_1__bindgen_ty_7,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_1 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    pub si_tid: ::std::os::raw::c_int,
+    pub si_overrun: ::std::os::raw::c_int,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_2 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_sigval: __sigval_t,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_3 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_4 {
+    pub si_pid: __pid_t,
+    pub si_uid: __uid_t,
+    pub si_status: ::std::os::raw::c_int,
+    pub si_utime: __clock_t,
+    pub si_stime: __clock_t,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    pub si_addr: *mut ::std::os::raw::c_void,
+    pub si_addr_lsb: ::std::os::raw::c_short,
+    pub _bounds: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    pub _addr_bnd: siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
+    pub _pkey: __uint32_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    pub _lower: *mut ::std::os::raw::c_void,
+    pub _upper: *mut ::std::os::raw::c_void,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_5 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_6 {
+    pub si_band: ::std::os::raw::c_long,
+    pub si_fd: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    pub _call_addr: *mut ::std::os::raw::c_void,
+    pub _syscall: ::std::os::raw::c_int,
+    pub _arch: ::std::os::raw::c_uint,
+}
+impl Default for siginfo_t__bindgen_ty_1__bindgen_ty_7 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for siginfo_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const SI_ASYNCNL: _bindgen_ty_4 = -60;
+pub const SI_DETHREAD: _bindgen_ty_4 = -7;
+pub const SI_TKILL: _bindgen_ty_4 = -6;
+pub const SI_SIGIO: _bindgen_ty_4 = -5;
+pub const SI_ASYNCIO: _bindgen_ty_4 = -4;
+pub const SI_MESGQ: _bindgen_ty_4 = -3;
+pub const SI_TIMER: _bindgen_ty_4 = -2;
+pub const SI_QUEUE: _bindgen_ty_4 = -1;
+pub const SI_USER: _bindgen_ty_4 = 0;
+pub const SI_KERNEL: _bindgen_ty_4 = 128;
+pub type _bindgen_ty_4 = ::std::os::raw::c_int;
+pub const ILL_ILLOPC: _bindgen_ty_5 = 1;
+pub const ILL_ILLOPN: _bindgen_ty_5 = 2;
+pub const ILL_ILLADR: _bindgen_ty_5 = 3;
+pub const ILL_ILLTRP: _bindgen_ty_5 = 4;
+pub const ILL_PRVOPC: _bindgen_ty_5 = 5;
+pub const ILL_PRVREG: _bindgen_ty_5 = 6;
+pub const ILL_COPROC: _bindgen_ty_5 = 7;
+pub const ILL_BADSTK: _bindgen_ty_5 = 8;
+pub const ILL_BADIADDR: _bindgen_ty_5 = 9;
+pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
+pub const FPE_INTDIV: _bindgen_ty_6 = 1;
+pub const FPE_INTOVF: _bindgen_ty_6 = 2;
+pub const FPE_FLTDIV: _bindgen_ty_6 = 3;
+pub const FPE_FLTOVF: _bindgen_ty_6 = 4;
+pub const FPE_FLTUND: _bindgen_ty_6 = 5;
+pub const FPE_FLTRES: _bindgen_ty_6 = 6;
+pub const FPE_FLTINV: _bindgen_ty_6 = 7;
+pub const FPE_FLTSUB: _bindgen_ty_6 = 8;
+pub const FPE_FLTUNK: _bindgen_ty_6 = 14;
+pub const FPE_CONDTRAP: _bindgen_ty_6 = 15;
+pub type _bindgen_ty_6 = ::std::os::raw::c_uint;
+pub const SEGV_MAPERR: _bindgen_ty_7 = 1;
+pub const SEGV_ACCERR: _bindgen_ty_7 = 2;
+pub const SEGV_BNDERR: _bindgen_ty_7 = 3;
+pub const SEGV_PKUERR: _bindgen_ty_7 = 4;
+pub const SEGV_ACCADI: _bindgen_ty_7 = 5;
+pub const SEGV_ADIDERR: _bindgen_ty_7 = 6;
+pub const SEGV_ADIPERR: _bindgen_ty_7 = 7;
+pub const SEGV_MTEAERR: _bindgen_ty_7 = 8;
+pub const SEGV_MTESERR: _bindgen_ty_7 = 9;
+pub type _bindgen_ty_7 = ::std::os::raw::c_uint;
+pub const BUS_ADRALN: _bindgen_ty_8 = 1;
+pub const BUS_ADRERR: _bindgen_ty_8 = 2;
+pub const BUS_OBJERR: _bindgen_ty_8 = 3;
+pub const BUS_MCEERR_AR: _bindgen_ty_8 = 4;
+pub const BUS_MCEERR_AO: _bindgen_ty_8 = 5;
+pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+pub const CLD_EXITED: _bindgen_ty_9 = 1;
+pub const CLD_KILLED: _bindgen_ty_9 = 2;
+pub const CLD_DUMPED: _bindgen_ty_9 = 3;
+pub const CLD_TRAPPED: _bindgen_ty_9 = 4;
+pub const CLD_STOPPED: _bindgen_ty_9 = 5;
+pub const CLD_CONTINUED: _bindgen_ty_9 = 6;
+pub type _bindgen_ty_9 = ::std::os::raw::c_uint;
+pub const POLL_IN: _bindgen_ty_10 = 1;
+pub const POLL_OUT: _bindgen_ty_10 = 2;
+pub const POLL_MSG: _bindgen_ty_10 = 3;
+pub const POLL_ERR: _bindgen_ty_10 = 4;
+pub const POLL_PRI: _bindgen_ty_10 = 5;
+pub const POLL_HUP: _bindgen_ty_10 = 6;
+pub type _bindgen_ty_10 = ::std::os::raw::c_uint;
+pub type sigval_t = __sigval_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigevent {
+    pub sigev_value: __sigval_t,
+    pub sigev_signo: ::std::os::raw::c_int,
+    pub sigev_notify: ::std::os::raw::c_int,
+    pub _sigev_un: sigevent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigevent__bindgen_ty_1 {
+    pub _pad: [::std::os::raw::c_int; 12usize],
+    pub _tid: __pid_t,
+    pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
+    pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: __sigval_t)>,
+    pub _attribute: *mut pthread_attr_t,
+}
+impl Default for sigevent__bindgen_ty_1__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigevent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type sigevent_t = sigevent;
+pub const SIGEV_SIGNAL: _bindgen_ty_11 = 0;
+pub const SIGEV_NONE: _bindgen_ty_11 = 1;
+pub const SIGEV_THREAD: _bindgen_ty_11 = 2;
+pub const SIGEV_THREAD_ID: _bindgen_ty_11 = 4;
+pub type _bindgen_ty_11 = ::std::os::raw::c_uint;
+pub type __sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[track_caller]
-pub unsafe fn raise(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn __sysv_signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn raise(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn __sysv_signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        raise(arg_arg1)
+        __sysv_signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn bsd_signal(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn signal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bsd_signal(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn signal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        bsd_signal(arg_arg1, arg_arg2)
+        signal(arg___sig, arg___handler)
     })
 }
 #[track_caller]
-pub unsafe fn kill(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn kill(arg___pid: __pid_t, arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn kill(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn kill(__pid: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        kill(arg_arg1, arg_arg2)
+        kill(arg___pid, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn killpg(arg_arg1: pid_t, arg_arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn killpg(arg1: pid_t, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        killpg(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn pthread_kill(
-    arg_arg1: pthread_t,
-    arg_arg2: ::std::os::raw::c_int,
+pub unsafe fn killpg(
+    arg___pgrp: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_kill(
-                arg1: pthread_t,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn killpg(__pgrp: __pid_t, __sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_kill(arg_arg1, arg_arg2)
+        killpg(arg___pgrp, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn pthread_sigmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
-) -> ::std::os::raw::c_int {
+pub unsafe fn raise(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pthread_sigmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
-            ) -> ::std::os::raw::c_int;
+            pub fn raise(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         }
-        pthread_sigmask(arg_arg1, arg_arg2, arg_arg3)
+        raise(arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn sigaction(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigaction,
-    arg_arg3: *mut sigaction,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ssignal(
+    arg___sig: ::std::os::raw::c_int,
+    arg___handler: __sighandler_t,
+) -> __sighandler_t {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigaction(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigaction,
-                arg3: *mut sigaction,
-            ) -> ::std::os::raw::c_int;
+            pub fn ssignal(
+                __sig: ::std::os::raw::c_int,
+                __handler: __sighandler_t,
+            ) -> __sighandler_t;
         }
-        sigaction(arg_arg1, arg_arg2, arg_arg3)
+        ssignal(arg___sig, arg___handler)
+    })
+}
+#[track_caller]
+pub unsafe fn gsignal(arg___sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gsignal(__sig: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        gsignal(arg___sig)
+    })
+}
+#[track_caller]
+pub unsafe fn psignal(arg___sig: ::std::os::raw::c_int, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psignal(__sig: ::std::os::raw::c_int, __s: *const ::std::os::raw::c_char);
+        }
+        psignal(arg___sig, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn psiginfo(arg___pinfo: *const siginfo_t, arg___s: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn psiginfo(__pinfo: *const siginfo_t, __s: *const ::std::os::raw::c_char);
+        }
+        psiginfo(arg___pinfo, arg___s)
+    })
+}
+#[track_caller]
+pub unsafe fn sigblock(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigblock(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigblock(arg___mask)
+    })
+}
+#[track_caller]
+pub unsafe fn sigsetmask(arg___mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigsetmask(__mask: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sigsetmask(arg___mask)
+    })
+}
+pub type sig_t = __sighandler_t;
+#[track_caller]
+pub unsafe fn sigemptyset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigemptyset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigemptyset(arg___set)
+    })
+}
+#[track_caller]
+pub unsafe fn sigfillset(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigfillset(__set: *mut sigset_t) -> ::std::os::raw::c_int;
+        }
+        sigfillset(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigaddset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigaddset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigaddset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigaltstack(
-    arg_arg1: *const stack_t,
-    arg_arg2: *mut stack_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigaltstack(arg1: *const stack_t, arg2: *mut stack_t) -> ::std::os::raw::c_int;
-        }
-        sigaltstack(arg_arg1, arg_arg2)
+        sigaddset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigdelset(
-    arg_arg1: *mut sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *mut sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigdelset(
-                arg1: *mut sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *mut sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigdelset(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigemptyset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigemptyset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigemptyset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigfillset(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigfillset(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
-        }
-        sigfillset(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sighold(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sighold(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sighold(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigignore(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigignore(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigignore(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn siginterrupt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn siginterrupt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        siginterrupt(arg_arg1, arg_arg2)
+        sigdelset(arg___set, arg___signo)
     })
 }
 #[track_caller]
 pub unsafe fn sigismember(
-    arg_arg1: *const sigset_t,
-    arg_arg2: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___signo: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigismember(
-                arg1: *const sigset_t,
-                arg2: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __signo: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigismember(arg_arg1, arg_arg2)
+        sigismember(arg___set, arg___signo)
     })
 }
-#[track_caller]
-pub unsafe fn sigpause(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpause(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigpause(arg_arg1)
-    })
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigaction {
+    pub __sigaction_handler: sigaction__bindgen_ty_1,
+    pub sa_mask: __sigset_t,
+    pub sa_flags: ::std::os::raw::c_int,
+    pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
 }
-#[track_caller]
-pub unsafe fn sigpending(arg_arg1: *mut sigset_t) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigpending(arg1: *mut sigset_t) -> ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigaction__bindgen_ty_1 {
+    pub sa_handler: __sighandler_t,
+    pub sa_sigaction: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut siginfo_t,
+            arg3: *mut ::std::os::raw::c_void,
+        ),
+    >,
+}
+impl Default for sigaction__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
         }
-        sigpending(arg_arg1)
-    })
+    }
+}
+impl Default for sigaction {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[track_caller]
 pub unsafe fn sigprocmask(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sigset_t,
-    arg_arg3: *mut sigset_t,
+    arg___how: ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___oset: *mut sigset_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigprocmask(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sigset_t,
-                arg3: *mut sigset_t,
+                __how: ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __oset: *mut sigset_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigprocmask(arg_arg1, arg_arg2, arg_arg3)
+        sigprocmask(arg___how, arg___set, arg___oset)
     })
 }
 #[track_caller]
-pub unsafe fn sigrelse(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn sigsuspend(arg___set: *const sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigrelse(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn sigsuspend(__set: *const sigset_t) -> ::std::os::raw::c_int;
         }
-        sigrelse(arg_arg1)
+        sigsuspend(arg___set)
     })
 }
 #[track_caller]
-pub unsafe fn sigset(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-) -> ::std::option::Option<
-    unsafe extern "C" fn(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ),
-> {
+pub unsafe fn sigaction(
+    arg___sig: ::std::os::raw::c_int,
+    arg___act: *const sigaction,
+    arg___oact: *mut sigaction,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigset(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-            ) -> ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: ::std::os::raw::c_int,
-                    arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-                ),
-            >;
+            pub fn sigaction(
+                __sig: ::std::os::raw::c_int,
+                __act: *const sigaction,
+                __oact: *mut sigaction,
+            ) -> ::std::os::raw::c_int;
         }
-        sigset(arg_arg1, arg_arg2)
+        sigaction(arg___sig, arg___act, arg___oact)
     })
 }
 #[track_caller]
-pub unsafe fn sigsuspend(arg_arg1: *const sigset_t) -> ::std::os::raw::c_int {
+pub unsafe fn sigpending(arg___set: *mut sigset_t) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigsuspend(arg1: *const sigset_t) -> ::std::os::raw::c_int;
+            pub fn sigpending(__set: *mut sigset_t) -> ::std::os::raw::c_int;
         }
-        sigsuspend(arg_arg1)
+        sigpending(arg___set)
     })
 }
 #[track_caller]
 pub unsafe fn sigwait(
-    arg_arg1: *const sigset_t,
-    arg_arg2: *mut ::std::os::raw::c_int,
+    arg___set: *const sigset_t,
+    arg___sig: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn sigwait(
-                arg1: *const sigset_t,
-                arg2: *mut ::std::os::raw::c_int,
+                __set: *const sigset_t,
+                __sig: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        sigwait(arg_arg1, arg_arg2)
+        sigwait(arg___set, arg___sig)
     })
 }
 #[track_caller]
-pub unsafe fn psignal(arg_arg1: ::std::os::raw::c_uint, arg_arg2: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn psignal(arg1: ::std::os::raw::c_uint, arg2: *const ::std::os::raw::c_char);
-        }
-        psignal(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sigblock(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigblock(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigblock(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigsetmask(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sigsetmask(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sigsetmask(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn sigvec(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sigvec,
-    arg_arg3: *mut sigvec,
+pub unsafe fn sigwaitinfo(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sigvec(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sigvec,
-                arg3: *mut sigvec,
+            pub fn sigwaitinfo(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
             ) -> ::std::os::raw::c_int;
         }
-        sigvec(arg_arg1, arg_arg2, arg_arg3)
+        sigwaitinfo(arg___set, arg___info)
+    })
+}
+#[track_caller]
+pub unsafe fn sigtimedwait(
+    arg___set: *const sigset_t,
+    arg___info: *mut siginfo_t,
+    arg___timeout: *const timespec,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigtimedwait(
+                __set: *const sigset_t,
+                __info: *mut siginfo_t,
+                __timeout: *const timespec,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigtimedwait(arg___set, arg___info, arg___timeout)
+    })
+}
+#[track_caller]
+pub unsafe fn sigqueue(
+    arg___pid: __pid_t,
+    arg___sig: ::std::os::raw::c_int,
+    arg___val: sigval,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigqueue(
+                __pid: __pid_t,
+                __sig: ::std::os::raw::c_int,
+                __val: sigval,
+            ) -> ::std::os::raw::c_int;
+        }
+        sigqueue(arg___pid, arg___sig, arg___val)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpx_sw_bytes {
+    pub magic1: __uint32_t,
+    pub extended_size: __uint32_t,
+    pub xstate_bv: __uint64_t,
+    pub xstate_size: __uint32_t,
+    pub __glibc_reserved1: [__uint32_t; 7usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_fpxreg; 8usize],
+    pub _xmm: [_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sigcontext {
+    pub r8: __uint64_t,
+    pub r9: __uint64_t,
+    pub r10: __uint64_t,
+    pub r11: __uint64_t,
+    pub r12: __uint64_t,
+    pub r13: __uint64_t,
+    pub r14: __uint64_t,
+    pub r15: __uint64_t,
+    pub rdi: __uint64_t,
+    pub rsi: __uint64_t,
+    pub rbp: __uint64_t,
+    pub rbx: __uint64_t,
+    pub rdx: __uint64_t,
+    pub rax: __uint64_t,
+    pub rcx: __uint64_t,
+    pub rsp: __uint64_t,
+    pub rip: __uint64_t,
+    pub eflags: __uint64_t,
+    pub cs: ::std::os::raw::c_ushort,
+    pub gs: ::std::os::raw::c_ushort,
+    pub fs: ::std::os::raw::c_ushort,
+    pub __pad0: ::std::os::raw::c_ushort,
+    pub err: __uint64_t,
+    pub trapno: __uint64_t,
+    pub oldmask: __uint64_t,
+    pub cr2: __uint64_t,
+    pub __bindgen_anon_1: sigcontext__bindgen_ty_1,
+    pub __reserved1: [__uint64_t; 8usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union sigcontext__bindgen_ty_1 {
+    pub fpstate: *mut _fpstate,
+    pub __fpstate_word: __uint64_t,
+}
+impl Default for sigcontext__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for sigcontext {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _xsave_hdr {
+    pub xstate_bv: __uint64_t,
+    pub __glibc_reserved1: [__uint64_t; 2usize],
+    pub __glibc_reserved2: [__uint64_t; 5usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ymmh_state {
+    pub ymmh_space: [__uint32_t; 64usize],
+}
+impl Default for _ymmh_state {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _xstate {
+    pub fpstate: _fpstate,
+    pub xstate_hdr: _xsave_hdr,
+    pub ymmh: _ymmh_state,
+}
+impl Default for _xstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stack_t {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_flags: ::std::os::raw::c_int,
+    pub ss_size: usize,
+}
+impl Default for stack_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type greg_t = ::std::os::raw::c_longlong;
+pub type gregset_t = [greg_t; 23usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpxreg {
+    pub significand: [::std::os::raw::c_ushort; 4usize],
+    pub exponent: ::std::os::raw::c_ushort,
+    pub __glibc_reserved1: [::std::os::raw::c_ushort; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_xmmreg {
+    pub element: [__uint32_t; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _libc_fpstate {
+    pub cwd: __uint16_t,
+    pub swd: __uint16_t,
+    pub ftw: __uint16_t,
+    pub fop: __uint16_t,
+    pub rip: __uint64_t,
+    pub rdp: __uint64_t,
+    pub mxcsr: __uint32_t,
+    pub mxcr_mask: __uint32_t,
+    pub _st: [_libc_fpxreg; 8usize],
+    pub _xmm: [_libc_xmmreg; 16usize],
+    pub __glibc_reserved1: [__uint32_t; 24usize],
+}
+pub type fpregset_t = *mut _libc_fpstate;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mcontext_t {
+    pub gregs: gregset_t,
+    pub fpregs: fpregset_t,
+    pub __reserved1: [::std::os::raw::c_ulonglong; 8usize],
+}
+impl Default for mcontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ucontext_t {
+    pub uc_flags: ::std::os::raw::c_ulong,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: sigset_t,
+    pub __fpregs_mem: _libc_fpstate,
+    pub __ssp: [::std::os::raw::c_ulonglong; 4usize],
+}
+impl Default for ucontext_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn siginterrupt(
+    arg___sig: ::std::os::raw::c_int,
+    arg___interrupt: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn siginterrupt(
+                __sig: ::std::os::raw::c_int,
+                __interrupt: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        siginterrupt(arg___sig, arg___interrupt)
+    })
+}
+pub const SS_ONSTACK: _bindgen_ty_12 = 1;
+pub const SS_DISABLE: _bindgen_ty_12 = 2;
+pub type _bindgen_ty_12 = ::std::os::raw::c_uint;
+#[track_caller]
+pub unsafe fn sigaltstack(
+    arg___ss: *const stack_t,
+    arg___oss: *mut stack_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sigaltstack(__ss: *const stack_t, __oss: *mut stack_t) -> ::std::os::raw::c_int;
+        }
+        sigaltstack(arg___ss, arg___oss)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sigstack {
+    pub ss_sp: *mut ::std::os::raw::c_void,
+    pub ss_onstack: ::std::os::raw::c_int,
+}
+impl Default for sigstack {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn pthread_sigmask(
+    arg___how: ::std::os::raw::c_int,
+    arg___newmask: *const __sigset_t,
+    arg___oldmask: *mut __sigset_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_sigmask(
+                __how: ::std::os::raw::c_int,
+                __newmask: *const __sigset_t,
+                __oldmask: *mut __sigset_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_sigmask(arg___how, arg___newmask, arg___oldmask)
+    })
+}
+#[track_caller]
+pub unsafe fn pthread_kill(
+    arg___threadid: pthread_t,
+    arg___signo: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pthread_kill(
+                __threadid: pthread_t,
+                __signo: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        pthread_kill(arg___threadid, arg___signo)
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmin() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmin() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmin()
+    })
+}
+#[track_caller]
+pub unsafe fn __libc_current_sigrtmax() -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __libc_current_sigrtmax() -> ::std::os::raw::c_int;
+        }
+        __libc_current_sigrtmax()
     })
 }
 pub type pg_time_t = int64;
@@ -37053,8 +38413,6 @@ pub unsafe fn pgstat_progress_end_command() {
         pgstat_progress_end_command()
     })
 }
-pub type sa_family_t = __uint8_t;
-pub type socklen_t = __darwin_socklen_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
@@ -37070,68 +38428,30 @@ impl Default for iovec {
         }
     }
 }
-pub type sae_associd_t = __uint32_t;
-pub type sae_connid_t = __uint32_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sa_endpoints {
-    pub sae_srcif: ::std::os::raw::c_uint,
-    pub sae_srcaddr: *const sockaddr,
-    pub sae_srcaddrlen: socklen_t,
-    pub sae_dstaddr: *const sockaddr,
-    pub sae_dstaddrlen: socklen_t,
-}
-impl Default for sa_endpoints {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type sa_endpoints_t = sa_endpoints;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct linger {
-    pub l_onoff: ::std::os::raw::c_int,
-    pub l_linger: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct so_np_extensions {
-    pub npx_flags: u_int32_t,
-    pub npx_mask: u_int32_t,
-}
+pub type socklen_t = __socklen_t;
+pub const __socket_type_SOCK_STREAM: __socket_type = 1;
+pub const __socket_type_SOCK_DGRAM: __socket_type = 2;
+pub const __socket_type_SOCK_RAW: __socket_type = 3;
+pub const __socket_type_SOCK_RDM: __socket_type = 4;
+pub const __socket_type_SOCK_SEQPACKET: __socket_type = 5;
+pub const __socket_type_SOCK_DCCP: __socket_type = 6;
+pub const __socket_type_SOCK_PACKET: __socket_type = 10;
+pub const __socket_type_SOCK_CLOEXEC: __socket_type = 524288;
+pub const __socket_type_SOCK_NONBLOCK: __socket_type = 2048;
+pub type __socket_type = ::std::os::raw::c_uint;
+pub type sa_family_t = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct sockaddr {
-    pub sa_len: __uint8_t,
     pub sa_family: sa_family_t,
     pub sa_data: [::std::os::raw::c_char; 14usize],
-}
-pub type sockaddr_ref_t = *mut sockaddr;
-pub type sockaddr_ref_ref_t = *mut *mut sockaddr;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct __sockaddr_header {
-    pub sa_len: __uint8_t,
-    pub sa_family: sa_family_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockproto {
-    pub sp_family: __uint16_t,
-    pub sp_protocol: __uint16_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::std::os::raw::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::std::os::raw::c_char; 112usize],
+    pub __ss_padding: [::std::os::raw::c_char; 118usize],
+    pub __ss_align: ::std::os::raw::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
@@ -37142,17 +38462,37 @@ impl Default for sockaddr_storage {
         }
     }
 }
-pub type sockaddr_storage_ref_t = *mut sockaddr_storage;
-pub type sockaddr_storage_ref_ref_t = *mut *mut sockaddr_storage;
+pub const MSG_OOB: _bindgen_ty_13 = 1;
+pub const MSG_PEEK: _bindgen_ty_13 = 2;
+pub const MSG_DONTROUTE: _bindgen_ty_13 = 4;
+pub const MSG_CTRUNC: _bindgen_ty_13 = 8;
+pub const MSG_PROXY: _bindgen_ty_13 = 16;
+pub const MSG_TRUNC: _bindgen_ty_13 = 32;
+pub const MSG_DONTWAIT: _bindgen_ty_13 = 64;
+pub const MSG_EOR: _bindgen_ty_13 = 128;
+pub const MSG_WAITALL: _bindgen_ty_13 = 256;
+pub const MSG_FIN: _bindgen_ty_13 = 512;
+pub const MSG_SYN: _bindgen_ty_13 = 1024;
+pub const MSG_CONFIRM: _bindgen_ty_13 = 2048;
+pub const MSG_RST: _bindgen_ty_13 = 4096;
+pub const MSG_ERRQUEUE: _bindgen_ty_13 = 8192;
+pub const MSG_NOSIGNAL: _bindgen_ty_13 = 16384;
+pub const MSG_MORE: _bindgen_ty_13 = 32768;
+pub const MSG_WAITFORONE: _bindgen_ty_13 = 65536;
+pub const MSG_BATCH: _bindgen_ty_13 = 262144;
+pub const MSG_ZEROCOPY: _bindgen_ty_13 = 67108864;
+pub const MSG_FASTOPEN: _bindgen_ty_13 = 536870912;
+pub const MSG_CMSG_CLOEXEC: _bindgen_ty_13 = 1073741824;
+pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct msghdr {
     pub msg_name: *mut ::std::os::raw::c_void,
     pub msg_namelen: socklen_t,
     pub msg_iov: *mut iovec,
-    pub msg_iovlen: ::std::os::raw::c_int,
+    pub msg_iovlen: usize,
     pub msg_control: *mut ::std::os::raw::c_void,
-    pub msg_controllen: socklen_t,
+    pub msg_controllen: usize,
     pub msg_flags: ::std::os::raw::c_int,
 }
 impl Default for msghdr {
@@ -37165,438 +38505,423 @@ impl Default for msghdr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct cmsghdr {
-    pub cmsg_len: socklen_t,
+    pub cmsg_len: usize,
     pub cmsg_level: ::std::os::raw::c_int,
     pub cmsg_type: ::std::os::raw::c_int,
+    pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
+}
+#[track_caller]
+pub unsafe fn __cmsg_nxthdr(arg___mhdr: *mut msghdr, arg___cmsg: *mut cmsghdr) -> *mut cmsghdr {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
+        }
+        __cmsg_nxthdr(arg___mhdr, arg___cmsg)
+    })
+}
+pub const SCM_RIGHTS: _bindgen_ty_14 = 1;
+pub type _bindgen_ty_14 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fd_set {
+    pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+}
+pub type __kernel_sighandler_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __kernel_key_t = ::std::os::raw::c_int;
+pub type __kernel_mqd_t = ::std::os::raw::c_int;
+pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = ::std::os::raw::c_long;
+pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_ino_t = __kernel_ulong_t;
+pub type __kernel_mode_t = ::std::os::raw::c_uint;
+pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
+pub type __kernel_uid_t = ::std::os::raw::c_uint;
+pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_suseconds_t = __kernel_long_t;
+pub type __kernel_daddr_t = ::std::os::raw::c_int;
+pub type __kernel_uid32_t = ::std::os::raw::c_uint;
+pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_size_t = __kernel_ulong_t;
+pub type __kernel_ssize_t = __kernel_long_t;
+pub type __kernel_ptrdiff_t = __kernel_long_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __kernel_fsid_t {
+    pub val: [::std::os::raw::c_int; 2usize],
+}
+pub type __kernel_off_t = __kernel_long_t;
+pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_old_time_t = __kernel_long_t;
+pub type __kernel_time_t = __kernel_long_t;
+pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_clock_t = __kernel_long_t;
+pub type __kernel_timer_t = ::std::os::raw::c_int;
+pub type __kernel_clockid_t = ::std::os::raw::c_int;
+pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
+pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: ::std::os::raw::c_int,
+    pub l_linger: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sf_hdtr {
-    pub headers: *mut iovec,
-    pub hdr_cnt: ::std::os::raw::c_int,
-    pub trailers: *mut iovec,
-    pub trl_cnt: ::std::os::raw::c_int,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct osockaddr {
+    pub sa_family: ::std::os::raw::c_ushort,
+    pub sa_data: [::std::os::raw::c_uchar; 14usize],
 }
-impl Default for sf_hdtr {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn accept(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn accept(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        accept(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn bind(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn bind(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        bind(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn connect(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sockaddr,
-    arg_arg3: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn connect(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sockaddr,
-                arg3: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        connect(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getpeername(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getpeername(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getpeername(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockname(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
-    arg_arg3: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockname(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
-                arg3: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockname(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn getsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_void,
-    arg_arg5: *mut socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_void,
-                arg5: *mut socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn listen(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn listen(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        listen(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn recv(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recv(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recv(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn recvfrom(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *mut sockaddr,
-    arg_arg6: *mut socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvfrom(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *mut sockaddr,
-                arg6: *mut socklen_t,
-            ) -> isize;
-        }
-        recvfrom(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn recvmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn recvmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        recvmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn send(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn send(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        send(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn sendmsg(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const msghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendmsg(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const msghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> isize;
-        }
-        sendmsg(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn sendto(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_void,
-    arg_arg3: usize,
-    arg_arg4: ::std::os::raw::c_int,
-    arg_arg5: *const sockaddr,
-    arg_arg6: socklen_t,
-) -> isize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sendto(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: usize,
-                arg4: ::std::os::raw::c_int,
-                arg5: *const sockaddr,
-                arg6: socklen_t,
-            ) -> isize;
-        }
-        sendto(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsockopt(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *const ::std::os::raw::c_void,
-    arg_arg5: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsockopt(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *const ::std::os::raw::c_void,
-                arg5: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsockopt(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5)
-    })
-}
-#[track_caller]
-pub unsafe fn shutdown(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn shutdown(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        shutdown(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn sockatmark(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sockatmark(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-        }
-        sockatmark(arg_arg1)
-    })
-}
+pub const SHUT_RD: _bindgen_ty_15 = 0;
+pub const SHUT_WR: _bindgen_ty_15 = 1;
+pub const SHUT_RDWR: _bindgen_ty_15 = 2;
+pub type _bindgen_ty_15 = ::std::os::raw::c_uint;
 #[track_caller]
 pub unsafe fn socket(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socket(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socket(arg_arg1, arg_arg2, arg_arg3)
+        socket(arg___domain, arg___type, arg___protocol)
     })
 }
 #[track_caller]
 pub unsafe fn socketpair(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
+    arg___domain: ::std::os::raw::c_int,
+    arg___type: ::std::os::raw::c_int,
+    arg___protocol: ::std::os::raw::c_int,
+    arg___fds: *mut ::std::os::raw::c_int,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn socketpair(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
+                __domain: ::std::os::raw::c_int,
+                __type: ::std::os::raw::c_int,
+                __protocol: ::std::os::raw::c_int,
+                __fds: *mut ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int;
         }
-        socketpair(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        socketpair(arg___domain, arg___type, arg___protocol, arg___fds)
     })
 }
 #[track_caller]
-pub unsafe fn sendfile(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: off_t,
-    arg_arg4: *mut off_t,
-    arg_arg5: *mut sf_hdtr,
-    arg_arg6: ::std::os::raw::c_int,
+pub unsafe fn bind(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn sendfile(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-                arg3: off_t,
-                arg4: *mut off_t,
-                arg5: *mut sf_hdtr,
-                arg6: ::std::os::raw::c_int,
+            pub fn bind(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        sendfile(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
+        bind(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn pfctlinput(arg_arg1: ::std::os::raw::c_int, arg_arg2: *mut sockaddr) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn pfctlinput(arg1: ::std::os::raw::c_int, arg2: *mut sockaddr);
-        }
-        pfctlinput(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn connectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const sa_endpoints_t,
-    arg_arg3: sae_associd_t,
-    arg_arg4: ::std::os::raw::c_uint,
-    arg_arg5: *const iovec,
-    arg_arg6: ::std::os::raw::c_uint,
-    arg_arg7: *mut usize,
-    arg_arg8: *mut sae_connid_t,
+pub unsafe fn getsockname(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn connectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const sa_endpoints_t,
-                arg3: sae_associd_t,
-                arg4: ::std::os::raw::c_uint,
-                arg5: *const iovec,
-                arg6: ::std::os::raw::c_uint,
-                arg7: *mut usize,
-                arg8: *mut sae_connid_t,
+            pub fn getsockname(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        connectx(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7, arg_arg8)
+        getsockname(arg___fd, arg___addr, arg___len)
     })
 }
 #[track_caller]
-pub unsafe fn disconnectx(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: sae_associd_t,
-    arg_arg3: sae_connid_t,
+pub unsafe fn connect(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___len: socklen_t,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn disconnectx(
-                arg1: ::std::os::raw::c_int,
-                arg2: sae_associd_t,
-                arg3: sae_connid_t,
+            pub fn connect(
+                __fd: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __len: socklen_t,
             ) -> ::std::os::raw::c_int;
         }
-        disconnectx(arg_arg1, arg_arg2, arg_arg3)
+        connect(arg___fd, arg___addr, arg___len)
     })
 }
+#[track_caller]
+pub unsafe fn getpeername(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getpeername(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getpeername(arg___fd, arg___addr, arg___len)
+    })
+}
+#[track_caller]
+pub unsafe fn send(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn send(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        send(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recv(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recv(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recv(arg___fd, arg___buf, arg___n, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn sendto(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *const ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *const sockaddr,
+    arg___addr_len: socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendto(
+                __fd: ::std::os::raw::c_int,
+                __buf: *const ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *const sockaddr,
+                __addr_len: socklen_t,
+            ) -> isize;
+        }
+        sendto(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn recvfrom(
+    arg___fd: ::std::os::raw::c_int,
+    arg___buf: *mut ::std::os::raw::c_void,
+    arg___n: usize,
+    arg___flags: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvfrom(
+                __fd: ::std::os::raw::c_int,
+                __buf: *mut ::std::os::raw::c_void,
+                __n: usize,
+                __flags: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> isize;
+        }
+        recvfrom(arg___fd, arg___buf, arg___n, arg___flags, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn sendmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *const msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sendmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *const msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        sendmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn recvmsg(
+    arg___fd: ::std::os::raw::c_int,
+    arg___message: *mut msghdr,
+    arg___flags: ::std::os::raw::c_int,
+) -> isize {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn recvmsg(
+                __fd: ::std::os::raw::c_int,
+                __message: *mut msghdr,
+                __flags: ::std::os::raw::c_int,
+            ) -> isize;
+        }
+        recvmsg(arg___fd, arg___message, arg___flags)
+    })
+}
+#[track_caller]
+pub unsafe fn getsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *mut ::std::os::raw::c_void,
+    arg___optlen: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *mut ::std::os::raw::c_void,
+                __optlen: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        getsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn setsockopt(
+    arg___fd: ::std::os::raw::c_int,
+    arg___level: ::std::os::raw::c_int,
+    arg___optname: ::std::os::raw::c_int,
+    arg___optval: *const ::std::os::raw::c_void,
+    arg___optlen: socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setsockopt(
+                __fd: ::std::os::raw::c_int,
+                __level: ::std::os::raw::c_int,
+                __optname: ::std::os::raw::c_int,
+                __optval: *const ::std::os::raw::c_void,
+                __optlen: socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        setsockopt(arg___fd, arg___level, arg___optname, arg___optval, arg___optlen)
+    })
+}
+#[track_caller]
+pub unsafe fn listen(
+    arg___fd: ::std::os::raw::c_int,
+    arg___n: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn listen(
+                __fd: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        listen(arg___fd, arg___n)
+    })
+}
+#[track_caller]
+pub unsafe fn accept(
+    arg___fd: ::std::os::raw::c_int,
+    arg___addr: *mut sockaddr,
+    arg___addr_len: *mut socklen_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn accept(
+                __fd: ::std::os::raw::c_int,
+                __addr: *mut sockaddr,
+                __addr_len: *mut socklen_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        accept(arg___fd, arg___addr, arg___addr_len)
+    })
+}
+#[track_caller]
+pub unsafe fn shutdown(
+    arg___fd: ::std::os::raw::c_int,
+    arg___how: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn shutdown(
+                __fd: ::std::os::raw::c_int,
+                __how: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        shutdown(arg___fd, arg___how)
+    })
+}
+#[track_caller]
+pub unsafe fn sockatmark(arg___fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        sockatmark(arg___fd)
+    })
+}
+#[track_caller]
+pub unsafe fn isfdtype(
+    arg___fd: ::std::os::raw::c_int,
+    arg___fdtype: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn isfdtype(
+                __fd: ::std::os::raw::c_int,
+                __fdtype: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        isfdtype(arg___fd, arg___fdtype)
+    })
+}
+pub type in_addr_t = u32;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct in_addr {
     pub s_addr: in_addr_t,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct sockaddr_in {
-    pub sin_len: __uint8_t,
-    pub sin_family: sa_family_t,
-    pub sin_port: in_port_t,
-    pub sin_addr: in_addr,
-    pub sin_zero: [::std::os::raw::c_char; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -37615,12 +38940,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct ip_mreqn {
     pub imr_multiaddr: in_addr,
     pub imr_address: in_addr,
@@ -37628,175 +38947,87 @@ pub struct ip_mreqn {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreq_source {
-    pub imr_multiaddr: in_addr,
-    pub imr_sourceaddr: in_addr,
-    pub imr_interface: in_addr,
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_req {
-    pub gr_interface: u32,
-    pub gr_group: sockaddr_storage,
-}
-impl Default for group_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct group_source_req {
-    pub gsr_interface: u32,
-    pub gsr_group: sockaddr_storage,
-    pub gsr_source: sockaddr_storage,
-}
-impl Default for group_source_req {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct __msfilterreq {
-    pub msfr_ifindex: u32,
-    pub msfr_fmode: u32,
-    pub msfr_nsrcs: u32,
-    pub __msfr_align: u32,
-    pub msfr_group: sockaddr_storage,
-    pub msfr_srcs: *mut sockaddr_storage,
-}
-impl Default for __msfilterreq {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[track_caller]
-pub unsafe fn setipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: u32,
-    arg_arg5: u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: u32,
-                arg5: u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        setipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn getipv4sourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: in_addr,
-    arg_arg3: in_addr,
-    arg_arg4: *mut u32,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut in_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipv4sourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: in_addr,
-                arg3: in_addr,
-                arg4: *mut u32,
-                arg5: *mut u32,
-                arg6: *mut in_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        getipv4sourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn setsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: u32,
-    arg_arg6: u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: u32,
-                arg6: u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        setsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getsourcefilter(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: u32,
-    arg_arg3: *mut sockaddr,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut u32,
-    arg_arg6: *mut u32,
-    arg_arg7: *mut sockaddr_storage,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getsourcefilter(
-                arg1: ::std::os::raw::c_int,
-                arg2: u32,
-                arg3: *mut sockaddr,
-                arg4: socklen_t,
-                arg5: *mut u32,
-                arg6: *mut u32,
-                arg7: *mut sockaddr_storage,
-            ) -> ::std::os::raw::c_int;
-        }
-        getsourcefilter(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
-    pub ipi_ifindex: ::std::os::raw::c_uint,
+    pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
     pub ipi_addr: in_addr,
 }
+pub const IPPROTO_IP: _bindgen_ty_16 = 0;
+pub const IPPROTO_ICMP: _bindgen_ty_16 = 1;
+pub const IPPROTO_IGMP: _bindgen_ty_16 = 2;
+pub const IPPROTO_IPIP: _bindgen_ty_16 = 4;
+pub const IPPROTO_TCP: _bindgen_ty_16 = 6;
+pub const IPPROTO_EGP: _bindgen_ty_16 = 8;
+pub const IPPROTO_PUP: _bindgen_ty_16 = 12;
+pub const IPPROTO_UDP: _bindgen_ty_16 = 17;
+pub const IPPROTO_IDP: _bindgen_ty_16 = 22;
+pub const IPPROTO_TP: _bindgen_ty_16 = 29;
+pub const IPPROTO_DCCP: _bindgen_ty_16 = 33;
+pub const IPPROTO_IPV6: _bindgen_ty_16 = 41;
+pub const IPPROTO_RSVP: _bindgen_ty_16 = 46;
+pub const IPPROTO_GRE: _bindgen_ty_16 = 47;
+pub const IPPROTO_ESP: _bindgen_ty_16 = 50;
+pub const IPPROTO_AH: _bindgen_ty_16 = 51;
+pub const IPPROTO_MTP: _bindgen_ty_16 = 92;
+pub const IPPROTO_BEETPH: _bindgen_ty_16 = 94;
+pub const IPPROTO_ENCAP: _bindgen_ty_16 = 98;
+pub const IPPROTO_PIM: _bindgen_ty_16 = 103;
+pub const IPPROTO_COMP: _bindgen_ty_16 = 108;
+pub const IPPROTO_SCTP: _bindgen_ty_16 = 132;
+pub const IPPROTO_UDPLITE: _bindgen_ty_16 = 136;
+pub const IPPROTO_MPLS: _bindgen_ty_16 = 137;
+pub const IPPROTO_ETHERNET: _bindgen_ty_16 = 143;
+pub const IPPROTO_RAW: _bindgen_ty_16 = 255;
+pub const IPPROTO_MPTCP: _bindgen_ty_16 = 262;
+pub const IPPROTO_MAX: _bindgen_ty_16 = 263;
+pub type _bindgen_ty_16 = ::std::os::raw::c_uint;
+pub const IPPROTO_HOPOPTS: _bindgen_ty_17 = 0;
+pub const IPPROTO_ROUTING: _bindgen_ty_17 = 43;
+pub const IPPROTO_FRAGMENT: _bindgen_ty_17 = 44;
+pub const IPPROTO_ICMPV6: _bindgen_ty_17 = 58;
+pub const IPPROTO_NONE: _bindgen_ty_17 = 59;
+pub const IPPROTO_DSTOPTS: _bindgen_ty_17 = 60;
+pub const IPPROTO_MH: _bindgen_ty_17 = 135;
+pub type _bindgen_ty_17 = ::std::os::raw::c_uint;
+pub type in_port_t = u16;
+pub const IPPORT_ECHO: _bindgen_ty_18 = 7;
+pub const IPPORT_DISCARD: _bindgen_ty_18 = 9;
+pub const IPPORT_SYSTAT: _bindgen_ty_18 = 11;
+pub const IPPORT_DAYTIME: _bindgen_ty_18 = 13;
+pub const IPPORT_NETSTAT: _bindgen_ty_18 = 15;
+pub const IPPORT_FTP: _bindgen_ty_18 = 21;
+pub const IPPORT_TELNET: _bindgen_ty_18 = 23;
+pub const IPPORT_SMTP: _bindgen_ty_18 = 25;
+pub const IPPORT_TIMESERVER: _bindgen_ty_18 = 37;
+pub const IPPORT_NAMESERVER: _bindgen_ty_18 = 42;
+pub const IPPORT_WHOIS: _bindgen_ty_18 = 43;
+pub const IPPORT_MTP: _bindgen_ty_18 = 57;
+pub const IPPORT_TFTP: _bindgen_ty_18 = 69;
+pub const IPPORT_RJE: _bindgen_ty_18 = 77;
+pub const IPPORT_FINGER: _bindgen_ty_18 = 79;
+pub const IPPORT_TTYLINK: _bindgen_ty_18 = 87;
+pub const IPPORT_SUPDUP: _bindgen_ty_18 = 95;
+pub const IPPORT_EXECSERVER: _bindgen_ty_18 = 512;
+pub const IPPORT_LOGINSERVER: _bindgen_ty_18 = 513;
+pub const IPPORT_CMDSERVER: _bindgen_ty_18 = 514;
+pub const IPPORT_EFSSERVER: _bindgen_ty_18 = 520;
+pub const IPPORT_BIFFUDP: _bindgen_ty_18 = 512;
+pub const IPPORT_WHOSERVER: _bindgen_ty_18 = 513;
+pub const IPPORT_ROUTESERVER: _bindgen_ty_18 = 520;
+pub const IPPORT_RESERVED: _bindgen_ty_18 = 1024;
+pub const IPPORT_USERRESERVED: _bindgen_ty_18 = 5000;
+pub type _bindgen_ty_18 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct in6_addr {
-    pub __u6_addr: in6_addr__bindgen_ty_1,
+    pub __in6_u: in6_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union in6_addr__bindgen_ty_1 {
-    pub __u6_addr8: [__uint8_t; 16usize],
-    pub __u6_addr16: [__uint16_t; 8usize],
-    pub __u6_addr32: [__uint32_t; 4usize],
+    pub __u6_addr8: [u8; 16usize],
+    pub __u6_addr16: [u16; 8usize],
+    pub __u6_addr32: [u32; 4usize],
 }
 impl Default for in6_addr__bindgen_ty_1 {
     fn default() -> Self {
@@ -37816,16 +39047,28 @@ impl Default for in6_addr {
         }
     }
 }
-pub type in6_addr_t = in6_addr;
+extern "C" {
+    pub static in6addr_any: in6_addr;
+}
+extern "C" {
+    pub static in6addr_loopback: in6_addr;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [::std::os::raw::c_uchar; 8usize],
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-    pub sin6_len: __uint8_t,
     pub sin6_family: sa_family_t,
     pub sin6_port: in_port_t,
-    pub sin6_flowinfo: __uint32_t,
+    pub sin6_flowinfo: u32,
     pub sin6_addr: in6_addr,
-    pub sin6_scope_id: __uint32_t,
+    pub sin6_scope_id: u32,
 }
 impl Default for sockaddr_in6 {
     fn default() -> Self {
@@ -37836,23 +39079,18 @@ impl Default for sockaddr_in6 {
         }
     }
 }
-extern "C" {
-    pub static in6addr_any: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
 }
-extern "C" {
-    pub static in6addr_loopback: in6_addr;
-}
-extern "C" {
-    pub static in6addr_nodelocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allnodes: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allrouters: in6_addr;
-}
-extern "C" {
-    pub static in6addr_linklocal_allv2routers: in6_addr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreq_source {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+    pub imr_sourceaddr: in_addr,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -37870,12 +39108,12 @@ impl Default for ipv6_mreq {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct in6_pktinfo {
-    pub ipi6_addr: in6_addr,
-    pub ipi6_ifindex: ::std::os::raw::c_uint,
+#[derive(Debug, Copy, Clone)]
+pub struct group_req {
+    pub gr_interface: u32,
+    pub gr_group: sockaddr_storage,
 }
-impl Default for in6_pktinfo {
+impl Default for group_req {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -37885,12 +39123,40 @@ impl Default for in6_pktinfo {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ip6_mtuinfo {
-    pub ip6m_addr: sockaddr_in6,
-    pub ip6m_mtu: u32,
+#[derive(Debug, Copy, Clone)]
+pub struct group_source_req {
+    pub gsr_interface: u32,
+    pub gsr_group: sockaddr_storage,
+    pub gsr_source: sockaddr_storage,
 }
-impl Default for ip6_mtuinfo {
+impl Default for group_source_req {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_msfilter {
+    pub imsf_multiaddr: in_addr,
+    pub imsf_interface: in_addr,
+    pub imsf_fmode: u32,
+    pub imsf_numsrc: u32,
+    pub imsf_slist: [in_addr; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct group_filter {
+    pub gf_interface: u32,
+    pub gf_group: sockaddr_storage,
+    pub gf_fmode: u32,
+    pub gf_numsrc: u32,
+    pub gf_slist: [sockaddr_storage; 1usize],
+}
+impl Default for group_filter {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -37900,464 +39166,236 @@ impl Default for ip6_mtuinfo {
     }
 }
 #[track_caller]
-pub unsafe fn inet6_option_space(arg_arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+pub unsafe fn ntohl(arg___netlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_space(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+            pub fn ntohl(__netlong: u32) -> u32;
         }
-        inet6_option_space(arg_arg1)
+        ntohl(arg___netlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *mut *mut cmsghdr,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn ntohs(arg___netshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut *mut cmsghdr,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn ntohs(__netshort: u16) -> u16;
         }
-        inet6_option_init(arg_arg1, arg_arg2, arg_arg3)
+        ntohs(arg___netshort)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_append(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
+pub unsafe fn htonl(arg___hostlong: u32) -> u32 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_append(
-                arg1: *mut cmsghdr,
-                arg2: *const __uint8_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
+            pub fn htonl(__hostlong: u32) -> u32;
         }
-        inet6_option_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        htonl(arg___hostlong)
     })
 }
 #[track_caller]
-pub unsafe fn inet6_option_alloc(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut __uint8_t {
+pub unsafe fn htons(arg___hostshort: u16) -> u16 {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn inet6_option_alloc(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut __uint8_t;
+            pub fn htons(__hostshort: u16) -> u16;
         }
-        inet6_option_alloc(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_next(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_next(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_next(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_option_find(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: *mut *mut __uint8_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_option_find(
-                arg1: *const cmsghdr,
-                arg2: *mut *mut __uint8_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_option_find(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> usize {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> usize;
-        }
-        inet6_rthdr_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut cmsghdr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut cmsghdr;
-        }
-        inet6_rthdr_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_add(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: *const in6_addr,
-    arg_arg3: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_add(
-                arg1: *mut cmsghdr,
-                arg2: *const in6_addr,
-                arg3: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_add(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_lasthop(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_uint,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_lasthop(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_uint,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_lasthop(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_segments(arg_arg1: *const cmsghdr) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_segments(arg1: *const cmsghdr) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getaddr(
-    arg_arg1: *mut cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getaddr(
-                arg1: *mut cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rthdr_getaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rthdr_getflags(
-    arg_arg1: *const cmsghdr,
-    arg_arg2: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rthdr_getflags(
-                arg1: *const cmsghdr,
-                arg2: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rthdr_getflags(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_init(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_append(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: socklen_t,
-    arg_arg6: __uint8_t,
-    arg_arg7: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_append(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: socklen_t,
-                arg6: __uint8_t,
-                arg7: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_append(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_finish(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_finish(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_finish(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_set_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_set_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_set_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_next(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_next(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_next(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_find(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: __uint8_t,
-    arg_arg5: *mut socklen_t,
-    arg_arg6: *mut *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_find(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: __uint8_t,
-                arg5: *mut socklen_t,
-                arg6: *mut *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_find(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_opt_get_val(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: *mut ::std::os::raw::c_void,
-    arg_arg4: socklen_t,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_opt_get_val(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-                arg3: *mut ::std::os::raw::c_void,
-                arg4: socklen_t,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_opt_get_val(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_space(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: ::std::os::raw::c_int,
-) -> socklen_t {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_space(
-                arg1: ::std::os::raw::c_int,
-                arg2: ::std::os::raw::c_int,
-            ) -> socklen_t;
-        }
-        inet6_rth_space(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_init(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: ::std::os::raw::c_int,
-) -> *mut ::std::os::raw::c_void {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_init(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-                arg4: ::std::os::raw::c_int,
-            ) -> *mut ::std::os::raw::c_void;
-        }
-        inet6_rth_init(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_add(
-    arg_arg1: *mut ::std::os::raw::c_void,
-    arg_arg2: *const in6_addr,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_add(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const in6_addr,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_add(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_reverse(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_reverse(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int;
-        }
-        inet6_rth_reverse(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_segments(arg_arg1: *const ::std::os::raw::c_void) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_segments(arg1: *const ::std::os::raw::c_void)
-                -> ::std::os::raw::c_int;
-        }
-        inet6_rth_segments(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn inet6_rth_getaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut in6_addr {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn inet6_rth_getaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut in6_addr;
-        }
-        inet6_rth_getaddr(arg_arg1, arg_arg2)
+        htons(arg___hostshort)
     })
 }
 #[track_caller]
 pub unsafe fn bindresvport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr_in,
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
             pub fn bindresvport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr_in,
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport(arg_arg1, arg_arg2)
+        bindresvport(arg___sockfd, arg___sock_in)
     })
 }
 #[track_caller]
-pub unsafe fn bindresvport_sa(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *mut sockaddr,
+pub unsafe fn bindresvport6(
+    arg___sockfd: ::std::os::raw::c_int,
+    arg___sock_in: *mut sockaddr_in6,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn bindresvport_sa(
-                arg1: ::std::os::raw::c_int,
-                arg2: *mut sockaddr,
+            pub fn bindresvport6(
+                __sockfd: ::std::os::raw::c_int,
+                __sock_in: *mut sockaddr_in6,
             ) -> ::std::os::raw::c_int;
         }
-        bindresvport_sa(arg_arg1, arg_arg2)
+        bindresvport6(arg___sockfd, arg___sock_in)
     })
 }
-extern "C" {
-    pub static mut h_errno: ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rpcent {
+    pub r_name: *mut ::std::os::raw::c_char,
+    pub r_aliases: *mut *mut ::std::os::raw::c_char,
+    pub r_number: ::std::os::raw::c_int,
+}
+impl Default for rpcent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn setrpcent(arg___stayopen: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setrpcent(__stayopen: ::std::os::raw::c_int);
+        }
+        setrpcent(arg___stayopen)
+    })
+}
+#[track_caller]
+pub unsafe fn endrpcent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endrpcent();
+        }
+        endrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname(arg___name: *const ::std::os::raw::c_char) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname(__name: *const ::std::os::raw::c_char) -> *mut rpcent;
+        }
+        getrpcbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber(arg___number: ::std::os::raw::c_int) -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber(__number: ::std::os::raw::c_int) -> *mut rpcent;
+        }
+        getrpcbynumber(arg___number)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent() -> *mut rpcent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent() -> *mut rpcent;
+        }
+        getrpcent()
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbyname_r(arg___name, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcbynumber_r(
+    arg___number: ::std::os::raw::c_int,
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcbynumber_r(
+                __number: ::std::os::raw::c_int,
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcbynumber_r(arg___number, arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getrpcent_r(
+    arg___result_buf: *mut rpcent,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut rpcent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getrpcent_r(
+                __result_buf: *mut rpcent,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut rpcent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getrpcent_r(arg___result_buf, arg___buffer, arg___buflen, arg___result)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct netent {
+    pub n_name: *mut ::std::os::raw::c_char,
+    pub n_aliases: *mut *mut ::std::os::raw::c_char,
+    pub n_addrtype: ::std::os::raw::c_int,
+    pub n_net: u32,
+}
+impl Default for netent {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn __h_errno_location() -> *mut ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn __h_errno_location() -> *mut ::std::os::raw::c_int;
+        }
+        __h_errno_location()
+    })
+}
+#[track_caller]
+pub unsafe fn herror(arg___str: *const ::std::os::raw::c_char) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn herror(__str: *const ::std::os::raw::c_char);
+        }
+        herror(arg___str)
+    })
+}
+#[track_caller]
+pub unsafe fn hstrerror(arg___err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn hstrerror(__err_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        hstrerror(arg___err_num)
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -38377,22 +39415,322 @@ impl Default for hostent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct netent {
-    pub n_name: *mut ::std::os::raw::c_char,
-    pub n_aliases: *mut *mut ::std::os::raw::c_char,
-    pub n_addrtype: ::std::os::raw::c_int,
-    pub n_net: u32,
-}
-impl Default for netent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
+#[track_caller]
+pub unsafe fn sethostent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn sethostent(__stay_open: ::std::os::raw::c_int);
         }
-    }
+        sethostent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endhostent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endhostent();
+        }
+        endhostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent() -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent() -> *mut hostent;
+        }
+        gethostent()
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyaddr(arg___addr, arg___len, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname(arg___name: *const ::std::os::raw::c_char) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname(__name: *const ::std::os::raw::c_char) -> *mut hostent;
+        }
+        gethostbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+) -> *mut hostent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+            ) -> *mut hostent;
+        }
+        gethostbyname2(arg___name, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostent_r(
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostent_r(
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyaddr_r(
+    arg___addr: *const ::std::os::raw::c_void,
+    arg___len: __socklen_t,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyaddr_r(
+                __addr: *const ::std::os::raw::c_void,
+                __len: __socklen_t,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyaddr_r(
+            arg___addr,
+            arg___len,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn gethostbyname2_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___af: ::std::os::raw::c_int,
+    arg___result_buf: *mut hostent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut hostent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gethostbyname2_r(
+                __name: *const ::std::os::raw::c_char,
+                __af: ::std::os::raw::c_int,
+                __result_buf: *mut hostent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut hostent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        gethostbyname2_r(
+            arg___name,
+            arg___af,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn setnetent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetent(__stay_open: ::std::os::raw::c_int);
+        }
+        setnetent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endnetent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endnetent();
+        }
+        endnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent() -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent() -> *mut netent;
+        }
+        getnetent()
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr(arg___net: u32, arg___type: ::std::os::raw::c_int) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr(__net: u32, __type: ::std::os::raw::c_int) -> *mut netent;
+        }
+        getnetbyaddr(arg___net, arg___type)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname(arg___name: *const ::std::os::raw::c_char) -> *mut netent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname(__name: *const ::std::os::raw::c_char) -> *mut netent;
+        }
+        getnetbyname(arg___name)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetent_r(
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetent_r(
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetent_r(arg___result_buf, arg___buf, arg___buflen, arg___result, arg___h_errnop)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyaddr_r(
+    arg___net: u32,
+    arg___type: ::std::os::raw::c_int,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyaddr_r(
+                __net: u32,
+                __type: ::std::os::raw::c_int,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyaddr_r(
+            arg___net,
+            arg___type,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getnetbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut netent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut netent,
+    arg___h_errnop: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut netent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut netent,
+                __h_errnop: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetbyname_r(
+            arg___name,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+            arg___h_errnop,
+        )
+    })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -38411,6 +39749,142 @@ impl Default for servent {
         }
     }
 }
+#[track_caller]
+pub unsafe fn setservent(arg___stay_open: ::std::os::raw::c_int) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setservent(__stay_open: ::std::os::raw::c_int);
+        }
+        setservent(arg___stay_open)
+    })
+}
+#[track_caller]
+pub unsafe fn endservent() {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn endservent();
+        }
+        endservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservent() -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent() -> *mut servent;
+        }
+        getservent()
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyname(arg___name, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+) -> *mut servent {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+            ) -> *mut servent;
+        }
+        getservbyport(arg___port, arg___proto)
+    })
+}
+#[track_caller]
+pub unsafe fn getservent_r(
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservent_r(
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyname_r(
+            arg___name,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn getservbyport_r(
+    arg___port: ::std::os::raw::c_int,
+    arg___proto: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut servent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut servent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getservbyport_r(
+                __port: ::std::os::raw::c_int,
+                __proto: *const ::std::os::raw::c_char,
+                __result_buf: *mut servent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut servent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getservbyport_r(
+            arg___port,
+            arg___proto,
+            arg___result_buf,
+            arg___buf,
+            arg___buflen,
+            arg___result,
+        )
+    })
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct protoent {
@@ -38427,59 +39901,13 @@ impl Default for protoent {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct addrinfo {
-    pub ai_flags: ::std::os::raw::c_int,
-    pub ai_family: ::std::os::raw::c_int,
-    pub ai_socktype: ::std::os::raw::c_int,
-    pub ai_protocol: ::std::os::raw::c_int,
-    pub ai_addrlen: socklen_t,
-    pub ai_canonname: *mut ::std::os::raw::c_char,
-    pub ai_addr: *mut sockaddr,
-    pub ai_next: *mut addrinfo,
-}
-impl Default for addrinfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rpcent {
-    pub r_name: *mut ::std::os::raw::c_char,
-    pub r_aliases: *mut *mut ::std::os::raw::c_char,
-    pub r_number: ::std::os::raw::c_int,
-}
-impl Default for rpcent {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
 #[track_caller]
-pub unsafe fn endhostent() {
+pub unsafe fn setprotoent(arg___stay_open: ::std::os::raw::c_int) {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn endhostent();
+            pub fn setprotoent(__stay_open: ::std::os::raw::c_int);
         }
-        endhostent()
-    })
-}
-#[track_caller]
-pub unsafe fn endnetent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endnetent();
-        }
-        endnetent()
+        setprotoent(arg___stay_open)
     })
 }
 #[track_caller]
@@ -38492,157 +39920,6 @@ pub unsafe fn endprotoent() {
     })
 }
 #[track_caller]
-pub unsafe fn endservent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endservent();
-        }
-        endservent()
-    })
-}
-#[track_caller]
-pub unsafe fn freeaddrinfo(arg_arg1: *mut addrinfo) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freeaddrinfo(arg1: *mut addrinfo);
-        }
-        freeaddrinfo(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gai_strerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gai_strerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        gai_strerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getaddrinfo(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const addrinfo,
-    arg_arg4: *mut *mut addrinfo,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getaddrinfo(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const addrinfo,
-                arg4: *mut *mut addrinfo,
-            ) -> ::std::os::raw::c_int;
-        }
-        getaddrinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: socklen_t,
-    arg_arg3: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: socklen_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyaddr(arg_arg1, arg_arg2, arg_arg3)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname(arg1: *const ::std::os::raw::c_char) -> *mut hostent;
-        }
-        gethostbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostent() -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostent() -> *mut hostent;
-        }
-        gethostent()
-    })
-}
-#[track_caller]
-pub unsafe fn getnameinfo(
-    arg_arg1: *const sockaddr,
-    arg_arg2: socklen_t,
-    arg_arg3: *mut ::std::os::raw::c_char,
-    arg_arg4: socklen_t,
-    arg_arg5: *mut ::std::os::raw::c_char,
-    arg_arg6: socklen_t,
-    arg_arg7: ::std::os::raw::c_int,
-) -> ::std::os::raw::c_int {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnameinfo(
-                arg1: *const sockaddr,
-                arg2: socklen_t,
-                arg3: *mut ::std::os::raw::c_char,
-                arg4: socklen_t,
-                arg5: *mut ::std::os::raw::c_char,
-                arg6: socklen_t,
-                arg7: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int;
-        }
-        getnameinfo(arg_arg1, arg_arg2, arg_arg3, arg_arg4, arg_arg5, arg_arg6, arg_arg7)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyaddr(arg_arg1: u32, arg_arg2: ::std::os::raw::c_int) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyaddr(arg1: u32, arg2: ::std::os::raw::c_int) -> *mut netent;
-        }
-        getnetbyaddr(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetbyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetbyname(arg1: *const ::std::os::raw::c_char) -> *mut netent;
-        }
-        getnetbyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getnetent() -> *mut netent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getnetent() -> *mut netent;
-        }
-        getnetent()
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobyname(arg_arg1: *const ::std::os::raw::c_char) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobyname(arg1: *const ::std::os::raw::c_char) -> *mut protoent;
-        }
-        getprotobyname(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn getprotobynumber(arg_arg1: ::std::os::raw::c_int) -> *mut protoent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getprotobynumber(arg1: ::std::os::raw::c_int) -> *mut protoent;
-        }
-        getprotobynumber(arg_arg1)
-    })
-}
-#[track_caller]
 pub unsafe fn getprotoent() -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
@@ -38652,239 +39929,91 @@ pub unsafe fn getprotoent() -> *mut protoent {
     })
 }
 #[track_caller]
-pub unsafe fn getservbyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobyname(arg___name: *const ::std::os::raw::c_char) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobyname(__name: *const ::std::os::raw::c_char) -> *mut protoent;
         }
-        getservbyname(arg_arg1, arg_arg2)
+        getprotobyname(arg___name)
     })
 }
 #[track_caller]
-pub unsafe fn getservbyport(
-    arg_arg1: ::std::os::raw::c_int,
-    arg_arg2: *const ::std::os::raw::c_char,
-) -> *mut servent {
+pub unsafe fn getprotobynumber(arg___proto: ::std::os::raw::c_int) -> *mut protoent {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getservbyport(
-                arg1: ::std::os::raw::c_int,
-                arg2: *const ::std::os::raw::c_char,
-            ) -> *mut servent;
+            pub fn getprotobynumber(__proto: ::std::os::raw::c_int) -> *mut protoent;
         }
-        getservbyport(arg_arg1, arg_arg2)
+        getprotobynumber(arg___proto)
     })
 }
 #[track_caller]
-pub unsafe fn getservent() -> *mut servent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getservent() -> *mut servent;
-        }
-        getservent()
-    })
-}
-#[track_caller]
-pub unsafe fn sethostent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn sethostent(arg1: ::std::os::raw::c_int);
-        }
-        sethostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setnetent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setnetent(arg1: ::std::os::raw::c_int);
-        }
-        setnetent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setprotoent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setprotoent(arg1: ::std::os::raw::c_int);
-        }
-        setprotoent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn setservent(arg_arg1: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setservent(arg1: ::std::os::raw::c_int);
-        }
-        setservent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn freehostent(arg_arg1: *mut hostent) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn freehostent(arg1: *mut hostent);
-        }
-        freehostent(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn gethostbyname2(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn gethostbyname2(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        gethostbyname2(arg_arg1, arg_arg2)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyaddr(
-    arg_arg1: *const ::std::os::raw::c_void,
-    arg_arg2: usize,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyaddr(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: usize,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyaddr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getipnodebyname(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: ::std::os::raw::c_int,
-    arg_arg3: ::std::os::raw::c_int,
-    arg_arg4: *mut ::std::os::raw::c_int,
-) -> *mut hostent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getipnodebyname(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: ::std::os::raw::c_int,
-                arg3: ::std::os::raw::c_int,
-                arg4: *mut ::std::os::raw::c_int,
-            ) -> *mut hostent;
-        }
-        getipnodebyname(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbyname(arg_name: *const ::std::os::raw::c_char) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbyname(name: *const ::std::os::raw::c_char) -> *mut rpcent;
-        }
-        getrpcbyname(arg_name)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcbynumber(arg_number: ::std::os::raw::c_int) -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcbynumber(number: ::std::os::raw::c_int) -> *mut rpcent;
-        }
-        getrpcbynumber(arg_number)
-    })
-}
-#[track_caller]
-pub unsafe fn getrpcent() -> *mut rpcent {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn getrpcent() -> *mut rpcent;
-        }
-        getrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn setrpcent(arg_stayopen: ::std::os::raw::c_int) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn setrpcent(stayopen: ::std::os::raw::c_int);
-        }
-        setrpcent(arg_stayopen)
-    })
-}
-#[track_caller]
-pub unsafe fn endrpcent() {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn endrpcent();
-        }
-        endrpcent()
-    })
-}
-#[track_caller]
-pub unsafe fn herror(arg_arg1: *const ::std::os::raw::c_char) {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn herror(arg1: *const ::std::os::raw::c_char);
-        }
-        herror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn hstrerror(arg_arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
-    crate::ffi::pg_guard_ffi_boundary(move || {
-        extern "C" {
-            pub fn hstrerror(arg1: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
-        }
-        hstrerror(arg_arg1)
-    })
-}
-#[track_caller]
-pub unsafe fn innetgr(
-    arg_arg1: *const ::std::os::raw::c_char,
-    arg_arg2: *const ::std::os::raw::c_char,
-    arg_arg3: *const ::std::os::raw::c_char,
-    arg_arg4: *const ::std::os::raw::c_char,
+pub unsafe fn getprotoent_r(
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn innetgr(
-                arg1: *const ::std::os::raw::c_char,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: *const ::std::os::raw::c_char,
-                arg4: *const ::std::os::raw::c_char,
+            pub fn getprotoent_r(
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        innetgr(arg_arg1, arg_arg2, arg_arg3, arg_arg4)
+        getprotoent_r(arg___result_buf, arg___buf, arg___buflen, arg___result)
     })
 }
 #[track_caller]
-pub unsafe fn getnetgrent(
-    arg_arg1: *mut *mut ::std::os::raw::c_char,
-    arg_arg2: *mut *mut ::std::os::raw::c_char,
-    arg_arg3: *mut *mut ::std::os::raw::c_char,
+pub unsafe fn getprotobyname_r(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
 ) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn getnetgrent(
-                arg1: *mut *mut ::std::os::raw::c_char,
-                arg2: *mut *mut ::std::os::raw::c_char,
-                arg3: *mut *mut ::std::os::raw::c_char,
+            pub fn getprotobyname_r(
+                __name: *const ::std::os::raw::c_char,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
             ) -> ::std::os::raw::c_int;
         }
-        getnetgrent(arg_arg1, arg_arg2, arg_arg3)
+        getprotobyname_r(arg___name, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn getprotobynumber_r(
+    arg___proto: ::std::os::raw::c_int,
+    arg___result_buf: *mut protoent,
+    arg___buf: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+    arg___result: *mut *mut protoent,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getprotobynumber_r(
+                __proto: ::std::os::raw::c_int,
+                __result_buf: *mut protoent,
+                __buf: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+                __result: *mut *mut protoent,
+            ) -> ::std::os::raw::c_int;
+        }
+        getprotobynumber_r(arg___proto, arg___result_buf, arg___buf, arg___buflen, arg___result)
+    })
+}
+#[track_caller]
+pub unsafe fn setnetgrent(arg___netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn setnetgrent(__netgroup: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+        }
+        setnetgrent(arg___netgroup)
     })
 }
 #[track_caller]
@@ -38897,20 +40026,366 @@ pub unsafe fn endnetgrent() {
     })
 }
 #[track_caller]
-pub unsafe fn setnetgrent(arg_arg1: *const ::std::os::raw::c_char) {
+pub unsafe fn getnetgrent(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn setnetgrent(arg1: *const ::std::os::raw::c_char);
+            pub fn getnetgrent(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
         }
-        setnetgrent(arg_arg1)
+        getnetgrent(arg___hostp, arg___userp, arg___domainp)
+    })
+}
+#[track_caller]
+pub unsafe fn innetgr(
+    arg___netgroup: *const ::std::os::raw::c_char,
+    arg___host: *const ::std::os::raw::c_char,
+    arg___user: *const ::std::os::raw::c_char,
+    arg___domain: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn innetgr(
+                __netgroup: *const ::std::os::raw::c_char,
+                __host: *const ::std::os::raw::c_char,
+                __user: *const ::std::os::raw::c_char,
+                __domain: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        innetgr(arg___netgroup, arg___host, arg___user, arg___domain)
+    })
+}
+#[track_caller]
+pub unsafe fn getnetgrent_r(
+    arg___hostp: *mut *mut ::std::os::raw::c_char,
+    arg___userp: *mut *mut ::std::os::raw::c_char,
+    arg___domainp: *mut *mut ::std::os::raw::c_char,
+    arg___buffer: *mut ::std::os::raw::c_char,
+    arg___buflen: usize,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnetgrent_r(
+                __hostp: *mut *mut ::std::os::raw::c_char,
+                __userp: *mut *mut ::std::os::raw::c_char,
+                __domainp: *mut *mut ::std::os::raw::c_char,
+                __buffer: *mut ::std::os::raw::c_char,
+                __buflen: usize,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnetgrent_r(arg___hostp, arg___userp, arg___domainp, arg___buffer, arg___buflen)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd(arg___ahost, arg___rport, arg___locuser, arg___remuser, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rcmd_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_ushort,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rcmd_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_ushort,
+                __locuser: *const ::std::os::raw::c_char,
+                __remuser: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rcmd_af(
+            arg___ahost,
+            arg___rport,
+            arg___locuser,
+            arg___remuser,
+            arg___cmd,
+            arg___fd2p,
+            arg___af,
+        )
+    })
+}
+#[track_caller]
+pub unsafe fn rexec(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p)
+    })
+}
+#[track_caller]
+pub unsafe fn rexec_af(
+    arg___ahost: *mut *mut ::std::os::raw::c_char,
+    arg___rport: ::std::os::raw::c_int,
+    arg___name: *const ::std::os::raw::c_char,
+    arg___pass: *const ::std::os::raw::c_char,
+    arg___cmd: *const ::std::os::raw::c_char,
+    arg___fd2p: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rexec_af(
+                __ahost: *mut *mut ::std::os::raw::c_char,
+                __rport: ::std::os::raw::c_int,
+                __name: *const ::std::os::raw::c_char,
+                __pass: *const ::std::os::raw::c_char,
+                __cmd: *const ::std::os::raw::c_char,
+                __fd2p: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rexec_af(arg___ahost, arg___rport, arg___name, arg___pass, arg___cmd, arg___fd2p, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok(arg___rhost, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn ruserok_af(
+    arg___rhost: *const ::std::os::raw::c_char,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn ruserok_af(
+                __rhost: *const ::std::os::raw::c_char,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        ruserok_af(arg___rhost, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok(
+    arg___raddr: u32,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok(
+                __raddr: u32,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok(arg___raddr, arg___suser, arg___remuser, arg___locuser)
+    })
+}
+#[track_caller]
+pub unsafe fn iruserok_af(
+    arg___raddr: *const ::std::os::raw::c_void,
+    arg___suser: ::std::os::raw::c_int,
+    arg___remuser: *const ::std::os::raw::c_char,
+    arg___locuser: *const ::std::os::raw::c_char,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn iruserok_af(
+                __raddr: *const ::std::os::raw::c_void,
+                __suser: ::std::os::raw::c_int,
+                __remuser: *const ::std::os::raw::c_char,
+                __locuser: *const ::std::os::raw::c_char,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        iruserok_af(arg___raddr, arg___suser, arg___remuser, arg___locuser, arg___af)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport(arg___alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport(__alport: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+        }
+        rresvport(arg___alport)
+    })
+}
+#[track_caller]
+pub unsafe fn rresvport_af(
+    arg___alport: *mut ::std::os::raw::c_int,
+    arg___af: sa_family_t,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn rresvport_af(
+                __alport: *mut ::std::os::raw::c_int,
+                __af: sa_family_t,
+            ) -> ::std::os::raw::c_int;
+        }
+        rresvport_af(arg___alport, arg___af)
+    })
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct addrinfo {
+    pub ai_flags: ::std::os::raw::c_int,
+    pub ai_family: ::std::os::raw::c_int,
+    pub ai_socktype: ::std::os::raw::c_int,
+    pub ai_protocol: ::std::os::raw::c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_addr: *mut sockaddr,
+    pub ai_canonname: *mut ::std::os::raw::c_char,
+    pub ai_next: *mut addrinfo,
+}
+impl Default for addrinfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[track_caller]
+pub unsafe fn getaddrinfo(
+    arg___name: *const ::std::os::raw::c_char,
+    arg___service: *const ::std::os::raw::c_char,
+    arg___req: *const addrinfo,
+    arg___pai: *mut *mut addrinfo,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getaddrinfo(
+                __name: *const ::std::os::raw::c_char,
+                __service: *const ::std::os::raw::c_char,
+                __req: *const addrinfo,
+                __pai: *mut *mut addrinfo,
+            ) -> ::std::os::raw::c_int;
+        }
+        getaddrinfo(arg___name, arg___service, arg___req, arg___pai)
+    })
+}
+#[track_caller]
+pub unsafe fn freeaddrinfo(arg___ai: *mut addrinfo) {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn freeaddrinfo(__ai: *mut addrinfo);
+        }
+        freeaddrinfo(arg___ai)
+    })
+}
+#[track_caller]
+pub unsafe fn gai_strerror(arg___ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn gai_strerror(__ecode: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+        }
+        gai_strerror(arg___ecode)
+    })
+}
+#[track_caller]
+pub unsafe fn getnameinfo(
+    arg___sa: *const sockaddr,
+    arg___salen: socklen_t,
+    arg___host: *mut ::std::os::raw::c_char,
+    arg___hostlen: socklen_t,
+    arg___serv: *mut ::std::os::raw::c_char,
+    arg___servlen: socklen_t,
+    arg___flags: ::std::os::raw::c_int,
+) -> ::std::os::raw::c_int {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn getnameinfo(
+                __sa: *const sockaddr,
+                __salen: socklen_t,
+                __host: *mut ::std::os::raw::c_char,
+                __hostlen: socklen_t,
+                __serv: *mut ::std::os::raw::c_char,
+                __servlen: socklen_t,
+                __flags: ::std::os::raw::c_int,
+            ) -> ::std::os::raw::c_int;
+        }
+        getnameinfo(
+            arg___sa,
+            arg___salen,
+            arg___host,
+            arg___hostlen,
+            arg___serv,
+            arg___servlen,
+            arg___flags,
+        )
     })
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
-    pub sun_len: ::std::os::raw::c_uchar,
     pub sun_family: sa_family_t,
-    pub sun_path: [::std::os::raw::c_char; 104usize],
+    pub sun_path: [::std::os::raw::c_char; 108usize],
 }
 impl Default for sockaddr_un {
     fn default() -> Self {
@@ -41528,20 +43003,46 @@ pub const RmgrIds_RM_NEXT_ID: RmgrIds = 22;
 pub type RmgrIds = ::std::os::raw::c_uint;
 pub type pg_crc32c = uint32;
 #[track_caller]
-pub unsafe fn pg_comp_crc32c_armv8(
+pub unsafe fn pg_comp_crc32c_sb8(
     arg_crc: pg_crc32c,
     arg_data: *const ::std::os::raw::c_void,
     arg_len: usize,
 ) -> pg_crc32c {
     crate::ffi::pg_guard_ffi_boundary(move || {
         extern "C" {
-            pub fn pg_comp_crc32c_armv8(
+            pub fn pg_comp_crc32c_sb8(
                 crc: pg_crc32c,
                 data: *const ::std::os::raw::c_void,
                 len: usize,
             ) -> pg_crc32c;
         }
-        pg_comp_crc32c_armv8(arg_crc, arg_data, arg_len)
+        pg_comp_crc32c_sb8(arg_crc, arg_data, arg_len)
+    })
+}
+extern "C" {
+    pub static mut pg_comp_crc32c: ::std::option::Option<
+        unsafe extern "C" fn(
+            crc: pg_crc32c,
+            data: *const ::std::os::raw::c_void,
+            len: usize,
+        ) -> pg_crc32c,
+    >;
+}
+#[track_caller]
+pub unsafe fn pg_comp_crc32c_sse42(
+    arg_crc: pg_crc32c,
+    arg_data: *const ::std::os::raw::c_void,
+    arg_len: usize,
+) -> pg_crc32c {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn pg_comp_crc32c_sse42(
+                crc: pg_crc32c,
+                data: *const ::std::os::raw::c_void,
+                len: usize,
+            ) -> pg_crc32c;
+        }
+        pg_comp_crc32c_sse42(arg_crc, arg_data, arg_len)
     })
 }
 pub const ForkNumber_InvalidForkNumber: ForkNumber = -1;
@@ -57470,6 +58971,15 @@ pub unsafe fn defGetInt64(arg_def: *mut DefElem) -> int64 {
             pub fn defGetInt64(def: *mut DefElem) -> int64;
         }
         defGetInt64(arg_def)
+    })
+}
+#[track_caller]
+pub unsafe fn defGetObjectId(arg_def: *mut DefElem) -> Oid {
+    crate::ffi::pg_guard_ffi_boundary(move || {
+        extern "C" {
+            pub fn defGetObjectId(def: *mut DefElem) -> Oid;
+        }
+        defGetObjectId(arg_def)
     })
 }
 #[track_caller]
@@ -113665,8 +115175,29 @@ pub unsafe fn range_split_internal(
         range_split_internal(arg_typcache, arg_r1, arg_r2, arg_output1, arg_output2)
     })
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+impl Default for __va_list_tag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AttrMissing {
@@ -113757,2610 +115288,3045 @@ pub struct ResourceOwnerData {
 pub struct SnapBuild {
     pub _address: u8,
 }
+impl pg_sys::seal::Sealed for A_ArrayExpr {}
 impl pg_sys::PgNode for A_ArrayExpr {}
 impl std::fmt::Display for A_ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Const {}
 impl pg_sys::PgNode for A_Const {}
 impl std::fmt::Display for A_Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Expr {}
 impl pg_sys::PgNode for A_Expr {}
 impl std::fmt::Display for A_Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indices {}
 impl pg_sys::PgNode for A_Indices {}
 impl std::fmt::Display for A_Indices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Indirection {}
 impl pg_sys::PgNode for A_Indirection {}
 impl std::fmt::Display for A_Indirection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for A_Star {}
 impl pg_sys::PgNode for A_Star {}
 impl std::fmt::Display for A_Star {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AccessPriv {}
 impl pg_sys::PgNode for AccessPriv {}
 impl std::fmt::Display for AccessPriv {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Agg {}
 impl pg_sys::PgNode for Agg {}
 impl std::fmt::Display for Agg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggPath {}
 impl pg_sys::PgNode for AggPath {}
 impl std::fmt::Display for AggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AggState {}
 impl pg_sys::PgNode for AggState {}
 impl std::fmt::Display for AggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Aggref {}
 impl pg_sys::PgNode for Aggref {}
 impl std::fmt::Display for Aggref {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Alias {}
 impl pg_sys::PgNode for Alias {}
 impl std::fmt::Display for Alias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterCollationStmt {}
 impl pg_sys::PgNode for AlterCollationStmt {}
 impl std::fmt::Display for AlterCollationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseRefreshCollStmt {}
 impl pg_sys::PgNode for AlterDatabaseRefreshCollStmt {}
 impl std::fmt::Display for AlterDatabaseRefreshCollStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseSetStmt {}
 impl pg_sys::PgNode for AlterDatabaseSetStmt {}
 impl std::fmt::Display for AlterDatabaseSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDatabaseStmt {}
 impl pg_sys::PgNode for AlterDatabaseStmt {}
 impl std::fmt::Display for AlterDatabaseStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDefaultPrivilegesStmt {}
 impl pg_sys::PgNode for AlterDefaultPrivilegesStmt {}
 impl std::fmt::Display for AlterDefaultPrivilegesStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterDomainStmt {}
 impl pg_sys::PgNode for AlterDomainStmt {}
 impl std::fmt::Display for AlterDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEnumStmt {}
 impl pg_sys::PgNode for AlterEnumStmt {}
 impl std::fmt::Display for AlterEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterEventTrigStmt {}
 impl pg_sys::PgNode for AlterEventTrigStmt {}
 impl std::fmt::Display for AlterEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionContentsStmt {}
 impl pg_sys::PgNode for AlterExtensionContentsStmt {}
 impl std::fmt::Display for AlterExtensionContentsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterExtensionStmt {}
 impl pg_sys::PgNode for AlterExtensionStmt {}
 impl std::fmt::Display for AlterExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFdwStmt {}
 impl pg_sys::PgNode for AlterFdwStmt {}
 impl std::fmt::Display for AlterFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterForeignServerStmt {}
 impl pg_sys::PgNode for AlterForeignServerStmt {}
 impl std::fmt::Display for AlterForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterFunctionStmt {}
 impl pg_sys::PgNode for AlterFunctionStmt {}
 impl std::fmt::Display for AlterFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectDependsStmt {}
 impl pg_sys::PgNode for AlterObjectDependsStmt {}
 impl std::fmt::Display for AlterObjectDependsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterObjectSchemaStmt {}
 impl pg_sys::PgNode for AlterObjectSchemaStmt {}
 impl std::fmt::Display for AlterObjectSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOpFamilyStmt {}
 impl pg_sys::PgNode for AlterOpFamilyStmt {}
 impl std::fmt::Display for AlterOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOperatorStmt {}
 impl pg_sys::PgNode for AlterOperatorStmt {}
 impl std::fmt::Display for AlterOperatorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterOwnerStmt {}
 impl pg_sys::PgNode for AlterOwnerStmt {}
 impl std::fmt::Display for AlterOwnerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPolicyStmt {}
 impl pg_sys::PgNode for AlterPolicyStmt {}
 impl std::fmt::Display for AlterPolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterPublicationStmt {}
 impl pg_sys::PgNode for AlterPublicationStmt {}
 impl std::fmt::Display for AlterPublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleSetStmt {}
 impl pg_sys::PgNode for AlterRoleSetStmt {}
 impl std::fmt::Display for AlterRoleSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterRoleStmt {}
 impl pg_sys::PgNode for AlterRoleStmt {}
 impl std::fmt::Display for AlterRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSeqStmt {}
 impl pg_sys::PgNode for AlterSeqStmt {}
 impl std::fmt::Display for AlterSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterStatsStmt {}
 impl pg_sys::PgNode for AlterStatsStmt {}
 impl std::fmt::Display for AlterStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSubscriptionStmt {}
 impl pg_sys::PgNode for AlterSubscriptionStmt {}
 impl std::fmt::Display for AlterSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterSystemStmt {}
 impl pg_sys::PgNode for AlterSystemStmt {}
 impl std::fmt::Display for AlterSystemStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSConfigurationStmt {}
 impl pg_sys::PgNode for AlterTSConfigurationStmt {}
 impl std::fmt::Display for AlterTSConfigurationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTSDictionaryStmt {}
 impl pg_sys::PgNode for AlterTSDictionaryStmt {}
 impl std::fmt::Display for AlterTSDictionaryStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableCmd {}
 impl pg_sys::PgNode for AlterTableCmd {}
 impl std::fmt::Display for AlterTableCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableMoveAllStmt {}
 impl pg_sys::PgNode for AlterTableMoveAllStmt {}
 impl std::fmt::Display for AlterTableMoveAllStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableSpaceOptionsStmt {}
 impl pg_sys::PgNode for AlterTableSpaceOptionsStmt {}
 impl std::fmt::Display for AlterTableSpaceOptionsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTableStmt {}
 impl pg_sys::PgNode for AlterTableStmt {}
 impl std::fmt::Display for AlterTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterTypeStmt {}
 impl pg_sys::PgNode for AlterTypeStmt {}
 impl std::fmt::Display for AlterTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlterUserMappingStmt {}
 impl pg_sys::PgNode for AlterUserMappingStmt {}
 impl std::fmt::Display for AlterUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AlternativeSubPlan {}
 impl pg_sys::PgNode for AlternativeSubPlan {}
 impl std::fmt::Display for AlternativeSubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Append {}
 impl pg_sys::PgNode for Append {}
 impl std::fmt::Display for Append {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendPath {}
 impl pg_sys::PgNode for AppendPath {}
 impl std::fmt::Display for AppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendRelInfo {}
 impl pg_sys::PgNode for AppendRelInfo {}
 impl std::fmt::Display for AppendRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for AppendState {}
 impl pg_sys::PgNode for AppendState {}
 impl std::fmt::Display for AppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayCoerceExpr {}
 impl pg_sys::PgNode for ArrayCoerceExpr {}
 impl std::fmt::Display for ArrayCoerceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ArrayExpr {}
 impl pg_sys::PgNode for ArrayExpr {}
 impl std::fmt::Display for ArrayExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BaseBackupCmd {}
 impl pg_sys::PgNode for BaseBackupCmd {}
 impl std::fmt::Display for BaseBackupCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitString {}
 impl pg_sys::PgNode for BitString {}
 impl std::fmt::Display for BitString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAnd {}
 impl pg_sys::PgNode for BitmapAnd {}
 impl std::fmt::Display for BitmapAnd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndPath {}
 impl pg_sys::PgNode for BitmapAndPath {}
 impl std::fmt::Display for BitmapAndPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapAndState {}
 impl pg_sys::PgNode for BitmapAndState {}
 impl std::fmt::Display for BitmapAndState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapPath {}
 impl pg_sys::PgNode for BitmapHeapPath {}
 impl std::fmt::Display for BitmapHeapPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScan {}
 impl pg_sys::PgNode for BitmapHeapScan {}
 impl std::fmt::Display for BitmapHeapScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapHeapScanState {}
 impl pg_sys::PgNode for BitmapHeapScanState {}
 impl std::fmt::Display for BitmapHeapScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScan {}
 impl pg_sys::PgNode for BitmapIndexScan {}
 impl std::fmt::Display for BitmapIndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapIndexScanState {}
 impl pg_sys::PgNode for BitmapIndexScanState {}
 impl std::fmt::Display for BitmapIndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOr {}
 impl pg_sys::PgNode for BitmapOr {}
 impl std::fmt::Display for BitmapOr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrPath {}
 impl pg_sys::PgNode for BitmapOrPath {}
 impl std::fmt::Display for BitmapOrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BitmapOrState {}
 impl pg_sys::PgNode for BitmapOrState {}
 impl std::fmt::Display for BitmapOrState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BoolExpr {}
 impl pg_sys::PgNode for BoolExpr {}
 impl std::fmt::Display for BoolExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Boolean {}
 impl pg_sys::PgNode for Boolean {}
 impl std::fmt::Display for Boolean {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BooleanTest {}
 impl pg_sys::PgNode for BooleanTest {}
 impl std::fmt::Display for BooleanTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for BufferHeapTupleTableSlot {}
 impl pg_sys::PgNode for BufferHeapTupleTableSlot {}
 impl std::fmt::Display for BufferHeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CTECycleClause {}
 impl pg_sys::PgNode for CTECycleClause {}
 impl std::fmt::Display for CTECycleClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CTESearchClause {}
 impl pg_sys::PgNode for CTESearchClause {}
 impl std::fmt::Display for CTESearchClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallContext {}
 impl pg_sys::PgNode for CallContext {}
 impl std::fmt::Display for CallContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CallStmt {}
 impl pg_sys::PgNode for CallStmt {}
 impl std::fmt::Display for CallStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseExpr {}
 impl pg_sys::PgNode for CaseExpr {}
 impl std::fmt::Display for CaseExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseTestExpr {}
 impl pg_sys::PgNode for CaseTestExpr {}
 impl std::fmt::Display for CaseTestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CaseWhen {}
 impl pg_sys::PgNode for CaseWhen {}
 impl std::fmt::Display for CaseWhen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CheckPointStmt {}
 impl pg_sys::PgNode for CheckPointStmt {}
 impl std::fmt::Display for CheckPointStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClosePortalStmt {}
 impl pg_sys::PgNode for ClosePortalStmt {}
 impl std::fmt::Display for ClosePortalStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ClusterStmt {}
 impl pg_sys::PgNode for ClusterStmt {}
 impl std::fmt::Display for ClusterStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoalesceExpr {}
 impl pg_sys::PgNode for CoalesceExpr {}
 impl std::fmt::Display for CoalesceExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomain {}
 impl pg_sys::PgNode for CoerceToDomain {}
 impl std::fmt::Display for CoerceToDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceToDomainValue {}
 impl pg_sys::PgNode for CoerceToDomainValue {}
 impl std::fmt::Display for CoerceToDomainValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CoerceViaIO {}
 impl pg_sys::PgNode for CoerceViaIO {}
 impl std::fmt::Display for CoerceViaIO {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateClause {}
 impl pg_sys::PgNode for CollateClause {}
 impl std::fmt::Display for CollateClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CollateExpr {}
 impl pg_sys::PgNode for CollateExpr {}
 impl std::fmt::Display for CollateExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnDef {}
 impl pg_sys::PgNode for ColumnDef {}
 impl std::fmt::Display for ColumnDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ColumnRef {}
 impl pg_sys::PgNode for ColumnRef {}
 impl std::fmt::Display for ColumnRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommentStmt {}
 impl pg_sys::PgNode for CommentStmt {}
 impl std::fmt::Display for CommentStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CommonTableExpr {}
 impl pg_sys::PgNode for CommonTableExpr {}
 impl std::fmt::Display for CommonTableExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CompositeTypeStmt {}
 impl pg_sys::PgNode for CompositeTypeStmt {}
 impl std::fmt::Display for CompositeTypeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Const {}
 impl pg_sys::PgNode for Const {}
 impl std::fmt::Display for Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Constraint {}
 impl pg_sys::PgNode for Constraint {}
 impl std::fmt::Display for Constraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConstraintsSetStmt {}
 impl pg_sys::PgNode for ConstraintsSetStmt {}
 impl std::fmt::Display for ConstraintsSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ConvertRowtypeExpr {}
 impl pg_sys::PgNode for ConvertRowtypeExpr {}
 impl std::fmt::Display for ConvertRowtypeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CopyStmt {}
 impl pg_sys::PgNode for CopyStmt {}
 impl std::fmt::Display for CopyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateAmStmt {}
 impl pg_sys::PgNode for CreateAmStmt {}
 impl std::fmt::Display for CreateAmStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateCastStmt {}
 impl pg_sys::PgNode for CreateCastStmt {}
 impl std::fmt::Display for CreateCastStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateConversionStmt {}
 impl pg_sys::PgNode for CreateConversionStmt {}
 impl std::fmt::Display for CreateConversionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateDomainStmt {}
 impl pg_sys::PgNode for CreateDomainStmt {}
 impl std::fmt::Display for CreateDomainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEnumStmt {}
 impl pg_sys::PgNode for CreateEnumStmt {}
 impl std::fmt::Display for CreateEnumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateEventTrigStmt {}
 impl pg_sys::PgNode for CreateEventTrigStmt {}
 impl std::fmt::Display for CreateEventTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateExtensionStmt {}
 impl pg_sys::PgNode for CreateExtensionStmt {}
 impl std::fmt::Display for CreateExtensionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFdwStmt {}
 impl pg_sys::PgNode for CreateFdwStmt {}
 impl std::fmt::Display for CreateFdwStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignServerStmt {}
 impl pg_sys::PgNode for CreateForeignServerStmt {}
 impl std::fmt::Display for CreateForeignServerStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateForeignTableStmt {}
 impl pg_sys::PgNode for CreateForeignTableStmt {}
 impl std::fmt::Display for CreateForeignTableStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateFunctionStmt {}
 impl pg_sys::PgNode for CreateFunctionStmt {}
 impl std::fmt::Display for CreateFunctionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassItem {}
 impl pg_sys::PgNode for CreateOpClassItem {}
 impl std::fmt::Display for CreateOpClassItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpClassStmt {}
 impl pg_sys::PgNode for CreateOpClassStmt {}
 impl std::fmt::Display for CreateOpClassStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateOpFamilyStmt {}
 impl pg_sys::PgNode for CreateOpFamilyStmt {}
 impl std::fmt::Display for CreateOpFamilyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePLangStmt {}
 impl pg_sys::PgNode for CreatePLangStmt {}
 impl std::fmt::Display for CreatePLangStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePolicyStmt {}
 impl pg_sys::PgNode for CreatePolicyStmt {}
 impl std::fmt::Display for CreatePolicyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatePublicationStmt {}
 impl pg_sys::PgNode for CreatePublicationStmt {}
 impl std::fmt::Display for CreatePublicationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRangeStmt {}
 impl pg_sys::PgNode for CreateRangeStmt {}
 impl std::fmt::Display for CreateRangeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateReplicationSlotCmd {}
 impl pg_sys::PgNode for CreateReplicationSlotCmd {}
 impl std::fmt::Display for CreateReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateRoleStmt {}
 impl pg_sys::PgNode for CreateRoleStmt {}
 impl std::fmt::Display for CreateRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSchemaStmt {}
 impl pg_sys::PgNode for CreateSchemaStmt {}
 impl std::fmt::Display for CreateSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSeqStmt {}
 impl pg_sys::PgNode for CreateSeqStmt {}
 impl std::fmt::Display for CreateSeqStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStatsStmt {}
 impl pg_sys::PgNode for CreateStatsStmt {}
 impl std::fmt::Display for CreateStatsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateStmt {}
 impl pg_sys::PgNode for CreateStmt {}
 impl std::fmt::Display for CreateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateSubscriptionStmt {}
 impl pg_sys::PgNode for CreateSubscriptionStmt {}
 impl std::fmt::Display for CreateSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableAsStmt {}
 impl pg_sys::PgNode for CreateTableAsStmt {}
 impl std::fmt::Display for CreateTableAsStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTableSpaceStmt {}
 impl pg_sys::PgNode for CreateTableSpaceStmt {}
 impl std::fmt::Display for CreateTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTransformStmt {}
 impl pg_sys::PgNode for CreateTransformStmt {}
 impl std::fmt::Display for CreateTransformStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateTrigStmt {}
 impl pg_sys::PgNode for CreateTrigStmt {}
 impl std::fmt::Display for CreateTrigStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreateUserMappingStmt {}
 impl pg_sys::PgNode for CreateUserMappingStmt {}
 impl std::fmt::Display for CreateUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CreatedbStmt {}
 impl pg_sys::PgNode for CreatedbStmt {}
 impl std::fmt::Display for CreatedbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScan {}
 impl pg_sys::PgNode for CteScan {}
 impl std::fmt::Display for CteScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CteScanState {}
 impl pg_sys::PgNode for CteScanState {}
 impl std::fmt::Display for CteScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CurrentOfExpr {}
 impl pg_sys::PgNode for CurrentOfExpr {}
 impl std::fmt::Display for CurrentOfExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomPath {}
 impl pg_sys::PgNode for CustomPath {}
 impl std::fmt::Display for CustomPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScan {}
 impl pg_sys::PgNode for CustomScan {}
 impl std::fmt::Display for CustomScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for CustomScanState {}
 impl pg_sys::PgNode for CustomScanState {}
 impl std::fmt::Display for CustomScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeallocateStmt {}
 impl pg_sys::PgNode for DeallocateStmt {}
 impl std::fmt::Display for DeallocateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeclareCursorStmt {}
 impl pg_sys::PgNode for DeclareCursorStmt {}
 impl std::fmt::Display for DeclareCursorStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefElem {}
 impl pg_sys::PgNode for DefElem {}
 impl std::fmt::Display for DefElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DefineStmt {}
 impl pg_sys::PgNode for DefineStmt {}
 impl std::fmt::Display for DefineStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DeleteStmt {}
 impl pg_sys::PgNode for DeleteStmt {}
 impl std::fmt::Display for DeleteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DiscardStmt {}
 impl pg_sys::PgNode for DiscardStmt {}
 impl std::fmt::Display for DiscardStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DoStmt {}
 impl pg_sys::PgNode for DoStmt {}
 impl std::fmt::Display for DoStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DomainConstraintState {}
 impl pg_sys::PgNode for DomainConstraintState {}
 impl std::fmt::Display for DomainConstraintState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropOwnedStmt {}
 impl pg_sys::PgNode for DropOwnedStmt {}
 impl std::fmt::Display for DropOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropReplicationSlotCmd {}
 impl pg_sys::PgNode for DropReplicationSlotCmd {}
 impl std::fmt::Display for DropReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropRoleStmt {}
 impl pg_sys::PgNode for DropRoleStmt {}
 impl std::fmt::Display for DropRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropStmt {}
 impl pg_sys::PgNode for DropStmt {}
 impl std::fmt::Display for DropStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropSubscriptionStmt {}
 impl pg_sys::PgNode for DropSubscriptionStmt {}
 impl std::fmt::Display for DropSubscriptionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropTableSpaceStmt {}
 impl pg_sys::PgNode for DropTableSpaceStmt {}
 impl std::fmt::Display for DropTableSpaceStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropUserMappingStmt {}
 impl pg_sys::PgNode for DropUserMappingStmt {}
 impl std::fmt::Display for DropUserMappingStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for DropdbStmt {}
 impl pg_sys::PgNode for DropdbStmt {}
 impl std::fmt::Display for DropdbStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EState {}
 impl pg_sys::PgNode for EState {}
 impl std::fmt::Display for EState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceClass {}
 impl pg_sys::PgNode for EquivalenceClass {}
 impl std::fmt::Display for EquivalenceClass {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EquivalenceMember {}
 impl pg_sys::PgNode for EquivalenceMember {}
 impl std::fmt::Display for EquivalenceMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for EventTriggerData {}
 impl pg_sys::PgNode for EventTriggerData {}
 impl std::fmt::Display for EventTriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExecuteStmt {}
 impl pg_sys::PgNode for ExecuteStmt {}
 impl std::fmt::Display for ExecuteStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExplainStmt {}
 impl pg_sys::PgNode for ExplainStmt {}
 impl std::fmt::Display for ExplainStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Expr {}
 impl pg_sys::PgNode for Expr {}
 impl std::fmt::Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprContext {}
 impl pg_sys::PgNode for ExprContext {}
 impl std::fmt::Display for ExprContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExprState {}
 impl pg_sys::PgNode for ExprState {}
 impl std::fmt::Display for ExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ExtensibleNode {}
 impl pg_sys::PgNode for ExtensibleNode {}
 impl std::fmt::Display for ExtensibleNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FdwRoutine {}
 impl pg_sys::PgNode for FdwRoutine {}
 impl std::fmt::Display for FdwRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FetchStmt {}
 impl pg_sys::PgNode for FetchStmt {}
 impl std::fmt::Display for FetchStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldSelect {}
 impl pg_sys::PgNode for FieldSelect {}
 impl std::fmt::Display for FieldSelect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FieldStore {}
 impl pg_sys::PgNode for FieldStore {}
 impl std::fmt::Display for FieldStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Float {}
 impl pg_sys::PgNode for Float {}
 impl std::fmt::Display for Float {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyCacheInfo {}
 impl pg_sys::PgNode for ForeignKeyCacheInfo {}
 impl std::fmt::Display for ForeignKeyCacheInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignKeyOptInfo {}
 impl pg_sys::PgNode for ForeignKeyOptInfo {}
 impl std::fmt::Display for ForeignKeyOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignPath {}
 impl pg_sys::PgNode for ForeignPath {}
 impl std::fmt::Display for ForeignPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScan {}
 impl pg_sys::PgNode for ForeignScan {}
 impl std::fmt::Display for ForeignScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ForeignScanState {}
 impl pg_sys::PgNode for ForeignScanState {}
 impl std::fmt::Display for ForeignScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FromExpr {}
 impl pg_sys::PgNode for FromExpr {}
 impl std::fmt::Display for FromExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncCall {}
 impl pg_sys::PgNode for FuncCall {}
 impl std::fmt::Display for FuncCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FuncExpr {}
 impl pg_sys::PgNode for FuncExpr {}
 impl std::fmt::Display for FuncExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionParameter {}
 impl pg_sys::PgNode for FunctionParameter {}
 impl std::fmt::Display for FunctionParameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScan {}
 impl pg_sys::PgNode for FunctionScan {}
 impl std::fmt::Display for FunctionScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for FunctionScanState {}
 impl pg_sys::PgNode for FunctionScanState {}
 impl std::fmt::Display for FunctionScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Gather {}
 impl pg_sys::PgNode for Gather {}
 impl std::fmt::Display for Gather {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMerge {}
 impl pg_sys::PgNode for GatherMerge {}
 impl std::fmt::Display for GatherMerge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergePath {}
 impl pg_sys::PgNode for GatherMergePath {}
 impl std::fmt::Display for GatherMergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherMergeState {}
 impl pg_sys::PgNode for GatherMergeState {}
 impl std::fmt::Display for GatherMergeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherPath {}
 impl pg_sys::PgNode for GatherPath {}
 impl std::fmt::Display for GatherPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GatherState {}
 impl pg_sys::PgNode for GatherState {}
 impl std::fmt::Display for GatherState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantRoleStmt {}
 impl pg_sys::PgNode for GrantRoleStmt {}
 impl std::fmt::Display for GrantRoleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GrantStmt {}
 impl pg_sys::PgNode for GrantStmt {}
 impl std::fmt::Display for GrantStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Group {}
 impl pg_sys::PgNode for Group {}
 impl std::fmt::Display for Group {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupPath {}
 impl pg_sys::PgNode for GroupPath {}
 impl std::fmt::Display for GroupPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupResultPath {}
 impl pg_sys::PgNode for GroupResultPath {}
 impl std::fmt::Display for GroupResultPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupState {}
 impl pg_sys::PgNode for GroupState {}
 impl std::fmt::Display for GroupState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingFunc {}
 impl pg_sys::PgNode for GroupingFunc {}
 impl std::fmt::Display for GroupingFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSet {}
 impl pg_sys::PgNode for GroupingSet {}
 impl std::fmt::Display for GroupingSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetData {}
 impl pg_sys::PgNode for GroupingSetData {}
 impl std::fmt::Display for GroupingSetData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for GroupingSetsPath {}
 impl pg_sys::PgNode for GroupingSetsPath {}
 impl std::fmt::Display for GroupingSetsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Hash {}
 impl pg_sys::PgNode for Hash {}
 impl std::fmt::Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoin {}
 impl pg_sys::PgNode for HashJoin {}
 impl std::fmt::Display for HashJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashJoinState {}
 impl pg_sys::PgNode for HashJoinState {}
 impl std::fmt::Display for HashJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashPath {}
 impl pg_sys::PgNode for HashPath {}
 impl std::fmt::Display for HashPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HashState {}
 impl pg_sys::PgNode for HashState {}
 impl std::fmt::Display for HashState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for HeapTupleTableSlot {}
 impl pg_sys::PgNode for HeapTupleTableSlot {}
 impl std::fmt::Display for HeapTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IdentifySystemCmd {}
 impl pg_sys::PgNode for IdentifySystemCmd {}
 impl std::fmt::Display for IdentifySystemCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ImportForeignSchemaStmt {}
 impl pg_sys::PgNode for ImportForeignSchemaStmt {}
 impl std::fmt::Display for ImportForeignSchemaStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSort {}
 impl pg_sys::PgNode for IncrementalSort {}
 impl std::fmt::Display for IncrementalSort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSortPath {}
 impl pg_sys::PgNode for IncrementalSortPath {}
 impl std::fmt::Display for IncrementalSortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IncrementalSortState {}
 impl pg_sys::PgNode for IncrementalSortState {}
 impl std::fmt::Display for IncrementalSortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexAmRoutine {}
 impl pg_sys::PgNode for IndexAmRoutine {}
 impl std::fmt::Display for IndexAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexClause {}
 impl pg_sys::PgNode for IndexClause {}
 impl std::fmt::Display for IndexClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexElem {}
 impl pg_sys::PgNode for IndexElem {}
 impl std::fmt::Display for IndexElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexInfo {}
 impl pg_sys::PgNode for IndexInfo {}
 impl std::fmt::Display for IndexInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScan {}
 impl pg_sys::PgNode for IndexOnlyScan {}
 impl std::fmt::Display for IndexOnlyScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOnlyScanState {}
 impl pg_sys::PgNode for IndexOnlyScanState {}
 impl std::fmt::Display for IndexOnlyScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexOptInfo {}
 impl pg_sys::PgNode for IndexOptInfo {}
 impl std::fmt::Display for IndexOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexPath {}
 impl pg_sys::PgNode for IndexPath {}
 impl std::fmt::Display for IndexPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScan {}
 impl pg_sys::PgNode for IndexScan {}
 impl std::fmt::Display for IndexScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexScanState {}
 impl pg_sys::PgNode for IndexScanState {}
 impl std::fmt::Display for IndexScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IndexStmt {}
 impl pg_sys::PgNode for IndexStmt {}
 impl std::fmt::Display for IndexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferClause {}
 impl pg_sys::PgNode for InferClause {}
 impl std::fmt::Display for InferClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InferenceElem {}
 impl pg_sys::PgNode for InferenceElem {}
 impl std::fmt::Display for InferenceElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InlineCodeBlock {}
 impl pg_sys::PgNode for InlineCodeBlock {}
 impl std::fmt::Display for InlineCodeBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for InsertStmt {}
 impl pg_sys::PgNode for InsertStmt {}
 impl std::fmt::Display for InsertStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Integer {}
 impl pg_sys::PgNode for Integer {}
 impl std::fmt::Display for Integer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for IntoClause {}
 impl pg_sys::PgNode for IntoClause {}
 impl std::fmt::Display for IntoClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Join {}
 impl pg_sys::PgNode for Join {}
 impl std::fmt::Display for Join {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinExpr {}
 impl pg_sys::PgNode for JoinExpr {}
 impl std::fmt::Display for JoinExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinPath {}
 impl pg_sys::PgNode for JoinPath {}
 impl std::fmt::Display for JoinPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JoinState {}
 impl pg_sys::PgNode for JoinState {}
 impl std::fmt::Display for JoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for JunkFilter {}
 impl pg_sys::PgNode for JunkFilter {}
 impl std::fmt::Display for JunkFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Limit {}
 impl pg_sys::PgNode for Limit {}
 impl std::fmt::Display for Limit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitPath {}
 impl pg_sys::PgNode for LimitPath {}
 impl std::fmt::Display for LimitPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LimitState {}
 impl pg_sys::PgNode for LimitState {}
 impl std::fmt::Display for LimitState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for List {}
 impl pg_sys::PgNode for List {}
 impl std::fmt::Display for List {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ListenStmt {}
 impl pg_sys::PgNode for ListenStmt {}
 impl std::fmt::Display for ListenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LoadStmt {}
 impl pg_sys::PgNode for LoadStmt {}
 impl std::fmt::Display for LoadStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRows {}
 impl pg_sys::PgNode for LockRows {}
 impl std::fmt::Display for LockRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsPath {}
 impl pg_sys::PgNode for LockRowsPath {}
 impl std::fmt::Display for LockRowsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockRowsState {}
 impl pg_sys::PgNode for LockRowsState {}
 impl std::fmt::Display for LockRowsState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockStmt {}
 impl pg_sys::PgNode for LockStmt {}
 impl std::fmt::Display for LockStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for LockingClause {}
 impl pg_sys::PgNode for LockingClause {}
 impl std::fmt::Display for LockingClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Material {}
 impl pg_sys::PgNode for Material {}
 impl std::fmt::Display for Material {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialPath {}
 impl pg_sys::PgNode for MaterialPath {}
 impl std::fmt::Display for MaterialPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MaterialState {}
 impl pg_sys::PgNode for MaterialState {}
 impl std::fmt::Display for MaterialState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Memoize {}
 impl pg_sys::PgNode for Memoize {}
 impl std::fmt::Display for Memoize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoizePath {}
 impl pg_sys::PgNode for MemoizePath {}
 impl std::fmt::Display for MemoizePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoizeState {}
 impl pg_sys::PgNode for MemoizeState {}
 impl std::fmt::Display for MemoizeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MemoryContextData {}
 impl pg_sys::PgNode for MemoryContextData {}
 impl std::fmt::Display for MemoryContextData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAction {}
 impl pg_sys::PgNode for MergeAction {}
 impl std::fmt::Display for MergeAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeActionState {}
 impl pg_sys::PgNode for MergeActionState {}
 impl std::fmt::Display for MergeActionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppend {}
 impl pg_sys::PgNode for MergeAppend {}
 impl std::fmt::Display for MergeAppend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendPath {}
 impl pg_sys::PgNode for MergeAppendPath {}
 impl std::fmt::Display for MergeAppendPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeAppendState {}
 impl pg_sys::PgNode for MergeAppendState {}
 impl std::fmt::Display for MergeAppendState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoin {}
 impl pg_sys::PgNode for MergeJoin {}
 impl std::fmt::Display for MergeJoin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeJoinState {}
 impl pg_sys::PgNode for MergeJoinState {}
 impl std::fmt::Display for MergeJoinState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergePath {}
 impl pg_sys::PgNode for MergePath {}
 impl std::fmt::Display for MergePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeStmt {}
 impl pg_sys::PgNode for MergeStmt {}
 impl std::fmt::Display for MergeStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MergeWhenClause {}
 impl pg_sys::PgNode for MergeWhenClause {}
 impl std::fmt::Display for MergeWhenClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggInfo {}
 impl pg_sys::PgNode for MinMaxAggInfo {}
 impl std::fmt::Display for MinMaxAggInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxAggPath {}
 impl pg_sys::PgNode for MinMaxAggPath {}
 impl std::fmt::Display for MinMaxAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinMaxExpr {}
 impl pg_sys::PgNode for MinMaxExpr {}
 impl std::fmt::Display for MinMaxExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MinimalTupleTableSlot {}
 impl pg_sys::PgNode for MinimalTupleTableSlot {}
 impl std::fmt::Display for MinimalTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTable {}
 impl pg_sys::PgNode for ModifyTable {}
 impl std::fmt::Display for ModifyTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTablePath {}
 impl pg_sys::PgNode for ModifyTablePath {}
 impl std::fmt::Display for ModifyTablePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ModifyTableState {}
 impl pg_sys::PgNode for ModifyTableState {}
 impl std::fmt::Display for ModifyTableState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for MultiAssignRef {}
 impl pg_sys::PgNode for MultiAssignRef {}
 impl std::fmt::Display for MultiAssignRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedArgExpr {}
 impl pg_sys::PgNode for NamedArgExpr {}
 impl std::fmt::Display for NamedArgExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScan {}
 impl pg_sys::PgNode for NamedTuplestoreScan {}
 impl std::fmt::Display for NamedTuplestoreScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NamedTuplestoreScanState {}
 impl pg_sys::PgNode for NamedTuplestoreScanState {}
 impl std::fmt::Display for NamedTuplestoreScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoop {}
 impl pg_sys::PgNode for NestLoop {}
 impl std::fmt::Display for NestLoop {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopParam {}
 impl pg_sys::PgNode for NestLoopParam {}
 impl std::fmt::Display for NestLoopParam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestLoopState {}
 impl pg_sys::PgNode for NestLoopState {}
 impl std::fmt::Display for NestLoopState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NestPath {}
 impl pg_sys::PgNode for NestPath {}
 impl std::fmt::Display for NestPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NextValueExpr {}
 impl pg_sys::PgNode for NextValueExpr {}
 impl std::fmt::Display for NextValueExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Node {}
 impl pg_sys::PgNode for Node {}
 impl std::fmt::Display for Node {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NotifyStmt {}
 impl pg_sys::PgNode for NotifyStmt {}
 impl std::fmt::Display for NotifyStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for NullTest {}
 impl pg_sys::PgNode for NullTest {}
 impl std::fmt::Display for NullTest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ObjectWithArgs {}
 impl pg_sys::PgNode for ObjectWithArgs {}
 impl std::fmt::Display for ObjectWithArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictClause {}
 impl pg_sys::PgNode for OnConflictClause {}
 impl std::fmt::Display for OnConflictClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictExpr {}
 impl pg_sys::PgNode for OnConflictExpr {}
 impl std::fmt::Display for OnConflictExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OnConflictSetState {}
 impl pg_sys::PgNode for OnConflictSetState {}
 impl std::fmt::Display for OnConflictSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for OpExpr {}
 impl pg_sys::PgNode for OpExpr {}
 impl std::fmt::Display for OpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PLAssignStmt {}
 impl pg_sys::PgNode for PLAssignStmt {}
 impl std::fmt::Display for PLAssignStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Param {}
 impl pg_sys::PgNode for Param {}
 impl std::fmt::Display for Param {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamPathInfo {}
 impl pg_sys::PgNode for ParamPathInfo {}
 impl std::fmt::Display for ParamPathInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ParamRef {}
 impl pg_sys::PgNode for ParamRef {}
 impl std::fmt::Display for ParamRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionBoundSpec {}
 impl pg_sys::PgNode for PartitionBoundSpec {}
 impl std::fmt::Display for PartitionBoundSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionCmd {}
 impl pg_sys::PgNode for PartitionCmd {}
 impl std::fmt::Display for PartitionCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionElem {}
 impl pg_sys::PgNode for PartitionElem {}
 impl std::fmt::Display for PartitionElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneInfo {}
 impl pg_sys::PgNode for PartitionPruneInfo {}
 impl std::fmt::Display for PartitionPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStep {}
 impl pg_sys::PgNode for PartitionPruneStep {}
 impl std::fmt::Display for PartitionPruneStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepCombine {}
 impl pg_sys::PgNode for PartitionPruneStepCombine {}
 impl std::fmt::Display for PartitionPruneStepCombine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionPruneStepOp {}
 impl pg_sys::PgNode for PartitionPruneStepOp {}
 impl std::fmt::Display for PartitionPruneStepOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionRangeDatum {}
 impl pg_sys::PgNode for PartitionRangeDatum {}
 impl std::fmt::Display for PartitionRangeDatum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionSpec {}
 impl pg_sys::PgNode for PartitionSpec {}
 impl std::fmt::Display for PartitionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PartitionedRelPruneInfo {}
 impl pg_sys::PgNode for PartitionedRelPruneInfo {}
 impl std::fmt::Display for PartitionedRelPruneInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Path {}
 impl pg_sys::PgNode for Path {}
 impl std::fmt::Display for Path {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathKey {}
 impl pg_sys::PgNode for PathKey {}
 impl std::fmt::Display for PathKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PathTarget {}
 impl pg_sys::PgNode for PathTarget {}
 impl std::fmt::Display for PathTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderInfo {}
 impl pg_sys::PgNode for PlaceHolderInfo {}
 impl std::fmt::Display for PlaceHolderInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlaceHolderVar {}
 impl pg_sys::PgNode for PlaceHolderVar {}
 impl std::fmt::Display for PlaceHolderVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Plan {}
 impl pg_sys::PgNode for Plan {}
 impl std::fmt::Display for Plan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanInvalItem {}
 impl pg_sys::PgNode for PlanInvalItem {}
 impl std::fmt::Display for PlanInvalItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanRowMark {}
 impl pg_sys::PgNode for PlanRowMark {}
 impl std::fmt::Display for PlanRowMark {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlanState {}
 impl pg_sys::PgNode for PlanState {}
 impl std::fmt::Display for PlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannedStmt {}
 impl pg_sys::PgNode for PlannedStmt {}
 impl std::fmt::Display for PlannedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerGlobal {}
 impl pg_sys::PgNode for PlannerGlobal {}
 impl std::fmt::Display for PlannerGlobal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerInfo {}
 impl pg_sys::PgNode for PlannerInfo {}
 impl std::fmt::Display for PlannerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PlannerParamItem {}
 impl pg_sys::PgNode for PlannerParamItem {}
 impl std::fmt::Display for PlannerParamItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PrepareStmt {}
 impl pg_sys::PgNode for PrepareStmt {}
 impl std::fmt::Display for PrepareStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSet {}
 impl pg_sys::PgNode for ProjectSet {}
 impl std::fmt::Display for ProjectSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetPath {}
 impl pg_sys::PgNode for ProjectSetPath {}
 impl std::fmt::Display for ProjectSetPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectSetState {}
 impl pg_sys::PgNode for ProjectSetState {}
 impl std::fmt::Display for ProjectSetState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionInfo {}
 impl pg_sys::PgNode for ProjectionInfo {}
 impl std::fmt::Display for ProjectionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ProjectionPath {}
 impl pg_sys::PgNode for ProjectionPath {}
 impl std::fmt::Display for ProjectionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PublicationObjSpec {}
 impl pg_sys::PgNode for PublicationObjSpec {}
 impl std::fmt::Display for PublicationObjSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for PublicationTable {}
 impl pg_sys::PgNode for PublicationTable {}
 impl std::fmt::Display for PublicationTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Query {}
 impl pg_sys::PgNode for Query {}
 impl std::fmt::Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeFunction {}
 impl pg_sys::PgNode for RangeFunction {}
 impl std::fmt::Display for RangeFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeSubselect {}
 impl pg_sys::PgNode for RangeSubselect {}
 impl std::fmt::Display for RangeSubselect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFunc {}
 impl pg_sys::PgNode for RangeTableFunc {}
 impl std::fmt::Display for RangeTableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableFuncCol {}
 impl pg_sys::PgNode for RangeTableFuncCol {}
 impl std::fmt::Display for RangeTableFuncCol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTableSample {}
 impl pg_sys::PgNode for RangeTableSample {}
 impl std::fmt::Display for RangeTableSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblEntry {}
 impl pg_sys::PgNode for RangeTblEntry {}
 impl std::fmt::Display for RangeTblEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblFunction {}
 impl pg_sys::PgNode for RangeTblFunction {}
 impl std::fmt::Display for RangeTblFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeTblRef {}
 impl pg_sys::PgNode for RangeTblRef {}
 impl std::fmt::Display for RangeTblRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RangeVar {}
 impl pg_sys::PgNode for RangeVar {}
 impl std::fmt::Display for RangeVar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RawStmt {}
 impl pg_sys::PgNode for RawStmt {}
 impl std::fmt::Display for RawStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReadReplicationSlotCmd {}
 impl pg_sys::PgNode for ReadReplicationSlotCmd {}
 impl std::fmt::Display for ReadReplicationSlotCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReassignOwnedStmt {}
 impl pg_sys::PgNode for ReassignOwnedStmt {}
 impl std::fmt::Display for ReassignOwnedStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnion {}
 impl pg_sys::PgNode for RecursiveUnion {}
 impl std::fmt::Display for RecursiveUnion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionPath {}
 impl pg_sys::PgNode for RecursiveUnionPath {}
 impl std::fmt::Display for RecursiveUnionPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RecursiveUnionState {}
 impl pg_sys::PgNode for RecursiveUnionState {}
 impl std::fmt::Display for RecursiveUnionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RefreshMatViewStmt {}
 impl pg_sys::PgNode for RefreshMatViewStmt {}
 impl std::fmt::Display for RefreshMatViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReindexStmt {}
 impl pg_sys::PgNode for ReindexStmt {}
 impl std::fmt::Display for ReindexStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelOptInfo {}
 impl pg_sys::PgNode for RelOptInfo {}
 impl std::fmt::Display for RelOptInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RelabelType {}
 impl pg_sys::PgNode for RelabelType {}
 impl std::fmt::Display for RelabelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RenameStmt {}
 impl pg_sys::PgNode for RenameStmt {}
 impl std::fmt::Display for RenameStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReplicaIdentityStmt {}
 impl pg_sys::PgNode for ReplicaIdentityStmt {}
 impl std::fmt::Display for ReplicaIdentityStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResTarget {}
 impl pg_sys::PgNode for ResTarget {}
 impl std::fmt::Display for ResTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RestrictInfo {}
 impl pg_sys::PgNode for RestrictInfo {}
 impl std::fmt::Display for RestrictInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Result {}
 impl pg_sys::PgNode for Result {}
 impl std::fmt::Display for Result {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultRelInfo {}
 impl pg_sys::PgNode for ResultRelInfo {}
 impl std::fmt::Display for ResultRelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ResultState {}
 impl pg_sys::PgNode for ResultState {}
 impl std::fmt::Display for ResultState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReturnSetInfo {}
 impl pg_sys::PgNode for ReturnSetInfo {}
 impl std::fmt::Display for ReturnSetInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ReturnStmt {}
 impl pg_sys::PgNode for ReturnStmt {}
 impl std::fmt::Display for ReturnStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RoleSpec {}
 impl pg_sys::PgNode for RoleSpec {}
 impl std::fmt::Display for RoleSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RollupData {}
 impl pg_sys::PgNode for RollupData {}
 impl std::fmt::Display for RollupData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowCompareExpr {}
 impl pg_sys::PgNode for RowCompareExpr {}
 impl std::fmt::Display for RowCompareExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowExpr {}
 impl pg_sys::PgNode for RowExpr {}
 impl std::fmt::Display for RowExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowIdentityVarInfo {}
 impl pg_sys::PgNode for RowIdentityVarInfo {}
 impl std::fmt::Display for RowIdentityVarInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RowMarkClause {}
 impl pg_sys::PgNode for RowMarkClause {}
 impl std::fmt::Display for RowMarkClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for RuleStmt {}
 impl pg_sys::PgNode for RuleStmt {}
 impl std::fmt::Display for RuleStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SQLValueFunction {}
 impl pg_sys::PgNode for SQLValueFunction {}
 impl std::fmt::Display for SQLValueFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScan {}
 impl pg_sys::PgNode for SampleScan {}
 impl std::fmt::Display for SampleScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SampleScanState {}
 impl pg_sys::PgNode for SampleScanState {}
 impl std::fmt::Display for SampleScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScalarArrayOpExpr {}
 impl pg_sys::PgNode for ScalarArrayOpExpr {}
 impl std::fmt::Display for ScalarArrayOpExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Scan {}
 impl pg_sys::PgNode for Scan {}
 impl std::fmt::Display for Scan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ScanState {}
 impl pg_sys::PgNode for ScanState {}
 impl std::fmt::Display for ScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SecLabelStmt {}
 impl pg_sys::PgNode for SecLabelStmt {}
 impl std::fmt::Display for SecLabelStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SelectStmt {}
 impl pg_sys::PgNode for SelectStmt {}
 impl std::fmt::Display for SelectStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SeqScan {}
 impl pg_sys::PgNode for SeqScan {}
 impl std::fmt::Display for SeqScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SeqScanState {}
 impl pg_sys::PgNode for SeqScanState {}
 impl std::fmt::Display for SeqScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetExprState {}
 impl pg_sys::PgNode for SetExprState {}
 impl std::fmt::Display for SetExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOp {}
 impl pg_sys::PgNode for SetOp {}
 impl std::fmt::Display for SetOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpPath {}
 impl pg_sys::PgNode for SetOpPath {}
 impl std::fmt::Display for SetOpPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOpState {}
 impl pg_sys::PgNode for SetOpState {}
 impl std::fmt::Display for SetOpState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetOperationStmt {}
 impl pg_sys::PgNode for SetOperationStmt {}
 impl std::fmt::Display for SetOperationStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SetToDefault {}
 impl pg_sys::PgNode for SetToDefault {}
 impl std::fmt::Display for SetToDefault {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Sort {}
 impl pg_sys::PgNode for Sort {}
 impl std::fmt::Display for Sort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortBy {}
 impl pg_sys::PgNode for SortBy {}
 impl std::fmt::Display for SortBy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortGroupClause {}
 impl pg_sys::PgNode for SortGroupClause {}
 impl std::fmt::Display for SortGroupClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortPath {}
 impl pg_sys::PgNode for SortPath {}
 impl std::fmt::Display for SortPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SortState {}
 impl pg_sys::PgNode for SortState {}
 impl std::fmt::Display for SortState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SpecialJoinInfo {}
 impl pg_sys::PgNode for SpecialJoinInfo {}
 impl std::fmt::Display for SpecialJoinInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StartReplicationCmd {}
 impl pg_sys::PgNode for StartReplicationCmd {}
 impl std::fmt::Display for StartReplicationCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StatisticExtInfo {}
 impl pg_sys::PgNode for StatisticExtInfo {}
 impl std::fmt::Display for StatisticExtInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for StatsElem {}
 impl pg_sys::PgNode for StatsElem {}
 impl std::fmt::Display for StatsElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for String {}
 impl pg_sys::PgNode for String {}
 impl std::fmt::Display for String {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubLink {}
 impl pg_sys::PgNode for SubLink {}
 impl std::fmt::Display for SubLink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlan {}
 impl pg_sys::PgNode for SubPlan {}
 impl std::fmt::Display for SubPlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubPlanState {}
 impl pg_sys::PgNode for SubPlanState {}
 impl std::fmt::Display for SubPlanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScan {}
 impl pg_sys::PgNode for SubqueryScan {}
 impl std::fmt::Display for SubqueryScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanPath {}
 impl pg_sys::PgNode for SubqueryScanPath {}
 impl std::fmt::Display for SubqueryScanPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubqueryScanState {}
 impl pg_sys::PgNode for SubqueryScanState {}
 impl std::fmt::Display for SubqueryScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SubscriptingRef {}
 impl pg_sys::PgNode for SubscriptingRef {}
 impl std::fmt::Display for SubscriptingRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestCost {}
 impl pg_sys::PgNode for SupportRequestCost {}
 impl std::fmt::Display for SupportRequestCost {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestIndexCondition {}
 impl pg_sys::PgNode for SupportRequestIndexCondition {}
 impl std::fmt::Display for SupportRequestIndexCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestRows {}
 impl pg_sys::PgNode for SupportRequestRows {}
 impl std::fmt::Display for SupportRequestRows {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSelectivity {}
 impl pg_sys::PgNode for SupportRequestSelectivity {}
 impl std::fmt::Display for SupportRequestSelectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestSimplify {}
 impl pg_sys::PgNode for SupportRequestSimplify {}
 impl std::fmt::Display for SupportRequestSimplify {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for SupportRequestWFuncMonotonic {}
 impl pg_sys::PgNode for SupportRequestWFuncMonotonic {}
 impl std::fmt::Display for SupportRequestWFuncMonotonic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableAmRoutine {}
 impl pg_sys::PgNode for TableAmRoutine {}
 impl std::fmt::Display for TableAmRoutine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFunc {}
 impl pg_sys::PgNode for TableFunc {}
 impl std::fmt::Display for TableFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScan {}
 impl pg_sys::PgNode for TableFuncScan {}
 impl std::fmt::Display for TableFuncScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableFuncScanState {}
 impl pg_sys::PgNode for TableFuncScanState {}
 impl std::fmt::Display for TableFuncScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableLikeClause {}
 impl pg_sys::PgNode for TableLikeClause {}
 impl std::fmt::Display for TableLikeClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TableSampleClause {}
 impl pg_sys::PgNode for TableSampleClause {}
 impl std::fmt::Display for TableSampleClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TargetEntry {}
 impl pg_sys::PgNode for TargetEntry {}
 impl std::fmt::Display for TargetEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidPath {}
 impl pg_sys::PgNode for TidPath {}
 impl std::fmt::Display for TidPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidRangePath {}
 impl pg_sys::PgNode for TidRangePath {}
 impl std::fmt::Display for TidRangePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidRangeScan {}
 impl pg_sys::PgNode for TidRangeScan {}
 impl std::fmt::Display for TidRangeScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidRangeScanState {}
 impl pg_sys::PgNode for TidRangeScanState {}
 impl std::fmt::Display for TidRangeScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScan {}
 impl pg_sys::PgNode for TidScan {}
 impl std::fmt::Display for TidScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TidScanState {}
 impl pg_sys::PgNode for TidScanState {}
 impl std::fmt::Display for TidScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TimeLineHistoryCmd {}
 impl pg_sys::PgNode for TimeLineHistoryCmd {}
 impl std::fmt::Display for TimeLineHistoryCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TransactionStmt {}
 impl pg_sys::PgNode for TransactionStmt {}
 impl std::fmt::Display for TransactionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerData {}
 impl pg_sys::PgNode for TriggerData {}
 impl std::fmt::Display for TriggerData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TriggerTransition {}
 impl pg_sys::PgNode for TriggerTransition {}
 impl std::fmt::Display for TriggerTransition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TruncateStmt {}
 impl pg_sys::PgNode for TruncateStmt {}
 impl std::fmt::Display for TruncateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TupleTableSlot {}
 impl pg_sys::PgNode for TupleTableSlot {}
 impl std::fmt::Display for TupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeCast {}
 impl pg_sys::PgNode for TypeCast {}
 impl std::fmt::Display for TypeCast {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for TypeName {}
 impl pg_sys::PgNode for TypeName {}
 impl std::fmt::Display for TypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Unique {}
 impl pg_sys::PgNode for Unique {}
 impl std::fmt::Display for Unique {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniquePath {}
 impl pg_sys::PgNode for UniquePath {}
 impl std::fmt::Display for UniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UniqueState {}
 impl pg_sys::PgNode for UniqueState {}
 impl std::fmt::Display for UniqueState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UnlistenStmt {}
 impl pg_sys::PgNode for UnlistenStmt {}
 impl std::fmt::Display for UnlistenStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpdateStmt {}
 impl pg_sys::PgNode for UpdateStmt {}
 impl std::fmt::Display for UpdateStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for UpperUniquePath {}
 impl pg_sys::PgNode for UpperUniquePath {}
 impl std::fmt::Display for UpperUniquePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumRelation {}
 impl pg_sys::PgNode for VacuumRelation {}
 impl std::fmt::Display for VacuumRelation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VacuumStmt {}
 impl pg_sys::PgNode for VacuumStmt {}
 impl std::fmt::Display for VacuumStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScan {}
 impl pg_sys::PgNode for ValuesScan {}
 impl std::fmt::Display for ValuesScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ValuesScanState {}
 impl pg_sys::PgNode for ValuesScanState {}
 impl std::fmt::Display for ValuesScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for Var {}
 impl pg_sys::PgNode for Var {}
 impl std::fmt::Display for Var {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableSetStmt {}
 impl pg_sys::PgNode for VariableSetStmt {}
 impl std::fmt::Display for VariableSetStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VariableShowStmt {}
 impl pg_sys::PgNode for VariableShowStmt {}
 impl std::fmt::Display for VariableShowStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for ViewStmt {}
 impl pg_sys::PgNode for ViewStmt {}
 impl std::fmt::Display for ViewStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for VirtualTupleTableSlot {}
 impl pg_sys::PgNode for VirtualTupleTableSlot {}
 impl std::fmt::Display for VirtualTupleTableSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAgg {}
 impl pg_sys::PgNode for WindowAgg {}
 impl std::fmt::Display for WindowAgg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggPath {}
 impl pg_sys::PgNode for WindowAggPath {}
 impl std::fmt::Display for WindowAggPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowAggState {}
 impl pg_sys::PgNode for WindowAggState {}
 impl std::fmt::Display for WindowAggState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowClause {}
 impl pg_sys::PgNode for WindowClause {}
 impl std::fmt::Display for WindowClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowDef {}
 impl pg_sys::PgNode for WindowDef {}
 impl std::fmt::Display for WindowDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFunc {}
 impl pg_sys::PgNode for WindowFunc {}
 impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WindowFuncExprState {}
 impl pg_sys::PgNode for WindowFuncExprState {}
 impl std::fmt::Display for WindowFuncExprState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithCheckOption {}
 impl pg_sys::PgNode for WithCheckOption {}
 impl std::fmt::Display for WithCheckOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WithClause {}
 impl pg_sys::PgNode for WithClause {}
 impl std::fmt::Display for WithClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScan {}
 impl pg_sys::PgNode for WorkTableScan {}
 impl std::fmt::Display for WorkTableScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for WorkTableScanState {}
 impl pg_sys::PgNode for WorkTableScanState {}
 impl std::fmt::Display for WorkTableScanState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlExpr {}
 impl pg_sys::PgNode for XmlExpr {}
 impl std::fmt::Display for XmlExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_node())
     }
 }
+impl pg_sys::seal::Sealed for XmlSerialize {}
 impl pg_sys::PgNode for XmlSerialize {}
 impl std::fmt::Display for XmlSerialize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgx'-based Postgres extensions"
@@ -34,13 +34,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 owo-colors = "3.5.0"
 once_cell = "1.16.0"
 libc = "0.2.137"
-pgx-macros = { path = "../pgx-macros", version = "=0.6.0-alpha.2" }
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.6.0-alpha.2" }
-pgx-utils = { path = "../pgx-utils", version = "=0.6.0-alpha.2" }
+pgx-macros = { path = "../pgx-macros", version = "=0.6.0" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.6.0" }
+pgx-utils = { path = "../pgx-utils", version = "=0.6.0" }
 postgres = "0.19.4"
 regex = "1.7.0"
-serde = "1.0.147"
-serde_json = "1.0.88"
+serde = "1.0.148"
+serde_json = "1.0.89"
 time = "0.3.17"
 eyre = "0.6.8"
 thiserror = "1.0"
@@ -49,4 +49,4 @@ thiserror = "1.0"
 path = "../pgx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.6.0-alpha.2"
+version = "=0.6.0"

--- a/pgx-utils/Cargo.toml
+++ b/pgx-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-utils"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Utility functions for 'pgx'"
@@ -24,10 +24,10 @@ petgraph = "0.6.2"
 proc-macro2 = { version = "1.0.47", features = [ "span-locations" ] }
 quote = "1.0.21"
 regex = "1.7.0"
-serde = { version = "1.0.147", features = [ "derive" ] }
-serde_derive = "1.0.147"
-serde_json = "1.0.88"
-syn = { version = "1.0.103", features = [ "extra-traits", "full", "fold", "parsing" ] }
+serde = { version = "1.0.148", features = [ "derive" ] }
+serde_derive = "1.0.148"
+serde_json = "1.0.89"
+syn = { version = "1.0.104", features = [ "extra-traits", "full", "fold", "parsing" ] }
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"], optional = true }
 unescape = "0.1.0"
 tracing = "0.1.37"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgx:  A Rust framework for creating Postgres extensions"
@@ -33,9 +33,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-macros = { path = "../pgx-macros/", version = "=0.6.0-alpha.2" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.6.0-alpha.2" }
-pgx-utils = { path = "../pgx-utils/", version = "=0.6.0-alpha.2" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.6.0" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.6.0" }
+pgx-utils = { path = "../pgx-utils/", version = "=0.6.0" }
 
 # used to internally impl things
 once_cell = "1.16.0" # polyfill until std::lazy::OnceCell stabilizes
@@ -57,8 +57,8 @@ cstr_core = "0.2.6" # no std compat
 heapless = "0.7.16" # shmem and PgLwLock
 libc = "0.2.137" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
-serde = { version = "1.0.147", features = [ "derive" ] } # impls on pub types
+serde = { version = "1.0.148", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
-serde_json = "1.0.88" # everything JSON
+serde_json = "1.0.89" # everything JSON
 time = { version = "0.3.17", features = ["formatting", "parsing", "alloc", "macros"], optional = true }
 


### PR DESCRIPTION
This is the full release of pgx 0.6.0!
Remember to `cargo install cargo-pgx --locked --version 0.6.0`!

# Postgres major version changes
As a reminder, we have dropped support for Postgres 10 and added support for Postgres 15! Please see our full release notes to get an overview of all changes between 0.5.6 and 0.6.0!

# Documentation updates

A fair amount of PGX documentation got some polish. Among those changes, thanks to @MaxKingPor we found the macro docs still mentioned `impl Iterator`! It now recommends `TableIterator` appropriately. Please let us know if you find any issues with the PGX documentation or have a question!

# Safety

We're continuing to make various changes internally to improve PGX's soundness. One more visible to users, but technically not a break in the API, is that thanks to @eeeebbbbrrrr in  https://github.com/tcdi/pgx/pull/893 we now require ereports happen on the "main thread". As a reminder, Postgres is single-threaded, so PGX does not function well in the multithreading situation.

# Compatibility

PGX's now should automatically set a locale it finds useful for DBs it creates (mostly for testing purposes) on every OS it currently functions on thanks to @Smittyvb in https://github.com/tcdi/pgx/pull/884!

# Breaking Changes

## `time-crate`
Thanks to @workingjubilee, you can now opt in or out of the `time` crate as a dependency using 
```
pgx = { version = "0.6.0", features = "time-crate" }
```

## `PgNode` is now sealed
This probably won't affect most users, but `PgNode` is now a "sealed trait", preventing you from implementing it on things. Sorry! PGX relies on the soundness of its implementation, and probably will rely on that more in the future.

## `SpiClient` now discourages misuse
@yrashk and @thomcc have significantly revised the way that `SpiClient` works, although a lot of users won't notice a difference. It now uses a scoped lifetime, existing as more of a consumable token, rather than something you can just arbitrarily instantiate. Also see:
  - https://github.com/tcdi/pgx/pull/896
  - https://github.com/tcdi/pgx/pull/897
  - https://github.com/tcdi/pgx/pull/898
  - https://github.com/tcdi/pgx/pull/900

## `PgRelation` will promise less

Rust functions that are safe should not cause UB with arbitrary inputs, so @workingjubilee made `PgRelation::with_lock` unsafe in https://github.com/tcdi/pgx/pull/886. Thanks to @JohnHVancouver for catching that one!

**Full Changelog**: https://github.com/tcdi/pgx/compare/v0.6.0-alpha.2...v0.6.0