### PR TITLE
Revert "Revert "Replace rayon""

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,6 @@ dependencies = [
  "pgx-sql-entity-graph",
  "proc-macro2",
  "quote",
- "rayon",
  "shlex",
  "sptr",
  "syn",

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -40,7 +40,6 @@ bindgen = { version = "0.60.1", default-features = false, features = ["runtime"]
 pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.6.1" }
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
-rayon = "1.6.0"
 syn = { version = "1.0.105", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -11,7 +11,6 @@ use bindgen::callbacks::{DeriveTrait, ImplementsTrait, MacroParsingBehavior};
 use eyre::{eyre, WrapErr};
 use pgx_pg_config::{prefix_path, PgConfig, PgConfigSelector, Pgx, SUPPORTED_MAJOR_VERSIONS};
 use quote::{quote, ToTokens};
-use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::{Command, Output};
@@ -155,12 +154,24 @@ fn main() -> eyre::Result<()> {
         let specific = pgx.get(&found)?;
         vec![specific]
     };
-
-    pg_configs
-        .par_iter()
-        .map(|pg_config| generate_bindings(pg_config, &build_paths, is_for_release))
-        .collect::<eyre::Result<Vec<_>>>()?;
-
+    std::thread::scope(|scope| {
+        // This is pretty much either always 1 (normally) or 5 (for releases),
+        // but in the future if we ever have way more, we should consider
+        // chunking `pg_configs` based on `thread::available_parallelism()`.
+        let threads = pg_configs
+            .iter()
+            .map(|pg_config| {
+                scope.spawn(|| generate_bindings(pg_config, &build_paths, is_for_release))
+            })
+            .collect::<Vec<_>>();
+        // Most of the rest of this is just for better error handling --
+        // `thread::scope` already joins the threads for us before it returns.
+        let results = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("thread panicked while generating bindings"))
+            .collect::<Vec<eyre::Result<_>>>();
+        results.into_iter().try_for_each(|r| r)
+    })?;
     // compile the cshim for each binding
     for pg_config in pg_configs {
         build_shim(&build_paths.shim_src, &build_paths.shim_dst, &pg_config)?;


### PR DESCRIPTION
...with `std::thread::scope` in the pgx-pg-sys build system. This reverts commit bfcc572a1a49d178e347ce8c93a688be66de9170.

Again.

This does not revert 4bb84ca92bb6d9dc8b9282ef7906b1798e0d6ea9 because that commit now has numerous conflicts with other changes.