### PR TITLE
`impl IntoDatum for Result<T: IntoDatum, E: Display>`

### DIFF
--- a/pgx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/mod.rs
@@ -419,6 +419,35 @@ impl PgExtern {
                     quote_spanned! { self.func.sig.output.span() =>
                        ::pgx::fcinfo::pg_return_void()
                     }
+                } else if retval_ty.result {
+                    if retval_ty.optional.is_some() {
+                        // returning `Result<Option<T>>`
+                        quote_spanned! {
+                            self.func.sig.output.span() =>
+                                match #result_ident {
+                                    // we panic if it's Result::Err
+                                    Err(e) => std::panic::panic_any(e),
+
+                                    // and we return the possibly NULL datum
+                                    Ok(value) => match ::pgx::datum::IntoDatum::into_datum(value) {
+                                        Some(datum) => datum,
+                                        None => ::pgx::fcinfo::pg_return_null(#fcinfo_ident),
+                                    }
+                                }
+                        }
+                    } else {
+                        // returning Result<T>
+                        quote_spanned! {
+                            self.func.sig.output.span() =>
+                                match #result_ident {
+                                    // we panic if it's Result:Err
+                                    Err(e) => std::panic::panic_any(e),
+
+                                    // and we return the datum, unless it's null then we raise a panic
+                                    Ok(value) => ::pgx::datum::IntoDatum::into_datum(value).unwrap_or_else(|| panic!("returned Datum was NULL")),
+                                }
+                        }
+                    }
                 } else if retval_ty.resolved_ty == syn::parse_quote!(pg_sys::Datum)
                     || retval_ty.resolved_ty == syn::parse_quote!(pgx::pg_sys::Datum)
                     || retval_ty.resolved_ty == syn::parse_quote!(::pgx::pg_sys::Datum)

--- a/pgx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/mod.rs
@@ -426,7 +426,7 @@ impl PgExtern {
                             self.func.sig.output.span() =>
                                 match #result_ident {
                                     // we panic if it's Result::Err
-                                    Err(e) => std::panic::panic_any(e),
+                                    Err(e) => panic!("{}", e),
 
                                     // and we return the possibly NULL datum
                                     Ok(value) => match ::pgx::datum::IntoDatum::into_datum(value) {
@@ -441,7 +441,7 @@ impl PgExtern {
                             self.func.sig.output.span() =>
                                 match #result_ident {
                                     // we panic if it's Result:Err
-                                    Err(e) => std::panic::panic_any(e),
+                                    Err(e) => panic!("{}", e),
 
                                     // and we return the datum, unless it's null then we raise a panic
                                     Ok(value) => ::pgx::datum::IntoDatum::into_datum(value).unwrap_or_else(|| panic!("returned Datum was NULL")),

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -48,6 +48,9 @@ time = "0.3.17"
 eyre = "0.6.8"
 thiserror = "1.0"
 
+[dev-dependencies]
+eyre = "0.6.8"  # testing functions that return `eyre::Result`
+
 [dependencies.pgx]
 path = "../pgx"
 default-features = false

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod pgbox_tests;
 mod pgx_module_qualification;
 mod postgres_type_tests;
 mod range_tests;
+mod result_tests;
 mod schema_tests;
 mod shmem_tests;
 mod spi_tests;

--- a/pgx-tests/src/tests/result_tests.rs
+++ b/pgx-tests/src/tests/result_tests.rs
@@ -12,6 +12,16 @@ mod tests {
     }
 
     #[pg_extern]
+    fn return_some_optional_result() -> Result<Option<i32>, Infallible> {
+        Ok(Some(42))
+    }
+
+    #[pg_extern]
+    fn return_none_optional_result() -> Result<Option<i32>, Infallible> {
+        Ok(None)
+    }
+
+    #[pg_extern]
     fn return_some_error() -> Result<i32, Box<dyn std::error::Error>> {
         Err("error!".into())
     }
@@ -34,6 +44,16 @@ mod tests {
     #[pg_test]
     fn test_return_result() {
         Spi::get_one::<i32>("SELECT tests.return_result()").expect("SPI returned NULL");
+    }
+
+    #[pg_test]
+    fn test_return_some_optional_result() {
+        assert_eq!(Some(42), Spi::get_one::<i32>("SELECT tests.return_some_optional_result()"));
+    }
+
+    #[pg_test]
+    fn test_return_none_optional_result() {
+        assert_eq!(None, Spi::get_one::<i32>("SELECT tests.return_none_optional_result()"));
     }
 
     #[pg_test(error = "error!")]

--- a/pgx-tests/src/tests/result_tests.rs
+++ b/pgx-tests/src/tests/result_tests.rs
@@ -1,0 +1,53 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+    use pgx::prelude::*;
+    use std::convert::Infallible;
+
+    #[pg_extern]
+    fn return_result() -> Result<i32, Infallible> {
+        Ok(42)
+    }
+
+    #[pg_extern]
+    fn return_some_error() -> Result<i32, Box<dyn std::error::Error>> {
+        Err("error!".into())
+    }
+
+    #[pg_extern]
+    fn return_eyre_result() -> eyre::Result<i32> {
+        Ok(42)
+    }
+
+    #[pg_extern]
+    fn return_eyre_result_error() -> eyre::Result<i32> {
+        Err(eyre::eyre!("error!"))
+    }
+
+    #[pg_test(error = "No such file or directory (os error 2)")]
+    fn test_return_io_error() -> Result<(), std::io::Error> {
+        std::fs::read("/tmp/i-sure-hope-this-doest-exist.pgx-tests::test_result_result").map(|_| ())
+    }
+
+    #[pg_test]
+    fn test_return_result() {
+        Spi::get_one::<i32>("SELECT tests.return_result()").expect("SPI returned NULL");
+    }
+
+    #[pg_test(error = "error!")]
+    fn test_return_some_error() {
+        Spi::get_one::<i32>("SELECT tests.return_some_error()").expect("SPI returned NULL");
+    }
+
+    #[pg_test]
+    fn test_return_eyre_result() {
+        Spi::get_one::<i32>("SELECT tests.return_eyre_result()").expect("SPI returned NULL");
+    }
+
+    #[pg_test(error = "error!")]
+    fn test_return_eyre_result_error() {
+        Spi::get_one::<i32>("SELECT tests.return_eyre_result_error()").expect("SPI returned NULL");
+    }
+}

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -380,11 +380,12 @@ impl IntoDatum for Vec<u8> {
     }
 }
 
-/// for NULL -- always converts to `None`
+/// for VOID
 impl IntoDatum for () {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        None
+        // VOID isn't very useful, but Postgres represents it as a non-null Datum with a zero value
+        Some(Datum::from(0))
     }
 
     fn type_oid() -> u32 {

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -13,7 +13,9 @@ Use of this source code is governed by the MIT license that can be found in the 
 //! cast of the primitive type to pg_sys::Datum
 
 use crate::{pg_sys, rust_regtypein, PgBox, PgOid, WhoAllocated};
-use pgx_pg_sys::{Datum, Oid};
+use core::fmt::Display;
+use pgx_pg_sys::errcodes::PgSqlErrorCode;
+use pgx_pg_sys::{ereport, Datum, Oid};
 
 /// Convert a Rust type into a `pg_sys::Datum`.
 ///
@@ -116,6 +118,33 @@ where
     }
 
     fn type_oid() -> u32 {
+        T::type_oid()
+    }
+}
+
+impl<T, E> IntoDatum for Result<T, E>
+where
+    T: IntoDatum,
+    E: Display,
+{
+    /// Returns The `Option<pg_sys::Datum>` representation of this Result's `Ok` variant.
+    ///
+    /// ## Panics
+    ///
+    /// If this Result represents an error, then that error is raised as a Postgres ERROR, using
+    /// the [`PgSqlErrorCode::ERRCODE_DATA_EXCEPTION`] error code
+    #[inline]
+    fn into_datum(self) -> Option<Datum> {
+        match self {
+            Ok(v) => v.into_datum(),
+            Err(e) => {
+                ereport!(ERROR, PgSqlErrorCode::ERRCODE_DATA_EXCEPTION, &format!("{}", e));
+            }
+        }
+    }
+
+    #[inline]
+    fn type_oid() -> pg_sys::Oid {
         T::type_oid()
     }
 }


### PR DESCRIPTION
This pulls out some commits from #969 into its own PR to add support for `#[pg_extern]`-style functions returning a `Result` of some kind.

We don't care about the type of the Error, so long as it implements `Display`.  If the returned value is the Err variant, we simply `panic!("{}", e)` with it.  

It's tested to also work with the [`eyre::Result`](https://docs.rs/eyre/latest/eyre/type.Result.html) type along with returning `Result<Option<T>, E>`.

It also allows `#[pg_test]` functions to return Results which makes writing unit tests a little nicer.