### PR TITLE
add doc to pg_test module in template

### DIFF
--- a/cargo-pgx/src/templates/lib_rs
+++ b/cargo-pgx/src/templates/lib_rs
@@ -19,10 +19,10 @@ mod tests {{
 
 }}
 
+/// This module is required by `cargo pgx test` invocations. 
+/// It must be visible at the root of your extension crate.
 #[cfg(test)]
 pub mod pg_test {{
-    // a public `pg_test` module with both `setup` and `postgresql_conf_options` function
-    // is required for `cargo pgx test` work properly
 
     pub fn setup(_options: Vec<&str>) {{
         // perform one-off initialization when the pg_test framework starts

--- a/cargo-pgx/src/templates/lib_rs
+++ b/cargo-pgx/src/templates/lib_rs
@@ -21,6 +21,9 @@ mod tests {{
 
 #[cfg(test)]
 pub mod pg_test {{
+    // a public `pg_test` module with both `setup` and `postgresql_conf_options` function
+    // is required for `cargo pgx test` work properly
+
     pub fn setup(_options: Vec<&str>) {{
         // perform one-off initialization when the pg_test framework starts
     }}

--- a/cargo-pgx/src/templates/lib_rs
+++ b/cargo-pgx/src/templates/lib_rs
@@ -23,7 +23,6 @@ mod tests {{
 /// It must be visible at the root of your extension crate.
 #[cfg(test)]
 pub mod pg_test {{
-
     pub fn setup(_options: Vec<&str>) {{
         // perform one-off initialization when the pg_test framework starts
     }}


### PR DESCRIPTION
Adding some doc to hopefully make it more clear about what is required for testing pgx extensions. As far as I can tell, tests won't run unless there's a module `pg_test` with BOTH `setup` and `postgresql_conf_options` defined.