### PR TITLE
Ensuring owned memory context is not current when dropping it (extension)

### DIFF
--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -52,4 +52,29 @@ mod tests {
         assert!(PgMemoryContexts::TopMemoryContext.parent().is_none());
         assert!(PgMemoryContexts::CurrentMemoryContext.parent().is_some());
     }
+
+    #[pg_test]
+    fn switch_to_should_switch_back_on_panic() {
+        let mut ctx = PgMemoryContexts::new("test");
+        let ctx_sys = ctx.value();
+        PgTryBuilder::new(move || {
+            ctx.switch_to(|_| {
+                assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, ctx_sys);
+                panic!();
+            });
+        })
+        .catch_others(|_| {})
+        .execute();
+        assert_ne!(unsafe { pg_sys::CurrentMemoryContext }, ctx_sys);
+    }
+
+    #[pg_test]
+    fn test_current_owned_memory_context_drop() {
+        let ctx = PgMemoryContexts::new("test");
+        let ctx_sys = ctx.value();
+        let parent = unsafe { (*ctx_sys).parent };
+        ctx.set_as_current();
+        drop(ctx);
+        assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, parent);
+    }
 }

--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -70,11 +70,12 @@ mod tests {
 
     #[pg_test]
     fn test_current_owned_memory_context_drop() {
-        let ctx = PgMemoryContexts::new("test");
-        let ctx_sys = ctx.value();
-        let parent = unsafe { (*ctx_sys).parent };
+        let mut ctx = PgMemoryContexts::new("test");
+        let mut another_ctx = PgMemoryContexts::new("another");
+        another_ctx.set_as_current();
         ctx.set_as_current();
+        assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, ctx.value());
         drop(ctx);
-        assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, parent);
+        assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, another_ctx.value());
     }
 }

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -178,6 +178,11 @@ pub struct OwnedMemoryContext(pg_sys::MemoryContext);
 impl Drop for OwnedMemoryContext {
     fn drop(&mut self) {
         unsafe {
+            // In order to prevent crashes, if we're trying to drop
+            // a context that is current, switch to its parent, and then drop it
+            if pg_sys::CurrentMemoryContext == self.0 {
+                pg_sys::CurrentMemoryContext = (*self.0).parent;
+            }
             pg_sys::MemoryContextDelete(self.0);
         }
     }

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -183,7 +183,7 @@ impl Drop for OwnedMemoryContext {
         unsafe {
             // In order to prevent crashes, if we're trying to drop
             // a context that is current, switch to its predecessor, and then drop it
-            if pg_sys::CurrentMemoryContext == self.owned {
+            if ptr::eq(pg_sys::CurrentMemoryContext, self.owned) {
                 pg_sys::CurrentMemoryContext = self.previous;
             }
             pg_sys::MemoryContextDelete(self.owned);

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -173,17 +173,20 @@ pub enum PgMemoryContexts {
 
 /// A `pg_sys::MemoryContext` that is owned by `PgMemoryContexts::Owned`
 #[derive(Debug)]
-pub struct OwnedMemoryContext(pg_sys::MemoryContext);
+pub struct OwnedMemoryContext {
+    owned: pg_sys::MemoryContext,
+    previous: pg_sys::MemoryContext,
+}
 
 impl Drop for OwnedMemoryContext {
     fn drop(&mut self) {
         unsafe {
             // In order to prevent crashes, if we're trying to drop
-            // a context that is current, switch to its parent, and then drop it
-            if pg_sys::CurrentMemoryContext == self.0 {
-                pg_sys::CurrentMemoryContext = (*self.0).parent;
+            // a context that is current, switch to its predecessor, and then drop it
+            if pg_sys::CurrentMemoryContext == self.owned {
+                pg_sys::CurrentMemoryContext = self.previous;
             }
-            pg_sys::MemoryContextDelete(self.0);
+            pg_sys::MemoryContextDelete(self.owned);
         }
     }
 }
@@ -191,15 +194,19 @@ impl Drop for OwnedMemoryContext {
 impl PgMemoryContexts {
     /// Create a new `PgMemoryContext::Owned`
     pub fn new(name: &str) -> PgMemoryContexts {
-        PgMemoryContexts::Owned(OwnedMemoryContext(unsafe {
-            pg_sys::AllocSetContextCreateExtended(
-                PgMemoryContexts::CurrentMemoryContext.value(),
-                name.as_pg_cstr(),
-                pg_sys::ALLOCSET_DEFAULT_MINSIZE as usize,
-                pg_sys::ALLOCSET_DEFAULT_INITSIZE as usize,
-                pg_sys::ALLOCSET_DEFAULT_MAXSIZE as usize,
-            )
-        }))
+        let previous = PgMemoryContexts::CurrentMemoryContext.value();
+        PgMemoryContexts::Owned(OwnedMemoryContext {
+            previous,
+            owned: unsafe {
+                pg_sys::AllocSetContextCreateExtended(
+                    PgMemoryContexts::CurrentMemoryContext.value(),
+                    name.as_pg_cstr(),
+                    pg_sys::ALLOCSET_DEFAULT_MINSIZE as usize,
+                    pg_sys::ALLOCSET_DEFAULT_INITSIZE as usize,
+                    pg_sys::ALLOCSET_DEFAULT_MAXSIZE as usize,
+                )
+            },
+        })
     }
 
     /// Retrieve the underlying Postgres `*mut MemoryContextData`
@@ -217,7 +224,7 @@ impl PgMemoryContexts {
             PgMemoryContexts::TopTransactionContext => unsafe { pg_sys::TopTransactionContext },
             PgMemoryContexts::CurTransactionContext => unsafe { pg_sys::CurTransactionContext },
             PgMemoryContexts::For(mc) => *mc,
-            PgMemoryContexts::Owned(mc) => mc.0,
+            PgMemoryContexts::Owned(mc) => mc.owned,
             PgMemoryContexts::Of(ptr) => PgMemoryContexts::get_context_for_pointer(*ptr),
             PgMemoryContexts::Transient { .. } => {
                 panic!("cannot use value() to retrieve a Transient PgMemoryContext")
@@ -226,9 +233,16 @@ impl PgMemoryContexts {
     }
 
     /// Set this MemoryContext as the `CurrentMemoryContext, returning whatever `CurrentMemoryContext` is
-    pub fn set_as_current(&self) -> PgMemoryContexts {
+    pub fn set_as_current(&mut self) -> PgMemoryContexts {
         unsafe {
             let old_context = pg_sys::CurrentMemoryContext;
+
+            match self {
+                PgMemoryContexts::Owned(mc) => {
+                    mc.previous = old_context;
+                }
+                _ => {}
+            }
 
             pg_sys::CurrentMemoryContext = self.value();
 


### PR DESCRIPTION
(Supersedes #921)

Problem: dropping owned memory context while it's current
    
The error will look like this:
    
```
TRAP: FailedAssertion("context != CurrentMemoryContext", File: "mcxt.c", Line: 224, PID: 71536)
```
    
Solution: avoid failing this assertion
  
We can say that it is on the user of `pgx` to ensure that the owned
context is dropped at the right time, but it may get tricky to do so.
    
For example, certain types are not UnwindSafe, so we can't use
`switch_to` or `PgTryBuilder` and guard the exceptional situation to
ensure the context is no longer current before it is dropped. So, due
to these limitations, we're forced to use `set_as_current` and the
reversal to the old context will never happen if there's a panic.

---

This is a stackable extension to #921. Instead of returning to the parent context, which may be an unexpected behavior, keep track of the previous context and returns to it instead.

I think this behavior is better than the original one in #921 (returns context's parent)