### PR TITLE
:fix: ensure multiple open SpiTupTables can coexist

### DIFF
--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -298,4 +298,28 @@ mod tests {
             Ok(Some(()))
         });
     }
+
+    #[pg_test]
+    fn test_open_multiple_tuptables() {
+        Spi::execute(|client| {
+            let a = client.select("SELECT 1", None, None).first();
+            let _b = client.select("SELECT 1 WHERE 'f'", None, None);
+            assert!(!a.is_empty());
+            assert_eq!(1, a.len());
+            assert!(a.get_heap_tuple().is_some());
+            assert_eq!(Some(1), a.get_datum(1));
+        });
+    }
+
+    #[pg_test]
+    fn test_open_multiple_tuptables_rev() {
+        Spi::execute(|client| {
+            let a = client.select("SELECT 1 WHERE 'f'", None, None).first();
+            let _b = client.select("SELECT 1", None, None);
+            assert!(a.is_empty());
+            assert_eq!(0, a.len());
+            assert!(a.get_heap_tuple().is_none());
+            assert!(a.get_datum::<i32>(1).is_none());
+        });
+    }
 }

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -617,7 +617,7 @@ impl SpiTupleTable {
         if self.current < 0 {
             panic!("SpiTupleTable positioned before start")
         }
-        if self.current as u64 >= unsafe { pg_sys::SPI_processed } {
+        if self.current as usize >= self.size {
             None
         } else {
             match self.tupdesc {
@@ -637,7 +637,7 @@ impl SpiTupleTable {
         if self.current < 0 {
             panic!("SpiTupleTable positioned before start")
         }
-        if self.current as u64 >= unsafe { pg_sys::SPI_processed } {
+        if self.current as usize >= self.size {
             None
         } else {
             match self.tupdesc {


### PR DESCRIPTION
Ensure `SpiTupleTable` refers to `self.size` and not to the static, shared `pg_sys::SPI_processed`, as to avoid interference between multiple open `SpiTupleTable`s.

Fixes https://github.com/tcdi/pgx/issues/936