### PR TITLE
`PgMemoryContexts::get_context_for_pointer()` is wildly unsafe.

### DIFF
--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -27,12 +27,6 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "utils/array.h"
 #include "storage/spin.h"
 
-
-PGDLLEXPORT MemoryContext pgx_GetMemoryContextChunk(void *ptr);
-MemoryContext pgx_GetMemoryContextChunk(void *ptr) {
-    return GetMemoryChunkContext(ptr);
-}
-
 PGDLLEXPORT void pgx_elog(int32 level, char *message);
 void pgx_elog(int32 level, char *message) {
     elog(level, "%s", message);

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -307,6 +307,105 @@ mod all_versions {
         (*tuple).t_data.cast::<std::os::raw::c_char>().add((*(*tuple).t_data).t_hoff as _)
     }
 
+    //
+    // TODO: [`TYPEALIGN`] and [`MAXALIGN`] are also part of PR #948 and when that's all merged,
+    //       their uses should be switched to these
+    //
+
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub const unsafe fn TYPEALIGN(alignval: usize, len: usize) -> usize {
+        // #define TYPEALIGN(ALIGNVAL,LEN)  \
+        // (((uintptr_t) (LEN) + ((ALIGNVAL) - 1)) & ~((uintptr_t) ((ALIGNVAL) - 1)))
+        ((len) + ((alignval) - 1)) & !((alignval) - 1)
+    }
+
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub const unsafe fn MAXALIGN(len: usize) -> usize {
+        // #define MAXALIGN(LEN) TYPEALIGN(MAXIMUM_ALIGNOF, (LEN))
+        TYPEALIGN(pg_sys::MAXIMUM_ALIGNOF as _, len)
+    }
+
+    ///  Given a currently-allocated chunk of Postgres allocated memory, determine the context
+    ///  it belongs to.
+    ///
+    /// All chunks allocated by any memory context manager are required to be
+    /// preceded by the corresponding MemoryContext stored, without padding, in the
+    /// preceding sizeof(void*) bytes.  A currently-allocated chunk must contain a
+    /// backpointer to its owning context.  The backpointer is used by pfree() and
+    /// repalloc() to find the context to call.
+    ///
+    /// # Safety
+    ///
+    /// The specified `pointer` **must** be one allocated by Postgres (via [`palloc`] and friends).
+    ///
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `pointer` is null, if it's not properly aligned, or if the memory
+    /// it points do doesn't have the a header that looks like a memory context pointer
+    #[allow(non_snake_case)]
+    pub unsafe fn GetMemoryContextChunk(
+        pointer: *mut std::os::raw::c_void,
+    ) -> pg_sys::MemoryContext {
+        /*
+         * Try to detect bogus pointers handed to us, poorly though we can.
+         * Presumably, a pointer that isn't MAXALIGNED isn't pointing at an
+         * allocated chunk.
+         */
+        assert!(!pointer.is_null());
+        assert_eq!(pointer, MAXALIGN(pointer as usize) as *mut ::std::os::raw::c_void);
+
+        /*
+         * OK, it's probably safe to look at the context.
+         */
+        // 	context = *(MemoryContext *) (((char *) pointer) - sizeof(void *));
+        let context = unsafe {
+            // SAFETY: the caller has assured us that `pointer` points to palloc'd memory, which
+            // means it'll have this header before it
+            *(pointer
+                .cast::<::std::os::raw::c_char>()
+                .sub(std::mem::size_of::<*mut ::std::os::raw::c_void>())
+                .cast())
+        };
+
+        assert!(MemoryContextIsValid(context));
+
+        context
+    }
+
+    /// Returns true if memory context is valid, as Postgres determines such a thing.
+    ///
+    /// # Safety
+    ///
+    /// Caller must determine that the specified `context` pointer, if it's probably a [`MemoryContextData`]
+    /// pointer, really is.  This function is a best effort, not a guarantee.
+    ///
+    /// # Implementation Note
+    ///
+    /// If Postgres adds more memory context types in the future, we need to do that here too.
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub unsafe fn MemoryContextIsValid(context: *mut crate::MemoryContextData) -> bool {
+        // #define MemoryContextIsValid(context) \
+        // 	((context) != NULL && \
+        // 	 (IsA((context), AllocSetContext) || \
+        // 	  IsA((context), SlabContext) || \
+        // 	  IsA((context), GenerationContext)))
+
+        !context.is_null()
+            && unsafe {
+                // SAFETY:  we just determined that context isn't null, so it's safe to `.as_ref()`
+                // and `.unwrap_unchecked()`
+                let context = context.as_ref().unwrap_unchecked();
+
+                context.type_ == crate::NodeTag_T_AllocSetContext
+                    || context.type_ == crate::NodeTag_T_SlabContext
+                    || context.type_ == crate::NodeTag_T_GenerationContext
+            }
+    }
+
     #[inline]
     pub fn VARHDRSZ_EXTERNAL() -> usize {
         offset_of!(super::varattrib_1b_e, va_data)

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -398,11 +398,9 @@ mod all_versions {
             && unsafe {
                 // SAFETY:  we just determined that context isn't null, so it's safe to `.as_ref()`
                 // and `.unwrap_unchecked()`
-                let context = context.as_ref().unwrap_unchecked();
-
-                context.type_ == crate::NodeTag_T_AllocSetContext
-                    || context.type_ == crate::NodeTag_T_SlabContext
-                    || context.type_ == crate::NodeTag_T_GenerationContext
+                (*context).type_ == crate::NodeTag_T_AllocSetContext
+                    || (*context).type_ == crate::NodeTag_T_SlabContext
+                    || (*context).type_ == crate::NodeTag_T_GenerationContext
             }
     }
 

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -34,7 +34,8 @@ impl Clone for PallocdVarlena {
         // SAFETY:  we know that `self.ptr` is valid as the only way we could have gotten one
         // is internally via Postgres
         let ptr = unsafe {
-            PgMemoryContexts::Of(self.ptr as void_mut_ptr)
+            PgMemoryContexts::of(self.ptr as void_mut_ptr)
+                .expect("could not determine owning memory context")
                 .copy_ptr_into(self.ptr as void_mut_ptr, len) as *mut pg_sys::varlena
         };
 

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -21,6 +21,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr;
 use pgx_pg_sys::PgTryBuilder;
 use std::fmt::Debug;
+use std::ptr::NonNull;
 
 /// A shorter type name for a `*const std::os::raw::c_void`
 #[allow(non_camel_case_types)]
@@ -157,7 +158,7 @@ pub enum PgMemoryContexts {
     /// It's incredibly important that the specified pointer be one actually allocated by
     /// Postgres' memory management system.  Otherwise, it's undefined behavior and will
     /// **absolutely** crash Postgres
-    Of(void_ptr),
+    Of(OwnerMemoryContext),
 
     /// Create a temporary MemoryContext for use with `::switch_to()`.  It gets deleted as soon
     /// as `::switch_to()` exits.
@@ -192,6 +193,12 @@ impl Drop for OwnedMemoryContext {
     }
 }
 
+/// A `pg_sys::MemoryContext` that allocated a specific pointer
+#[derive(Debug, Clone, Copy)]
+pub struct OwnerMemoryContext {
+    memcxt: NonNull<pg_sys::MemoryContextData>,
+}
+
 impl PgMemoryContexts {
     /// Create a new `PgMemoryContext::Owned`
     pub fn new(name: &str) -> PgMemoryContexts {
@@ -210,6 +217,33 @@ impl PgMemoryContexts {
         })
     }
 
+    /// Create a [`PgMemoryContexts::Of`] variant that wraps the [`pg_sys::MemoryContext`] that owns
+    /// the specified pointer.
+    ///
+    /// Note that the specified pointer **must** be allocated by Postgres, via [`pg_sys::palloc`] or
+    /// similar functions.
+    ///
+    /// Returns [`Option::None`] if the specified pointer is null.
+    ///
+    /// # Safety
+    ///
+    /// This function is incredibly unsafe.  If the specified pointer is not one originally allocated
+    /// by Postgres, there is absolutely no telling what will be returned.
+    ///
+    /// Furthermore, users of this function's return value have no choice but to assume the returned
+    /// [`PgMemoryContexts::Of`] variant represents a legitimate [`pg_sys::MemoryContext`].
+    pub unsafe fn of(ptr: void_mut_ptr) -> Option<PgMemoryContexts> {
+        let parent = unsafe {
+            // (un)SAFETY: the caller assumes responsibility for ensuring the provided pointer is
+            // going to be accepted by Postgres `GetMemoryContextChunk`.  Postgres will ERROR
+            // if its invariants aren't met, but who really knows when the ptr could have come
+            // come from anywhere
+            pg_sys::GetMemoryContextChunk(ptr)
+        };
+        let memcxt = NonNull::new(parent)?;
+        Some(PgMemoryContexts::Of(OwnerMemoryContext { memcxt }))
+    }
+
     /// Retrieve the underlying Postgres `*mut MemoryContextData`
     ///
     /// This works for every type except the `::Transient` type.
@@ -226,7 +260,7 @@ impl PgMemoryContexts {
             PgMemoryContexts::CurTransactionContext => unsafe { pg_sys::CurTransactionContext },
             PgMemoryContexts::For(mc) => *mc,
             PgMemoryContexts::Owned(mc) => mc.owned,
-            PgMemoryContexts::Of(ptr) => PgMemoryContexts::get_context_for_pointer(*ptr),
+            PgMemoryContexts::Of(owner) => owner.memcxt.as_ptr(),
             PgMemoryContexts::Transient { .. } => {
                 panic!("cannot use value() to retrieve a Transient PgMemoryContext")
             }
@@ -509,68 +543,5 @@ impl PgMemoryContexts {
             }
             _ => unguarded_exec_in_context(self.value(), f),
         }
-    }
-
-    ///
-    /// GetMemoryChunkContext
-    ///    Given a currently-allocated chunk, determine the context
-    ///         it belongs to.
-    ///
-    /// All chunks allocated by any memory context manager are required to be
-    /// preceded by the corresponding MemoryContext stored, without padding, in the
-    /// preceding sizeof(void*) bytes.  A currently-allocated chunk must contain a
-    /// backpointer to its owning context.  The backpointer is used by pfree() and
-    /// repalloc() to find the context to call.
-    ///
-    fn get_context_for_pointer(ptr: void_ptr) -> pg_sys::MemoryContext {
-        extern "C" {
-            pub fn pgx_GetMemoryContextChunk(pointer: void_ptr) -> pg_sys::MemoryContext;
-        }
-        unsafe { pgx_GetMemoryContextChunk(ptr) }
-
-        //
-        // the below causes PG to crash b/c it mis-calculates where the MemoryContext address is
-        //
-        // I have likely either screwed up max_align()/type_align() or the pointer math at the
-        // bottom of the function
-        //
-
-        //        // #define MAXALIGN(LEN)                  TYPEALIGN(MAXIMUM_ALIGNOF, (LEN))
-        //        #[inline]
-        //        fn max_align(len: void_ptr) -> void_ptr {
-        //            // #define TYPEALIGN(ALIGNVAL,LEN)  \
-        //            //      (((uintptr_t) (LEN) + ((ALIGNVAL) - 1)) & ~((uintptr_t) ((ALIGNVAL) - 1)))
-        //            #[inline]
-        //            fn type_align(
-        //                alignval: u32,
-        //                len: void_ptr,
-        //            ) -> void_ptr {
-        //                (((len as usize) + ((alignval) - 1) as usize) & !(((alignval) - 1) as usize))
-        //                    as void_ptr
-        //            }
-        //            type_align(pg_sys::MAXIMUM_ALIGNOF, len)
-        //        }
-        //
-        //        let context;
-        //
-        //        /*
-        //         * Try to detect bogus pointers handed to us, poorly though we can.
-        //         * Presumably, a pointer that isn't MAXALIGNED isn't pointing at an
-        //         * allocated chunk.
-        //         */
-        //        assert!(!ptr.is_null());
-        //        assert_eq!(
-        //            ptr as void_ptr,
-        //            max_align(ptr) as void_ptr
-        //        );
-        //
-        //        /*
-        //         * OK, it's probably safe to look at the context.
-        //         */
-        //        //            context = *(MemoryContext *) (((char *) pointer) - sizeof(void *));
-        //        context = (((ptr as *const std::os::raw::c_char) as usize)
-        //            - std::mem::size_of::<void_ptr>())
-        //            as pg_sys::MemoryContext;
-        //        context
     }
 }


### PR DESCRIPTION
So much so that it's now been removed (it was a dumb wrapper around `pgx_GetMemoryContextChunk` anyways in favor of a type that forces the user to go through an `unsafe{}` block to get a `PgMemoryContexts::Of()` variant.

Also, the `pgx_GetMemoryContextChunk` function has been ported to Rust (removed from the c-shim) and moved over to pgx-pg-sys as `GetMemoryContextChunk`.  And with it came a new `MemoryContextIdValid` function.

Note that this also required ripping off the `TYPEALIGN` and `MAXALIGN` functions from PR https://github.com/tcdi/pgx/pull/948, so once it and this is merged, there needs to be some kind of follow-up.