### PR TITLE
A `no-schema-generation` feature flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: Run custom_types example tests
       run: cargo test --package custom_types --features "pg$PG_VER" --no-default-features
 
+    - name: Run custom_types without schema generation example tests
+      run: cargo test --package custom_types --features "pg$PG_VER no-schema-generation" --no-default-features
+
     - name: Run custom_sql example tests
       run: cargo test --package custom_sql --features "pg$PG_VER" --no-default-features
 

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -14,6 +14,7 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
+no-schema-generation = [ "pgx/no-schema-generation", "pgx-tests/no-schema-generation" ]
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }

--- a/pgx-examples/custom_types/src/complex.rs
+++ b/pgx-examples/custom_types/src/complex.rs
@@ -59,6 +59,7 @@ mod tests {
     use maplit::*;
     use pgx::prelude::*;
 
+    #[cfg(not(feature = "no-schema-generation"))]
     #[pg_test]
     fn test_known_animals_via_spi() {
         let animals = Spi::get_one::<Animals>("SELECT known_animals();");

--- a/pgx-examples/custom_types/src/ordered.rs
+++ b/pgx-examples/custom_types/src/ordered.rs
@@ -54,6 +54,7 @@ mod tests {
     use crate::ordered::OrderedThing;
     use pgx::prelude::*;
 
+    #[cfg(not(feature = "no-schema-generation"))]
     #[pg_test]
     fn test_ordering_via_spi() {
         let items = Spi::get_one::<Vec<OrderedThing>>(

--- a/pgx-examples/custom_types/src/rust_enum.rs
+++ b/pgx-examples/custom_types/src/rust_enum.rs
@@ -23,6 +23,7 @@ mod tests {
     use crate::rust_enum::SomeEnum;
     use pgx::prelude::*;
 
+    #[cfg(not(feature = "no-schema-generation"))]
     #[pg_test]
     fn test_some_enum() {
         let val = Spi::get_one::<SomeEnum>(r#"SELECT '"hello world"'::SomeEnum"#);

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -17,6 +17,9 @@ proc-macro = true
 # Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
 rustc-args = ["--cfg", "docsrs"]
 
+[features]
+no-schema-generation = ["pgx-sql-entity-graph/no-schema-generation"]
+
 [dependencies]
 pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.6.0" }
 proc-macro2 = "1.0.47"

--- a/pgx-sql-entity-graph/Cargo.toml
+++ b/pgx-sql-entity-graph/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [features]
 syntax-highlighting = ["dep:syntect", "dep:owo-colors", "dep:atty"]
+no-schema-generation = []
 
 [dependencies]
 seq-macro = "0.3"

--- a/pgx-sql-entity-graph/src/enrich.rs
+++ b/pgx-sql-entity-graph/src/enrich.rs
@@ -1,0 +1,33 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens, TokenStreamExt};
+
+pub struct CodeEnrichment<T>(pub T);
+
+/// Generates the rust code that pgx requires for one of its SQL interfaces such as `#[pg_extern]`
+pub trait ToRustCodeTokens {
+    fn to_rust_code_tokens(&self) -> TokenStream2 {
+        quote! {}
+    }
+}
+
+/// Generates the rust code to tie one of pgx' supported SQL interfaces into pgx' schema generator
+pub trait ToEntityGraphTokens {
+    fn to_entity_graph_tokens(&self) -> TokenStream2 {
+        quote! {}
+    }
+}
+
+impl<T> ToTokens for CodeEnrichment<T>
+where
+    T: ToEntityGraphTokens + ToRustCodeTokens,
+{
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        #[cfg(not(feature = "no-schema-generation"))]
+        {
+            // only emit entity graph tokens when we're generating a schema, which is our default mode
+            tokens.append_all(self.0.to_entity_graph_tokens());
+        }
+
+        tokens.append_all(self.0.to_rust_code_tokens());
+    }
+}

--- a/pgx-sql-entity-graph/src/lib.rs
+++ b/pgx-sql-entity-graph/src/lib.rs
@@ -19,6 +19,7 @@ pub use aggregate::{
     AggregateType, AggregateTypeList, FinalizeModify, ParallelOption, PgAggregate,
 };
 pub use control_file::ControlFile;
+pub use enrich::CodeEnrichment;
 pub use extension_sql::entity::{ExtensionSqlEntity, SqlDeclaredEntity};
 pub use extension_sql::{ExtensionSql, ExtensionSqlFile, SqlDeclared};
 pub use extern_args::{parse_extern_attributes, ExternArgs};
@@ -49,6 +50,7 @@ pub use used_type::{UsedType, UsedTypeEntity};
 
 pub(crate) mod aggregate;
 pub(crate) mod control_file;
+pub(crate) mod enrich;
 pub(crate) mod extension_sql;
 pub(crate) mod extern_args;
 pub mod lifetimes;

--- a/pgx-sql-entity-graph/src/postgres_hash/mod.rs
+++ b/pgx-sql-entity-graph/src/postgres_hash/mod.rs
@@ -16,12 +16,13 @@ to the `pgx` framework and very subject to change between versions. While you ma
 */
 pub mod entity;
 
+use crate::enrich::{ToEntityGraphTokens, ToRustCodeTokens};
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{DeriveInput, Ident};
 
-use crate::ToSqlConfig;
+use crate::{CodeEnrichment, ToSqlConfig};
 
 /// A parsed `#[derive(PostgresHash)]` item.
 ///
@@ -37,7 +38,8 @@ use crate::ToSqlConfig;
 /// use pgx_sql_entity_graph::PostgresHash;
 ///
 /// # fn main() -> eyre::Result<()> {
-/// let parsed: PostgresHash = parse_quote! {
+/// use pgx_sql_entity_graph::CodeEnrichment;
+/// let parsed: CodeEnrichment<PostgresHash> = parse_quote! {
 ///     #[derive(PostgresHash)]
 ///     struct Example<'a> {
 ///         demo: &'a str,
@@ -56,7 +58,8 @@ use crate::ToSqlConfig;
 /// use pgx_sql_entity_graph::PostgresHash;
 ///
 /// # fn main() -> eyre::Result<()> {
-/// let parsed: PostgresHash = parse_quote! {
+/// use pgx_sql_entity_graph::CodeEnrichment;
+/// let parsed: CodeEnrichment<PostgresHash> = parse_quote! {
 ///     #[derive(PostgresHash)]
 ///     enum Demo {
 ///         Example,
@@ -73,43 +76,32 @@ pub struct PostgresHash {
 }
 
 impl PostgresHash {
-    pub fn new(name: Ident, to_sql_config: ToSqlConfig) -> Result<Self, syn::Error> {
+    pub fn new(
+        name: Ident,
+        to_sql_config: ToSqlConfig,
+    ) -> Result<CodeEnrichment<Self>, syn::Error> {
         if !to_sql_config.overrides_default() {
             crate::ident_is_acceptable_to_postgres(&name)?;
         }
-        Ok(Self { name, to_sql_config })
+        Ok(CodeEnrichment(Self { name, to_sql_config }))
     }
 
-    pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
+    pub fn from_derive_input(
+        derive_input: DeriveInput,
+    ) -> Result<CodeEnrichment<Self>, syn::Error> {
         let to_sql_config =
             ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
         Self::new(derive_input.ident, to_sql_config)
     }
 }
 
-impl Parse for PostgresHash {
-    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        use syn::Item;
-
-        let parsed = input.parse()?;
-        let (ident, attrs) = match &parsed {
-            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
-            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
-            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
-        };
-
-        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
-        Self::new(ident, to_sql_config)
-    }
-}
-
-impl ToTokens for PostgresHash {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
+impl ToEntityGraphTokens for PostgresHash {
+    fn to_entity_graph_tokens(&self) -> TokenStream2 {
         let name = &self.name;
         let sql_graph_entity_fn_name =
             syn::Ident::new(&format!("__pgx_internals_hash_{}", self.name), Span::call_site());
         let to_sql_config = &self.to_sql_config;
-        let inv = quote! {
+        quote! {
             #[no_mangle]
             #[doc(hidden)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> pgx::pgx_sql_entity_graph::SqlGraphEntity {
@@ -128,7 +120,24 @@ impl ToTokens for PostgresHash {
                 };
                 pgx::pgx_sql_entity_graph::SqlGraphEntity::Hash(submission)
             }
+        }
+    }
+}
+
+impl ToRustCodeTokens for PostgresHash {}
+
+impl Parse for CodeEnrichment<PostgresHash> {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        use syn::Item;
+
+        let parsed = input.parse()?;
+        let (ident, attrs) = match &parsed {
+            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
+            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
+            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
         };
-        tokens.append_all(inv);
+
+        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
+        PostgresHash::new(ident, to_sql_config)
     }
 }

--- a/pgx-sql-entity-graph/src/postgres_ord/mod.rs
+++ b/pgx-sql-entity-graph/src/postgres_ord/mod.rs
@@ -16,12 +16,13 @@ to the `pgx` framework and very subject to change between versions. While you ma
 */
 pub mod entity;
 
+use crate::enrich::{ToEntityGraphTokens, ToRustCodeTokens};
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{DeriveInput, Ident};
 
-use crate::ToSqlConfig;
+use crate::{CodeEnrichment, ToSqlConfig};
 
 /// A parsed `#[derive(PostgresOrd)]` item.
 ///
@@ -37,7 +38,8 @@ use crate::ToSqlConfig;
 /// use pgx_sql_entity_graph::PostgresOrd;
 ///
 /// # fn main() -> eyre::Result<()> {
-/// let parsed: PostgresOrd = parse_quote! {
+/// use pgx_sql_entity_graph::CodeEnrichment;
+/// let parsed: CodeEnrichment<PostgresOrd> = parse_quote! {
 ///     #[derive(PostgresOrd)]
 ///     struct Example<'a> {
 ///         demo: &'a str,
@@ -56,7 +58,8 @@ use crate::ToSqlConfig;
 /// use pgx_sql_entity_graph::PostgresOrd;
 ///
 /// # fn main() -> eyre::Result<()> {
-/// let parsed: PostgresOrd = parse_quote! {
+/// use pgx_sql_entity_graph::CodeEnrichment;
+/// let parsed: CodeEnrichment<PostgresOrd> = parse_quote! {
 ///     #[derive(PostgresOrd)]
 ///     enum Demo {
 ///         Example,
@@ -73,43 +76,33 @@ pub struct PostgresOrd {
 }
 
 impl PostgresOrd {
-    pub fn new(name: Ident, to_sql_config: ToSqlConfig) -> Result<Self, syn::Error> {
+    pub fn new(
+        name: Ident,
+        to_sql_config: ToSqlConfig,
+    ) -> Result<CodeEnrichment<Self>, syn::Error> {
         if !to_sql_config.overrides_default() {
             crate::ident_is_acceptable_to_postgres(&name)?;
         }
 
-        Ok(Self { name, to_sql_config })
+        Ok(CodeEnrichment(Self { name, to_sql_config }))
     }
 
-    pub fn from_derive_input(derive_input: DeriveInput) -> Result<Self, syn::Error> {
+    pub fn from_derive_input(
+        derive_input: DeriveInput,
+    ) -> Result<CodeEnrichment<Self>, syn::Error> {
         let to_sql_config =
             ToSqlConfig::from_attributes(derive_input.attrs.as_slice())?.unwrap_or_default();
         Self::new(derive_input.ident, to_sql_config)
     }
 }
 
-impl Parse for PostgresOrd {
-    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        use syn::Item;
-
-        let parsed = input.parse()?;
-        let (ident, attrs) = match &parsed {
-            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
-            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
-            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
-        };
-        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
-        Self::new(ident, to_sql_config)
-    }
-}
-
-impl ToTokens for PostgresOrd {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
+impl ToEntityGraphTokens for PostgresOrd {
+    fn to_entity_graph_tokens(&self) -> TokenStream2 {
         let name = &self.name;
         let sql_graph_entity_fn_name =
             syn::Ident::new(&format!("__pgx_internals_ord_{}", self.name), Span::call_site());
         let to_sql_config = &self.to_sql_config;
-        let inv = quote! {
+        quote! {
             #[no_mangle]
             #[doc(hidden)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> pgx::pgx_sql_entity_graph::SqlGraphEntity {
@@ -128,7 +121,23 @@ impl ToTokens for PostgresOrd {
                 };
                 pgx::pgx_sql_entity_graph::SqlGraphEntity::Ord(submission)
             }
+        }
+    }
+}
+
+impl ToRustCodeTokens for PostgresOrd {}
+
+impl Parse for CodeEnrichment<PostgresOrd> {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        use syn::Item;
+
+        let parsed = input.parse()?;
+        let (ident, attrs) = match &parsed {
+            Item::Enum(item) => (item.ident.clone(), item.attrs.as_slice()),
+            Item::Struct(item) => (item.ident.clone(), item.attrs.as_slice()),
+            _ => return Err(syn::Error::new(input.span(), "expected enum or struct")),
         };
-        tokens.append_all(inv);
+        let to_sql_config = ToSqlConfig::from_attributes(attrs)?.unwrap_or_default();
+        PostgresOrd::new(ident, to_sql_config)
     }
 }

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -21,6 +21,7 @@ pg13 = [ "pgx/pg13" ]
 pg14 = [ "pgx/pg14" ]
 pg15 = [ "pgx/pg15" ]
 pg_test = [ ]
+no-schema-generation = [ "pgx/no-schema-generation", "pgx-macros/no-schema-generation" ]
 
 [package.metadata.docs.rs]
 features = ["pg14"]

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -25,6 +25,7 @@ pg13 = [ "pgx-pg-sys/pg13" ]
 pg14 = [ "pgx-pg-sys/pg14" ]
 pg15 = [ "pgx-pg-sys/pg15" ]
 time-crate = ["dep:time"]
+no-schema-generation = ["pgx-macros/no-schema-generation", "pgx-sql-entity-graph/no-schema-generation"]
 
 [package.metadata.docs.rs]
 features = ["pg14"]


### PR DESCRIPTION
This adds a `no-schema-generation` feature flag to pgx, which it pushes down into both `pgx-macros` and `pgx-sql-entity-graph` (`pgx-macros` pushes it down as well).

Also "cleans up" pgx-sql-entity-graph a bit by introducing a two new traits, `ToEntityGraphTokens` and `ToRustCodeTokens`, and a new type `CodeEnrichment<T>`.  It forces the various sql interface types, such as `PgExtern`, `PgAggregate`, `PostgresTypes`, etc, to implement these traits individually, and then it provides a blanket `impl ToTokens for CodeEnrichment<T: ToEntityGraphTokens + ToRustCodeTokens>`.  When the new `no-schema-generation` flag is set, then it simply skips generating the tokens necessary to support schema generation.

The `Schema` type can't follow these rules, for reasons, so it also handles the `no-schema-generation` feature flag directly.