### PR TITLE
Port c-shim.c `pgx_GETSTRUCT` and `pgx_HeapTupleHeaderGetOid` to Rust

### DIFF
--- a/pgx-pg-sys/cshim/pgx-cshim.c
+++ b/pgx-pg-sys/cshim/pgx-cshim.c
@@ -164,18 +164,6 @@ ListCell *pgx_list_nth_cell(List *list, int nth) {
     return list_nth_cell(list, nth);
 }
 
-#if IS_PG_11
-PGDLLEXPORT Oid pgx_HeapTupleHeaderGetOid(HeapTupleHeader htup_header);
-Oid pgx_HeapTupleHeaderGetOid(HeapTupleHeader htup_header) {
-    return HeapTupleHeaderGetOid(htup_header);
-}
-#endif
-
-PGDLLEXPORT char *pgx_GETSTRUCT(HeapTuple tuple);
-char *pgx_GETSTRUCT(HeapTuple tuple) {
-    return GETSTRUCT(tuple);
-}
-
 PGDLLEXPORT char *pgx_ARR_DATA_PTR(ArrayType *arr);
 char *pgx_ARR_DATA_PTR(ArrayType *arr) {
     return ARR_DATA_PTR(arr);

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -298,14 +298,13 @@ mod all_versions {
     /// # Safety
     ///
     /// This function cannot determine if the `tuple` argument is really a non-null pointer to a [`HeapTuple`].
+    #[inline(always)]
     pub unsafe fn GETSTRUCT(tuple: crate::HeapTuple) -> *mut std::os::raw::c_char {
         // #define GETSTRUCT(TUP) ((char *) ((TUP)->t_data) + (TUP)->t_data->t_hoff)
-        tuple
-            .as_mut()
-            .unwrap_unchecked()
-            .t_data
-            .cast::<std::os::raw::c_char>()
-            .add(tuple.as_ref().unwrap_unchecked().t_data.as_ref().unwrap_unchecked().t_hoff as _)
+
+        // SAFETY:  The caller has asserted `tuple` is a valid HeapTuple and is properly aligned
+        // Additionally, t_data.t_hoff is an a u8, so it'll fit inside a usize
+        (*tuple).t_data.cast::<std::os::raw::c_char>().add((*(*tuple).t_data).t_hoff as _)
     }
 
     #[inline]

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -291,7 +291,21 @@ mod all_versions {
         pub fn pgx_list_nth_int(list: *mut super::List, nth: i32) -> i32;
         pub fn pgx_list_nth_oid(list: *mut super::List, nth: i32) -> super::Oid;
         pub fn pgx_list_nth_cell(list: *mut super::List, nth: i32) -> *mut super::ListCell;
-        pub fn pgx_GETSTRUCT(tuple: pg_sys::HeapTuple) -> *mut std::os::raw::c_char;
+    }
+
+    /// Given a valid HeapTuple pointer, return address of the user data
+    ///
+    /// # Safety
+    ///
+    /// This function cannot determine if the `tuple` argument is really a non-null pointer to a [`HeapTuple`].
+    pub unsafe fn GETSTRUCT(tuple: crate::HeapTuple) -> *mut std::os::raw::c_char {
+        // #define GETSTRUCT(TUP) ((char *) ((TUP)->t_data) + (TUP)->t_data->t_hoff)
+        tuple
+            .as_mut()
+            .unwrap_unchecked()
+            .t_data
+            .cast::<std::os::raw::c_char>()
+            .add(tuple.as_ref().unwrap_unchecked().t_data.as_ref().unwrap_unchecked().t_hoff as _)
     }
 
     #[inline]
@@ -398,12 +412,27 @@ mod all_versions {
         buffer < 0
     }
 
+    /// Retrieve the "user data" of the specified [`HeapTuple`] as a specific type. Typically this
+    /// will be a struct that represents a Postgres system catalog, such as [`FormData_pg_class`].
+    ///
+    /// # Returns
+    ///
+    /// A pointer to the [`HeapTuple`]'s "user data", cast as a mutable pointer to `T`.  If the
+    /// specified `htup` pointer is null, the null pointer is returned.
+    ///
+    /// # Safety
+    ///
+    /// This function cannot verify that the specified `htup` points to a valid [`HeapTuple`] nor
+    /// that if it does, that its bytes are bitwise compatible with `T`.
     #[inline]
-    pub fn heap_tuple_get_struct<T>(htup: super::HeapTuple) -> *mut T {
+    pub unsafe fn heap_tuple_get_struct<T>(htup: super::HeapTuple) -> *mut T {
         if htup.is_null() {
-            0 as *mut T
+            std::ptr::null_mut()
         } else {
-            unsafe { pgx_GETSTRUCT(htup) as *mut T }
+            unsafe {
+                // SAFETY:  The caller has told us `htop` is a valid HeapTuple
+                GETSTRUCT(htup).cast()
+            }
         }
     }
 

--- a/pgx/src/enum_helper.rs
+++ b/pgx/src/enum_helper.rs
@@ -94,10 +94,10 @@ unsafe fn extract_enum_oid(tup: *mut pg_sys::HeapTupleData) -> pg_sys::Oid {
     unsafe {
         // SAFETY:  The caller has assured us that `tup` is a valid HeapTupleData pointer and as such
         // we can correctly assume that its `t_data` member will be properly allocated
-        let t_data = tup.as_ref().unwrap_unchecked().t_data;
-        let header = t_data.as_ref().unwrap_unchecked();
-        if (header.t_infomask & pg_sys::HEAP_HASOID as u16) != 0 {
-            let oid_ptr = (t_data.cast::<std::os::raw::c_char>().add(header.t_hoff as _))
+        let t_data = (*tup).t_data;
+        let header = t_data;
+        if ((*header).t_infomask & pg_sys::HEAP_HASOID as u16) != 0 {
+            let oid_ptr = (t_data.cast::<std::os::raw::c_char>().add((*header).t_hoff as _))
                 .sub(std::mem::size_of::<pg_sys::Oid>())
                 .cast::<pg_sys::Oid>();
 


### PR DESCRIPTION
Our c-shim has a few functions that expose Postgres `#define` macros for inspecting and casting a `HeapTupleData`.

- `pgx_GETSTRUCT` is now known as `GETSTRUCT` and lives directly in `pgx-pg-sys/src/lib.rs`
- `pgx_HeapTupleHeaderGetOid` is (currently) only used by `enum_helper.rs` for Postgres v11, so that's where its port lives (as the impl for `fn extract_enum_oid()`, under a `#[cfg]` feature flag

Related to the other PRs about porting c-shim stuff to Rust.  This may be the last one.

Would appreciate your eyeballs, @workingjubilee.