### PR TITLE
`AnyElement::into()` needs to be unsafe

### DIFF
--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -34,9 +34,15 @@ impl AnyElement {
         self.typoid
     }
 
+    /// Convert this element into a specific type.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as it cannot guarantee that the underlying datum can be represented
+    /// as `T`.  This is your responsibility
     #[inline]
-    pub fn into<T: FromDatum>(&self) -> Option<T> {
-        unsafe { T::from_polymorphic_datum(self.datum(), false, self.oid()) }
+    pub unsafe fn into<T: FromDatum>(&self) -> Option<T> {
+        T::from_polymorphic_datum(self.datum(), false, self.oid())
     }
 }
 


### PR DESCRIPTION
see title