### PR TITLE
Problem: can't use `pg_guard` on parameterized functions

### DIFF
--- a/pgx-macros/src/rewriter.rs
+++ b/pgx-macros/src/rewriter.rs
@@ -13,10 +13,11 @@ use proc_macro2::Ident;
 use quote::{quote, quote_spanned};
 use std::ops::Deref;
 use std::str::FromStr;
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    FnArg, ForeignItem, ForeignItemFn, ItemFn, ItemForeignMod, Pat, ReturnType, Signature,
-    Visibility,
+    FnArg, ForeignItem, ForeignItemFn, GenericParam, ItemFn, ItemForeignMod, Pat, ReturnType,
+    Signature, Token, Visibility,
 };
 
 pub struct PgGuardRewriter();
@@ -43,6 +44,8 @@ impl PgGuardRewriter {
         let sig = func.sig.clone();
         let vis = func.vis.clone();
         let attrs = func.attrs.clone();
+
+        let generics = func.sig.generics.clone();
 
         // but for the inner function (the one we're wrapping) we don't need any kind of
         // abi classification
@@ -72,6 +75,21 @@ impl PgGuardRewriter {
             quote! {}
         };
 
+        let body = if generics.params.is_empty() {
+            quote! { #func_name(#arg_list) }
+        } else {
+            let ty = generics
+                .params
+                .into_iter()
+                .filter_map(|p| match p {
+                    GenericParam::Type(ty) => Some(ty.ident),
+                    GenericParam::Const(c) => Some(c.ident),
+                    GenericParam::Lifetime(_) => None,
+                })
+                .collect::<Punctuated<_, Token![,]>>();
+            quote! { #func_name::<#ty>(#arg_list) }
+        };
+
         quote_spanned! {func.span()=>
             #prolog
             #(#attrs)*
@@ -81,7 +99,7 @@ impl PgGuardRewriter {
 
                 #[allow(unused_unsafe)]
                 unsafe {
-                    pg_sys::panic::pgx_extern_c_guard( || #func_name(#arg_list) )
+                    pg_sys::panic::pgx_extern_c_guard( || #body )
                 }
             }
         }

--- a/pgx-macros/src/rewriter.rs
+++ b/pgx-macros/src/rewriter.rs
@@ -47,6 +47,16 @@ impl PgGuardRewriter {
 
         let generics = func.sig.generics.clone();
 
+        if attrs.iter().any(|attr| attr.path.is_ident("no_mangle"))
+            && generics.params.iter().any(|p| match p {
+                GenericParam::Type(_) => true,
+                GenericParam::Lifetime(_) => false,
+                GenericParam::Const(_) => true,
+            })
+        {
+            panic!("#[pg_guard] for function with generic parameters must not be combined with #[no_mangle]");
+        }
+
         // but for the inner function (the one we're wrapping) we don't need any kind of
         // abi classification
         func.sig.abi = None;

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod memcxt_tests;
 mod name_tests;
 mod numeric_tests;
 mod pg_extern_tests;
+mod pg_guard_tests;
 mod pg_try_tests;
 mod pgbox_tests;
 mod postgres_type_tests;

--- a/pgx-tests/src/tests/pg_guard_tests.rs
+++ b/pgx-tests/src/tests/pg_guard_tests.rs
@@ -1,0 +1,28 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+use pgx::prelude::*;
+
+#[pg_extern]
+fn extern_func() -> bool {
+    extern_func_impl::<u8>()
+}
+
+// This ensures that parameterized function compiles when it has `pg_guard` attached to it
+#[pg_guard]
+extern "C" fn extern_func_impl<T>() -> bool {
+    true
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+}

--- a/pgx-tests/src/tests/pg_guard_tests.rs
+++ b/pgx-tests/src/tests/pg_guard_tests.rs
@@ -16,7 +16,25 @@ fn extern_func() -> bool {
 
 // This ensures that parameterized function compiles when it has `pg_guard` attached to it
 #[pg_guard]
+// Uncommenting the line below will make it fail to compile
+// #[no_mangle]
 extern "C" fn extern_func_impl<T>() -> bool {
+    true
+}
+
+// This ensures that non-parameterized function compiles when it has `pg_guard` attached to it
+// and [no_mangle]
+#[pg_guard]
+#[no_mangle]
+extern "C" fn extern_func_impl_1() -> bool {
+    true
+}
+
+// This ensures that lifetime-parameterized function compiles when it has `pg_guard` attached to it
+// and [no_mangle]
+#[pg_guard]
+#[no_mangle]
+extern "C" fn extern_func_impl_2<'a>() -> bool {
     true
 }
 


### PR DESCRIPTION
This code won't compile:

```rust
#[pg_guard]
extern "C" fn extern_func_impl<T>() -> bool {
    true
}
```

The error is

```
error[E0282]: type annotations needed
```

Solution: ensure this case is handled