### PR TITLE
clone implementation for PgTupleDesc

### DIFF
--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -611,6 +611,25 @@ mod sql_generator_tests {
             unimplemented!("Just a SQL generation test")
         }
     }
+
+    #[pg_extern]
+    fn generate_lots_of_dogs() -> SetOfIterator<'static, pgx::composite_type!("Dog")> {
+        let tuple_desc =
+            pgx::PgTupleDesc::for_composite_type("Dog").expect("Coudln't find TestType");
+
+        let tuples: Vec<PgHeapTuple<'_, AllocatedByRust>> = (0..10_000)
+            .into_iter()
+            .map(move |i| {
+                let datums: Vec<Option<pg_sys::Datum>> =
+                    vec!["good boy".into_datum(), i.into_datum()];
+
+                PgHeapTuple::from_datums(tuple_desc.clone(), datums)
+                    .expect("couldn't get heap tuple")
+            })
+            .collect();
+
+        SetOfIterator::new(tuples)
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -917,5 +936,17 @@ mod tests {
                 assert_eq!(e, pgx::spi::Error::DatumError(TryFromDatumError::IncompatibleTypes))
             }
         }
+    }
+
+    #[pg_test]
+    fn test_tuple_desc_clone() {
+        Spi::connect(|client| {
+            let query = "select * from generate_lots_of_dogs()";
+            let table = client.select(query, None, None);
+
+            assert_eq!(table.len(), 10_000);
+
+            Ok(Some(()))
+        });
     }
 }

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -940,13 +940,11 @@ mod tests {
 
     #[pg_test]
     fn test_tuple_desc_clone() {
-        Spi::connect(|client| {
+        let result = Spi::connect(|client| {
             let query = "select * from generate_lots_of_dogs()";
-            let table = client.select(query, None, None);
-
-            assert_eq!(table.len(), 10_000);
-
-            Ok(Some(()))
+            client.select(query, None, None)
         });
+        let table = result.expect("unable to select table result");
+        assert_eq!(table.len(), 10_000);
     }
 }


### PR DESCRIPTION
Adding `.clone()` for `PgTupleDesc` allows us to create composite type heap tuples quickly without generating a fresh `PgTupleDesc` for each instance of the tuple. 

The associated test shows the use case.   In my testing I was able to call `PgTupleDesc::for_composite_type(TYPE)` once and clone it 10,000 time 52x faster  than calling `PgTupleDesc::for_composite_type(TYPE)`  10,000 times (39ms vs .7ms)

This will improve performance on large SRF  or arrays of composite types