### PR TITLE
Cursor API should not require &self mut

### DIFF
--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -289,15 +289,12 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_spi_unwind_safe() {
-        Spi::connect(|client| {
-            PgTryBuilder::new(|| {
-                client.update("SELECT 1", None, None);
-                let cursor = client.open_cursor("SELECT 1", None).detach_into_name();
-                client.find_cursor(&cursor);
-            })
-            .execute();
-            Ok(Some(()))
+    fn test_spi_non_mut() {
+        // Ensures update and cursor APIs do not need mutable reference to SpiClient
+        Spi::execute(|client| {
+            client.update("SELECT 1", None, None);
+            let cursor = client.open_cursor("SELECT 1", None).detach_into_name();
+            client.find_cursor(&cursor);
         });
     }
 }

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -189,7 +189,7 @@ mod tests {
 
     #[pg_test]
     fn test_cursor() {
-        Spi::execute(|mut client| {
+        Spi::execute(|client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
@@ -211,7 +211,7 @@ mod tests {
 
     #[pg_test]
     fn test_cursor_by_name() {
-        let cursor_name = Spi::connect(|mut client| {
+        let cursor_name = Spi::connect(|client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
@@ -228,7 +228,7 @@ mod tests {
         fn sum_all(table: pgx::SpiTupleTable) -> i32 {
             table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
         }
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             let mut cursor = client.find_cursor(&cursor_name);
             assert_eq!(sum_all(cursor.fetch(3)), 4 + 5 + 6);
             assert_eq!(sum_all(cursor.fetch(3)), 7 + 8 + 9);
@@ -236,7 +236,7 @@ mod tests {
             Ok(None::<()>)
         });
 
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             let mut cursor = client.find_cursor(&cursor_name);
             assert_eq!(sum_all(cursor.fetch(3)), 10);
             Ok(None::<()>)
@@ -245,14 +245,14 @@ mod tests {
 
     #[pg_test(error = "syntax error at or near \"THIS\"")]
     fn test_cursor_failure() {
-        Spi::execute(|mut client| {
+        Spi::execute(|client| {
             client.open_cursor("THIS IS NOT SQL", None);
         });
     }
 
     #[pg_test(error = "cursor named \"NOT A CURSOR\" not found")]
     fn test_cursor_not_found() {
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             client.find_cursor("NOT A CURSOR");
             Ok(None::<()>)
         });
@@ -293,6 +293,8 @@ mod tests {
         Spi::connect(|client| {
             PgTryBuilder::new(|| {
                 client.update("SELECT 1", None, None);
+                let cursor = client.open_cursor("SELECT 1", None).detach_into_name();
+                client.find_cursor(&cursor);
             })
             .execute();
             Ok(Some(()))

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -404,7 +404,7 @@ impl<'a> SpiClient<'a> {
     ///
     /// See [`SpiCursor`] docs for usage details.
     pub fn open_cursor(
-        &mut self,
+        &self,
         query: &str,
         args: Option<Vec<(PgOid, Option<pg_sys::Datum>)>>,
     ) -> SpiCursor {
@@ -457,7 +457,7 @@ impl<'a> SpiClient<'a> {
     /// Returned name can be used with this method to retrieve the open cursor.
     ///
     /// See [`SpiCursor`] docs for usage details.
-    pub fn find_cursor(&mut self, name: &str) -> SpiCursor {
+    pub fn find_cursor(&self, name: &str) -> SpiCursor {
         use pgx_pg_sys::AsPgCStr;
 
         let ptr = NonNull::new(unsafe { pg_sys::SPI_cursor_find(name.as_pg_cstr()) })


### PR DESCRIPTION
Problem: cursor API takes &mut self

Solution: make cursor functions take &self

Just like with other functions, it makes them UnwindSafe

This improves just-merged #579 