### PR TITLE
Ensure setting owned memory context as current twice won't lead to problems (bugfix)

### DIFF
--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -78,4 +78,14 @@ mod tests {
         drop(ctx);
         assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, another_ctx.value());
     }
+
+    #[pg_test]
+    fn test_current_owned_memory_context_drop_when_set_current_twice() {
+        let ctx_parent = PgMemoryContexts::CurrentMemoryContext.value();
+        let mut ctx = PgMemoryContexts::new("test");
+        ctx.set_as_current();
+        ctx.set_as_current();
+        drop(ctx);
+        assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, ctx_parent);
+    }
 }

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -240,7 +240,11 @@ impl PgMemoryContexts {
 
             match self {
                 PgMemoryContexts::Owned(mc) => {
-                    mc.previous = old_context;
+                    // If the context is set as current while it's already current,
+                    // don't update `previous` as it'll self-reference instead.
+                    if old_context != mc.owned {
+                        mc.previous = old_context;
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
When an owned context is set as current twice, dropping it will fail or result in current context being deleted.

Solution: ensure we're not forgetting the "previous" context

When we set an owned context as a current one, but it is already current, it would previously overwrite the reference to the "previous" context to point to itself. At which point we don't know the previous context we can revert to anymore.

This change ensures setting an owned context as a current one in an uninterrupted sequence is idempotent.