### PR TITLE
Teach `pgx-tests/src/framework.rs` to detect `cargo test` feature arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "arrays"
 version = "0.1.0"
 dependencies = [
@@ -1248,6 +1254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,6 +1415,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathsearch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da983bc5e582ab17179c190b4b66c7d76c5943a69c6d34df2a2b6bf8a2977b05"
+dependencies = [
+ "anyhow",
+ "libc",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1508,7 @@ dependencies = [
  "dirs",
  "eyre",
  "owo-colors",
+ "pathsearch",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1533,6 +1559,7 @@ dependencies = [
 name = "pgx-tests"
 version = "0.6.1"
 dependencies = [
+ "clap-cargo",
  "eyre",
  "libc",
  "once_cell",
@@ -1544,6 +1571,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror",
  "time",
 ]
@@ -2262,6 +2290,21 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d08ba83d6dde63d053e42d7230f0dc7f8d8efeb8d30d3681580d158156461ba"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -8,12 +8,13 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::command::get::{find_control_file, get_property};
+use crate::manifest::{display_version_info, PgVersionSource};
 use crate::profile::CargoProfile;
 use crate::CommandExecute;
 use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
-use pgx_pg_config::{get_target_dir, PgConfig};
+use pgx_pg_config::{get_target_dir, PgConfig, Pgx};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -48,7 +49,7 @@ pub(crate) struct Install {
 
 impl CommandExecute for Install {
     #[tracing::instrument(level = "error", skip(self))]
-    fn execute(self) -> eyre::Result<()> {
+    fn execute(mut self) -> eyre::Result<()> {
         let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
@@ -68,8 +69,13 @@ impl CommandExecute for Install {
             self.release.then_some(CargoProfile::Release).unwrap_or(CargoProfile::Dev),
         )?;
 
-        let features =
-            crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
+        crate::manifest::modify_features_for_version(
+            &Pgx::from_config()?,
+            Some(&mut self.features),
+            &package_manifest,
+            &PgVersionSource::SystemPath(pg_version),
+            self.test,
+        );
 
         install_extension(
             self.manifest_path.as_ref(),
@@ -79,7 +85,7 @@ impl CommandExecute for Install {
             &profile,
             self.test,
             None,
-            &features,
+            &self.features,
         )
     }
 }
@@ -101,6 +107,7 @@ pub(crate) fn install_extension(
     base_directory: Option<PathBuf>,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
+    display_version_info(pg_config, &PgVersionSource::SystemPath(pg_config.label()?.into()));
     let base_directory = base_directory.unwrap_or_else(|| PathBuf::from("/"));
     tracing::Span::current()
         .record("base_directory", &tracing::field::display(&base_directory.display()));

--- a/cargo-pgx/src/command/install.rs
+++ b/cargo-pgx/src/command/install.rs
@@ -73,10 +73,11 @@ impl CommandExecute for Install {
             &Pgx::from_config()?,
             Some(&mut self.features),
             &package_manifest,
-            &PgVersionSource::SystemPath(pg_version),
+            &PgVersionSource::PgConfig(pg_version),
             self.test,
         );
 
+        display_version_info(&pg_config, &PgVersionSource::PgConfig(pg_config.label()?.into()));
         install_extension(
             self.manifest_path.as_ref(),
             self.package.as_ref(),
@@ -107,7 +108,6 @@ pub(crate) fn install_extension(
     base_directory: Option<PathBuf>,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
-    display_version_info(pg_config, &PgVersionSource::SystemPath(pg_config.label()?.into()));
     let base_directory = base_directory.unwrap_or_else(|| PathBuf::from("/"));
     tracing::Span::current()
         .record("base_directory", &tracing::field::display(&base_directory.display()));

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -8,11 +8,12 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::command::install::install_extension;
+use crate::manifest::PgVersionSource;
 use crate::CommandExecute;
 use crate::{command::get::get_property, profile::CargoProfile};
 use cargo_toml::Manifest;
 use eyre::{eyre, WrapErr};
-use pgx_pg_config::{get_target_dir, PgConfig};
+use pgx_pg_config::{get_target_dir, PgConfig, Pgx};
 use std::path::{Path, PathBuf};
 
 /// Create an installation package directory.
@@ -48,7 +49,7 @@ pub(crate) struct Package {
 
 impl CommandExecute for Package {
     #[tracing::instrument(level = "error", skip(self))]
-    fn execute(self) -> eyre::Result<()> {
+    fn execute(mut self) -> eyre::Result<()> {
         let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(&metadata)?;
@@ -64,8 +65,13 @@ impl CommandExecute for Package {
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
 
-        let features =
-            crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
+        crate::manifest::modify_features_for_version(
+            &Pgx::from_config()?,
+            Some(&mut self.features),
+            &package_manifest,
+            &PgVersionSource::SystemPath(pg_version),
+            false,
+        );
         let profile = CargoProfile::from_flags(
             self.profile.as_deref(),
             // NB:  `cargo pgx package` defaults to "--release" whereas all other commands default to "debug"
@@ -84,7 +90,7 @@ impl CommandExecute for Package {
             out_dir,
             &profile,
             self.test,
-            &features,
+            &self.features,
         )
     }
 }

--- a/cargo-pgx/src/command/package.rs
+++ b/cargo-pgx/src/command/package.rs
@@ -8,7 +8,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::command::install::install_extension;
-use crate::manifest::PgVersionSource;
+use crate::manifest::{display_version_info, PgVersionSource};
 use crate::CommandExecute;
 use crate::{command::get::get_property, profile::CargoProfile};
 use cargo_toml::Manifest;
@@ -69,7 +69,7 @@ impl CommandExecute for Package {
             &Pgx::from_config()?,
             Some(&mut self.features),
             &package_manifest,
-            &PgVersionSource::SystemPath(pg_version),
+            &PgVersionSource::PgConfig(pg_version),
             false,
         );
         let profile = CargoProfile::from_flags(
@@ -114,6 +114,7 @@ pub(crate) fn package_extension(
         std::fs::create_dir_all(&out_dir)?;
     }
 
+    display_version_info(pg_config, &PgVersionSource::PgConfig(pg_config.label()?.into()));
     install_extension(
         user_manifest_path,
         user_package,

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 // Since we support extensions with `#[no_std]`
 extern crate alloc;
+use crate::manifest::{get_package_manifest, pg_config_and_version};
 use alloc::vec::Vec;
 
 // An apparent bug in `glibc` 2.17 prevents us from safely dropping this
@@ -74,16 +75,7 @@ pub(crate) struct Schema {
 
 impl CommandExecute for Schema {
     #[tracing::instrument(level = "error", skip(self))]
-    fn execute(self) -> eyre::Result<()> {
-        let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
-            .wrap_err("couldn't get cargo metadata")?;
-        crate::metadata::validate(&metadata)?;
-        let package_manifest_path =
-            crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                .wrap_err("Couldn't get manifest path")?;
-        let package_manifest =
-            Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
-
+    fn execute(mut self) -> eyre::Result<()> {
         let log_level = if let Ok(log_level) = std::env::var("RUST_LOG") {
             Some(log_level)
         } else {
@@ -95,27 +87,19 @@ impl CommandExecute for Schema {
             }
         };
 
-        let (pg_config, pg_version) = match self.pg_config {
-            None => match self.pg_version {
-                None => {
-                    let pg_version = match self.pg_version {
-                        Some(s) => s,
-                        None => crate::manifest::default_pg_version(&package_manifest)
-                            .ok_or(eyre!("No provided `pg$VERSION` flag."))?,
-                    };
-                    (Pgx::from_config()?.get(&pg_version)?.clone(), pg_version)
-                }
-                Some(pgver) => (Pgx::from_config()?.get(&pgver)?.clone(), pgver),
-            },
-            Some(config) => {
-                let pg_config = PgConfig::new_with_defaults(PathBuf::from(config));
-                let pg_version = format!("pg{}", pg_config.major_version()?);
-                (pg_config, pg_version)
-            }
-        };
-
-        let features =
-            crate::manifest::features_for_version(self.features, &package_manifest, &pg_version);
+        let pgx = Pgx::from_config()?;
+        let (package_manifest, package_manifest_path) = get_package_manifest(
+            &self.features,
+            self.package.as_ref(),
+            self.manifest_path.as_ref(),
+        )?;
+        let (pg_config, _pg_version) = pg_config_and_version(
+            &pgx,
+            &package_manifest,
+            self.pg_version.clone(),
+            Some(&mut self.features),
+            true,
+        )?;
 
         let profile = CargoProfile::from_flags(
             self.profile.as_deref(),
@@ -129,7 +113,7 @@ impl CommandExecute for Schema {
             package_manifest_path,
             &profile,
             self.test,
-            &features,
+            &self.features,
             self.out.as_ref(),
             self.dot,
             log_level,

--- a/cargo-pgx/src/command/stop.rs
+++ b/cargo-pgx/src/command/stop.rs
@@ -8,16 +8,16 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 
 use crate::command::status::status_postgres;
+use crate::manifest::{get_package_manifest, pg_config_and_version};
 use crate::CommandExecute;
-use cargo_toml::Manifest;
-use eyre::{eyre, WrapErr};
+use eyre::eyre;
 use owo_colors::OwoColorize;
 use pgx_pg_config::{PgConfig, PgConfigSelector, Pgx};
 use std::path::PathBuf;
 use std::process::Stdio;
 
 /// Stop a pgx-managed Postgres instance
-#[derive(clap::Args, Debug)]
+#[derive(clap::Args, Debug, Clone)]
 #[clap(author)]
 pub(crate) struct Stop {
     /// The Postgres version to stop (`pg11`, `pg12`, `pg13`, `pg14`, `pg15`, or `all`)
@@ -36,32 +36,29 @@ pub(crate) struct Stop {
 impl CommandExecute for Stop {
     #[tracing::instrument(level = "error", skip(self))]
     fn execute(self) -> eyre::Result<()> {
-        let pgx = Pgx::from_config()?;
+        fn perform(me: Stop, pgx: &Pgx) -> eyre::Result<()> {
+            let (package_manifest, _) = get_package_manifest(
+                &clap_cargo::Features::default(),
+                me.package.as_ref(),
+                me.manifest_path,
+            )?;
+            let (pg_config, _) =
+                pg_config_and_version(&pgx, &package_manifest, me.pg_version, None, false)?;
 
-        let pg_version = match self.pg_version {
-            Some(s) => s,
-            None => {
-                let metadata =
-                    crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-                        .wrap_err("couldn't get cargo metadata")?;
-                crate::metadata::validate(&metadata)?;
-                let package_manifest_path =
-                    crate::manifest::manifest_path(&metadata, self.package.as_ref())
-                        .wrap_err("Couldn't get manifest path")?;
-                let package_manifest = Manifest::from_path(&package_manifest_path)
-                    .wrap_err("Couldn't parse manifest")?;
-
-                crate::manifest::default_pg_version(&package_manifest)
-                    .ok_or(eyre!("no provided `pg$VERSION` flag."))?
-            }
-        };
-
-        for pg_config in pgx.iter(PgConfigSelector::new(&pg_version)) {
-            let pg_config = pg_config?;
-            stop_postgres(pg_config)?
+            stop_postgres(pg_config)
         }
 
-        Ok(())
+        let pgx = Pgx::from_config()?;
+        if self.pg_version == Some("all".into()) {
+            for v in pgx.iter(PgConfigSelector::All) {
+                let mut versioned_start = self.clone();
+                versioned_start.pg_version = Some(v?.label()?);
+                perform(versioned_start, &pgx)?;
+            }
+            Ok(())
+        } else {
+            perform(self, &pgx)
+        }
     }
 }
 

--- a/cargo-pgx/src/manifest.rs
+++ b/cargo-pgx/src/manifest.rs
@@ -85,7 +85,7 @@ pub(crate) fn modify_features_for_version(
                     default_features
                         .iter()
                         // only include default features that aren't known pgXX version features
-                        .filter(|flag| pgx.get(flag).ok().is_none())
+                        .filter(|flag| !pgx.is_feature_flag(flag))
                         .cloned(),
                 );
             }

--- a/cargo-pgx/src/manifest.rs
+++ b/cargo-pgx/src/manifest.rs
@@ -8,9 +8,40 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 use cargo_metadata::Metadata;
 use cargo_toml::Manifest;
-use eyre::eyre;
-use pgx_pg_config::SUPPORTED_MAJOR_VERSIONS;
+use clap_cargo::Features;
+use eyre::{eyre, Context};
+use pgx_pg_config::{PgConfig, Pgx};
 use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub(crate) enum PgVersionSource {
+    UserSpecified(String),
+    FeatureFlag(String),
+    DefaultFeature(String),
+    SystemPath(String),
+}
+
+impl From<PgVersionSource> for String {
+    fn from(v: PgVersionSource) -> Self {
+        match v {
+            PgVersionSource::UserSpecified(s) => s,
+            PgVersionSource::FeatureFlag(s) => s,
+            PgVersionSource::DefaultFeature(s) => s,
+            PgVersionSource::SystemPath(s) => s,
+        }
+    }
+}
+
+impl PgVersionSource {
+    fn label(&self) -> &String {
+        match self {
+            PgVersionSource::UserSpecified(s) => s,
+            PgVersionSource::FeatureFlag(s) => s,
+            PgVersionSource::DefaultFeature(s) => s,
+            PgVersionSource::SystemPath(s) => s,
+        }
+    }
+}
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn manifest_path(
@@ -35,51 +66,148 @@ pub(crate) fn manifest_path(
     Ok(manifest_path)
 }
 
-pub(crate) fn default_pg_version(manifest: &Manifest) -> Option<String> {
-    let default_features = manifest.features.get("default")?;
-    for default_feature in default_features {
-        for major_version in SUPPORTED_MAJOR_VERSIONS {
-            let potential_feature = format!("pg{}", major_version);
-            if *default_feature == format!("pg{}", major_version) {
-                return Some(potential_feature);
+pub(crate) fn modify_features_for_version(
+    pgx: &Pgx,
+    features: Option<&mut Features>,
+    manifest: &Manifest,
+    pg_version: &PgVersionSource,
+    test: bool,
+) {
+    if let Some(features) = features {
+        if let Some(default_features) = manifest.features.get("default") {
+            if !features.no_default_features {
+                // if the user didn't specify `--no-default-features`, which would otherwise indicate
+                // they think they know what they're doing, we need to build an explicit set of features
+                // to use and turn on `--no-default-features`
+
+                features.no_default_features = true;
+                features.features.extend(
+                    default_features
+                        .iter()
+                        // only include default features that aren't known pgXX version features
+                        .filter(|flag| pgx.get(flag).ok().is_none())
+                        .cloned(),
+                );
             }
+        }
+
+        // if we know we're running from the `pgx-tests/src/framework.rs`, remove any user-specified features
+        // that aren't valid for the manifest
+        if test {
+            features.features.retain(|flag| {
+                if manifest.features.contains_key(flag) {
+                    true
+                } else {
+                    use owo_colors::OwoColorize;
+                    println!(
+                        "{} feature `{}`",
+                        "    Ignoring".bold().yellow(),
+                        flag.bold().white()
+                    );
+                    false
+                }
+            });
+        }
+
+        // no matter what, we need the postgres version we determined to be included in the
+        // set of features to compile with
+        if !features.features.contains(pg_version.label()) {
+            features.features.push(pg_version.label().clone());
         }
     }
-    None
 }
 
-pub(crate) fn features_for_version(
-    mut features: clap_cargo::Features,
+pub(crate) fn pg_config_and_version<'a>(
+    pgx: &'a Pgx,
     manifest: &Manifest,
-    pg_version: &String,
-) -> clap_cargo::Features {
-    let default_features = manifest.features.get("default");
+    specified_pg_version: Option<String>,
+    user_features: Option<&mut Features>,
+    verbose: bool,
+) -> eyre::Result<(&'a PgConfig, PgVersionSource)> {
+    let pg_version = {
+        'outer: loop {
+            if let Some(pg_version) = specified_pg_version {
+                // the user gave us an explicit Postgres version to use, so we will
+                break 'outer Some(PgVersionSource::UserSpecified(pg_version));
+            } else if let Some(features) = user_features.as_ref() {
+                // the user did not give us an explicit Postgres version, so see if there's one in the set
+                // of `--feature` flags they gave us
+                for flag in &features.features {
+                    if pgx.get(&flag).ok().is_some() {
+                        // use the first feature flag that is a Postgres version we support
+                        break 'outer Some(PgVersionSource::FeatureFlag(flag.clone()));
+                    }
+                }
 
-    match default_features {
-        Some(default_features) => {
-            if default_features.contains(&pg_version) {
-                return features;
-            }
-            let default_features = default_features
-                .iter()
-                .filter(|default_feature| {
-                    for supported_major in SUPPORTED_MAJOR_VERSIONS {
-                        if **default_feature == format!("pg{}", supported_major) {
-                            return false;
+                // user didn't give us a feature flag that is a Postgres version
+
+                // if they didn't ask for `--no-default-features` lets see if we have a default
+                // postgres version feature specified in the manifest
+                if !features.no_default_features {
+                    if let Some(default_features) = manifest.features.get("default") {
+                        for flag in default_features {
+                            if pgx.get(flag).ok().is_some() {
+                                break 'outer Some(PgVersionSource::DefaultFeature(flag.clone()));
+                            }
                         }
                     }
-                    true
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            features.no_default_features = true;
-            features.features.extend(default_features);
-            if features.features.iter().all(|f| f != pg_version) {
-                features.features.push(pg_version.clone());
+                }
+            } else {
+                // lets check the manifest for a default feature
+                if let Some(default_features) = manifest.features.get("default") {
+                    for flag in default_features {
+                        if pgx.get(flag).ok().is_some() {
+                            break 'outer Some(PgVersionSource::DefaultFeature(flag.clone()));
+                        }
+                    }
+                }
             }
+
+            // we cannot determine the Postgres version the user wants to use
+            break 'outer None;
         }
-        None => (),
     };
 
-    features
+    match pg_version {
+        Some(pg_version) => {
+            // we have determined a Postgres version
+
+            modify_features_for_version(pgx, user_features, manifest, &pg_version, false);
+            let pg_config = pgx.get(&pg_version.label())?;
+
+            if verbose {
+                display_version_info(pg_config, &pg_version);
+            }
+
+            Ok((pg_config, pg_version))
+        }
+        None => Err(eyre!("Could not determine which Postgres version feature flag to use")),
+    }
+}
+
+pub(crate) fn display_version_info(pg_config: &PgConfig, pg_version: &PgVersionSource) {
+    use owo_colors::OwoColorize;
+    eprintln!(
+        "{} {:?} and `pg_config` from {}",
+        "       Using".bold().green(),
+        pg_version.bold().white(),
+        pg_config.path().unwrap().display().cyan()
+    );
+}
+
+pub(crate) fn get_package_manifest(
+    features: &Features,
+    package_nane: Option<&String>,
+    manifest_path: Option<impl AsRef<std::path::Path>>,
+) -> eyre::Result<(Manifest, PathBuf)> {
+    let metadata = crate::metadata::metadata(&features, manifest_path.as_ref())
+        .wrap_err("couldn't get cargo metadata")?;
+    crate::metadata::validate(&metadata)?;
+    let package_manifest_path = crate::manifest::manifest_path(&metadata, package_nane)
+        .wrap_err("Couldn't get manifest path")?;
+
+    Ok((
+        Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?,
+        package_manifest_path,
+    ))
 }

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -14,6 +14,7 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
+bob = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 [dependencies]
 dirs = "4.0.0"
 eyre = "0.6.8"
+pathsearch = "0.2.0"
 owo-colors = "3.5.0"
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_derive = "1.0.149"

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -48,7 +48,7 @@ pub fn get_c_locale_flags() -> &'static [&'static str] {
 mod path_methods;
 pub use path_methods::{get_target_dir, prefix_path};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PgVersion {
     major: u16,
     minor: u16,
@@ -67,7 +67,7 @@ impl Display for PgVersion {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PgConfig {
     version: Option<PgVersion>,
     pg_config: Option<PathBuf>,
@@ -119,7 +119,9 @@ impl PgConfig {
     }
 
     pub fn from_path() -> Self {
-        Self::new_with_defaults("pg_config".into())
+        let path =
+            pathsearch::find_executable_in_path("pg_config").unwrap_or_else(|| "pg_config".into());
+        Self::new_with_defaults(path)
     }
 
     pub fn is_real(&self) -> bool {
@@ -285,15 +287,16 @@ impl PgConfig {
         match Command::new(&pg_config).arg(arg).output() {
             Ok(output) => Ok(String::from_utf8(output.stdout).unwrap().trim().to_string()),
             Err(e) => match e.kind() {
-                ErrorKind::NotFound => {
-                    Err(e).wrap_err_with(|| format!("Unable to find `{}`", "pg_config".yellow()))
-                }
+                ErrorKind::NotFound => Err(e).wrap_err_with(|| {
+                    format!("Unable to find `{}` on the system $PATH", "pg_config".yellow())
+                }),
                 _ => Err(e.into()),
             },
         }
     }
 }
 
+#[derive(Debug)]
 pub struct Pgx {
     pg_configs: Vec<PgConfig>,
     base_port: u16,

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -413,6 +413,17 @@ impl Pgx {
         Err(eyre!("Postgres `{}` is not managed by pgx", label))
     }
 
+    /// Returns true if the specified `label` represents a Postgres version number feature flag,
+    /// such as `pg14` or `pg15`
+    pub fn is_feature_flag(&self, label: &str) -> bool {
+        for v in SUPPORTED_MAJOR_VERSIONS {
+            if label == &format!("pg{}", v) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn home() -> Result<PathBuf, std::io::Error> {
         std::env::var("PGX_HOME").map_or_else(
             |_| {

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -32,6 +32,7 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.16.0"
 libc = "0.2.137"
@@ -41,6 +42,7 @@ postgres = "0.19.4"
 regex = "1.7.0"
 serde = "1.0.149"
 serde_json = "1.0.89"
+sysinfo = "0.27.0"
 time = "0.3.17"
 eyre = "0.6.8"
 thiserror = "1.0"

--- a/pgx-tests/src/framework.rs
+++ b/pgx-tests/src/framework.rs
@@ -7,6 +7,7 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
+use std::collections::HashSet;
 use std::process::{Command, Stdio};
 
 use eyre::{eyre, WrapErr};
@@ -20,6 +21,7 @@ use std::fmt::Write as _;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use sysinfo::{Pid, ProcessExt, System, SystemExt};
 
 mod shutdown;
 pub use shutdown::add_shutdown_hook;
@@ -283,10 +285,13 @@ fn install_extension() -> eyre::Result<()> {
     eprintln!("installing extension");
     let profile = std::env::var("PGX_BUILD_PROFILE").unwrap_or("debug".into());
     let no_schema = std::env::var("PGX_NO_SCHEMA").unwrap_or("false".into()) == "true";
-    let mut features = std::env::var("PGX_FEATURES").unwrap_or("".to_string());
-    if !features.contains("pg_test") {
-        features += " pg_test";
-    }
+    let mut features = std::env::var("PGX_FEATURES")
+        .unwrap_or("".to_string())
+        .split_ascii_whitespace()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+    features.insert("pg_test".into());
+
     let no_default_features =
         std::env::var("PGX_NO_DEFAULT_FEATURES").unwrap_or("false".to_string()) == "true";
     let all_features = std::env::var("PGX_ALL_FEATURES").unwrap_or("false".to_string()) == "true";
@@ -294,6 +299,10 @@ fn install_extension() -> eyre::Result<()> {
     let pg_version = format!("pg{}", pg_sys::get_pg_major_version_string());
     let pgx = Pgx::from_config()?;
     let pg_config = pgx.get(&pg_version)?;
+    let cargo_test_args = get_cargo_test_features()?;
+    println!("detected cargo args: {:?}", cargo_test_args);
+
+    features.extend(cargo_test_args.features.iter().cloned());
 
     let mut command = Command::new("cargo");
     command
@@ -315,16 +324,16 @@ fn install_extension() -> eyre::Result<()> {
         command.env("RUST_LOG", rust_log);
     }
 
-    if !features.trim().is_empty() {
+    if !features.is_empty() {
         command.arg("--features");
-        command.arg(features);
+        command.arg(features.into_iter().collect::<Vec<_>>().join(" "));
     }
 
-    if no_default_features {
+    if no_default_features || cargo_test_args.no_default_features {
         command.arg("--no-default-features");
     }
 
-    if all_features {
+    if all_features || cargo_test_args.all_features {
         command.arg("--all-features");
     }
 
@@ -623,4 +632,66 @@ pub fn get_named_capture(
         Some(cap) => Some(cap[name].to_string()),
         None => None,
     }
+}
+
+fn get_cargo_test_features() -> eyre::Result<clap_cargo::Features> {
+    let mut features = clap_cargo::Features::default();
+    let cargo_user_args = get_cargo_args();
+    let mut iter = cargo_user_args.iter();
+    while let Some(part) = iter.next() {
+        match part.as_str() {
+            "--no-default-features" => features.no_default_features = true,
+            "--features" => {
+                let configured_features = iter.next().ok_or(eyre!(
+                    "no `--features` specified in the cargo argument list: {:?}",
+                    cargo_user_args
+                ))?;
+                features.features =
+                    configured_features.split_ascii_whitespace().map(|s| s.to_string()).collect();
+            }
+            "--all-features" => features.all_features = true,
+            _ => {}
+        }
+    }
+
+    Ok(features)
+}
+
+fn get_cargo_args() -> Vec<String> {
+    // setup the sysinfo crate's "System"
+    let mut system = System::new_all();
+    system.refresh_all();
+
+    // starting with our process, look for the full set of arguments for the top-most "cargo" command
+    // in our process tree.
+    //
+    // it's possible we've been called by:
+    //  - the user from the command-line via `cargo test ...`
+    //  - `cargo pgx test ...`
+    //  - `cargo test ...`
+    //  - some other combination with a `cargo ...` in the middle, perhaps
+    //
+    // we're interested in the first arguments the **user** gave to cargo, so `framework.rs`
+    // can later figure out which set of features to pass to `cargo pgx`
+    let mut pid = Pid::from(std::process::id() as usize);
+    while let Some(process) = system.process(pid) {
+        // only if it's "cargo"...
+        if process.exe().ends_with("cargo") {
+            // ... and only if it's "cargo test"...
+            if process.cmd().iter().any(|arg| arg == "test")
+                && !process.cmd().iter().any(|arg| arg == "pgx")
+            {
+                // ... do we want its args
+                return process.cmd().iter().cloned().collect();
+            }
+        }
+
+        // and we want to keep going to find the top-most "cargo" process in our tree
+        match process.parent() {
+            Some(parent_pid) => pid = parent_pid,
+            None => break,
+        }
+    }
+
+    Vec::new()
 }


### PR DESCRIPTION
Running a plain `cargo test --features "a b c"` never properly worked with pgx' test framework as none of the "feature"-related arguments were being passed down into pgx' test framework.  Now they are.

In the case of a `cargo test --all --features "a b c"`-style execution, `cargo-pgx` will elide passing features to a workspace member that doesn't have that feature.

This necessitated reworking how **all** of the `cargo-pgx` commands detect which Postgres version feature flag to use, along with the general set of features to turn on.  The search order is now:

### schema/run/test/connect

- direct `cargo-pgx` argument
- `--features "pgXX"` flag
- `default = [ "pgXX" ]` from the extension's Cargo.toml

### install/package

- created from a direct `--pg_config` argument
- created from the `pg_config` on the system `$PATH`

### start/stop/status

- direct `cargo-pgx` argument
- `default = [ "pgXX" ]` from the extension's Cargo.toml

As a few drive-bys, teach cargo-pgx to output the type of `pgXX` feature flag it found and the full path to the `pg_config` binary it's using for that operation.