### PR TITLE
pgx-pg-sys: cshim: Makefile: user AR variable

### DIFF
--- a/pgx-pg-sys/cshim/Makefile
+++ b/pgx-pg-sys/cshim/Makefile
@@ -15,7 +15,7 @@ STATIC_LIB_NAME = lib${MODULE_big}.a
 
 
 ${STATIC_LIB_NAME}: pgx-cshim.o
-	ar crv $@ pgx-cshim.o
+	$(AR) crv $@ pgx-cshim.o
 
 all: ${STATIC_LIB_NAME}
 


### PR DESCRIPTION
Instead of calling ar directly, the AR variable should be used. In a cross-compilation environment, ar might not exist or point to the wrong ar binary.