### PR TITLE
cleanup cargo-pgx handling of the `--profile` argument

### DIFF
--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -63,7 +63,10 @@ impl CommandExecute for Install {
             Some(config) => PgConfig::new_with_defaults(PathBuf::from(config)),
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
-        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
+        let profile = CargoProfile::from_flags(
+            self.profile.as_deref(),
+            self.release.then_some(CargoProfile::Release).unwrap_or(CargoProfile::Dev),
+        )?;
 
         let features =
             crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -68,7 +68,7 @@ impl CommandExecute for Package {
             crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
         let profile = CargoProfile::from_flags(
             self.profile.as_deref(),
-            // NB:  `cargo pgx profile` defaults to "--release" whereas all other commands default to "debug"
+            // NB:  `cargo pgx package` defaults to "--release" whereas all other commands default to "debug"
             self.debug.then_some(CargoProfile::Dev).unwrap_or(CargoProfile::Release),
         )?;
         let out_dir = if let Some(out_dir) = self.out_dir {

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -66,7 +66,11 @@ impl CommandExecute for Package {
 
         let features =
             crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
-        let profile = CargoProfile::from_flags(!self.debug, self.profile.as_deref())?;
+        let profile = CargoProfile::from_flags(
+            self.profile.as_deref(),
+            // NB:  `cargo pgx profile` defaults to "--release" whereas all other commands default to "debug"
+            self.debug.then_some(CargoProfile::Dev).unwrap_or(CargoProfile::Release),
+        )?;
         let out_dir = if let Some(out_dir) = self.out_dir {
             out_dir
         } else {

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -97,7 +97,10 @@ impl CommandExecute for Run {
             None => get_property(&package_manifest_path, "extname")?
                 .ok_or(eyre!("could not determine extension name"))?,
         };
-        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
+        let profile = CargoProfile::from_flags(
+            self.profile.as_deref(),
+            self.release.then_some(CargoProfile::Release).unwrap_or(CargoProfile::Dev),
+        )?;
 
         run(
             pg_config,

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -118,7 +118,10 @@ impl CommandExecute for Schema {
         let features =
             crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
 
-        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
+        let profile = CargoProfile::from_flags(
+            self.profile.as_deref(),
+            self.release.then_some(CargoProfile::Release).unwrap_or(CargoProfile::Dev),
+        )?;
 
         generate_schema(
             &pg_config,

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -65,7 +65,10 @@ impl CommandExecute for Test {
             None => crate::manifest::default_pg_version(&package_manifest)
                 .ok_or(eyre!("No provided `pg$VERSION` flag."))?,
         };
-        let profile = CargoProfile::from_flags(self.release, self.profile.as_deref())?;
+        let profile = CargoProfile::from_flags(
+            self.profile.as_deref(),
+            self.release.then_some(CargoProfile::Release).unwrap_or(CargoProfile::Dev),
+        )?;
 
         for pg_config in pgx.iter(PgConfigSelector::new(&pg_version)) {
             let mut testname = self.testname.clone();

--- a/cargo-pgx/src/profile.rs
+++ b/cargo-pgx/src/profile.rs
@@ -21,19 +21,15 @@ pub enum CargoProfile {
 }
 
 impl CargoProfile {
-    pub fn from_flags(release: bool, profile: Option<&str>) -> eyre::Result<Self> {
-        match (profile, release) {
-            (Some(profile), true) => {
-                eyre::bail!("conflicting usage of --profile={:?} and --release", profile);
-            }
+    pub fn from_flags(profile: Option<&str>, default: CargoProfile) -> eyre::Result<Self> {
+        match profile {
             // Cargo treats `--profile release` the same as `--release`.
-            (Some("release"), false) => Ok(Self::Release),
+            Some("release") => Ok(Self::Release),
             // Cargo has two names for the debug profile, due to legacy
             // reasons...
-            (Some("debug"), false) | (Some("dev"), false) => Ok(Self::Dev),
-            (Some(profile), false) => Ok(Self::Profile(profile.into())),
-            (None, true) => Ok(Self::Release),
-            (None, false) => Ok(Self::Dev),
+            Some("debug") | Some("dev") => Ok(Self::Dev),
+            Some(profile) => Ok(Self::Profile(profile.into())),
+            None => Ok(default),
         }
     }
 


### PR DESCRIPTION
Especially as it relates to `cargo pgx package --profile foo`.

Fixes the error reported during

```shell
$ cargo pgx package --profile artifacts
Error:
   0: conflicting usage of --profile="artifacts" and --release
```

`cargo pgx package` will now prefer the specified profile, then default to "release"

I put this PR against `master` so that we can get it into a 0.6.1 release sometime.