### PR TITLE
Change bounds on `IntoDatum for Result<T, E>` such that `E: Any + Display`

### DIFF
--- a/pgx-pg-sys/src/submodules/panic.rs
+++ b/pgx-pg-sys/src/submodules/panic.rs
@@ -79,6 +79,19 @@ pub struct ErrorReport {
     pub(crate) location: ErrorReportLocation,
 }
 
+impl Display for ErrorReport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.sqlerrcode, self.message)?;
+        if let Some(hint) = &self.hint {
+            write!(f, "\nHINT: {}", hint)?;
+        }
+        if let Some(detail) = &self.detail {
+            write!(f, "\nDETAIL: {}", detail)?;
+        }
+        write!(f, "{}", self.location)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ErrorReportWithLevel {
     pub(crate) level: PgLogLevel,

--- a/pgx-pg-sys/src/submodules/panic.rs
+++ b/pgx-pg-sys/src/submodules/panic.rs
@@ -88,7 +88,7 @@ impl Display for ErrorReport {
         if let Some(detail) = &self.detail {
             write!(f, "\nDETAIL: {}", detail)?;
         }
-        write!(f, "{}", self.location)
+        write!(f, "\nLOCATION: {}", self.location)
     }
 }
 

--- a/pgx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -6,6 +6,7 @@ A trait denoting a type can possibly be mapped to an SQL type
 to the `pgx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */
+use std::any::Any;
 use std::error::Error;
 use std::fmt::Display;
 
@@ -109,7 +110,7 @@ pub unsafe trait SqlTranslatable {
 
 unsafe impl<E> SqlTranslatable for Result<(), E>
 where
-    E: Display,
+    E: Any + Display,
 {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Err(ArgumentError::NotValidAsArgument("()"))
@@ -153,7 +154,7 @@ where
 unsafe impl<T, E> SqlTranslatable for Result<T, E>
 where
     T: SqlTranslatable,
-    E: Display,
+    E: Any + Display,
 {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         T::argument_sql()


### PR DESCRIPTION
Broaden the bounds on our support for converting a Result into a datum a bit so that we can detect if the `Err` variant contains one of our `ErrorReport` types.  If it does, that's the thing we'll raise, at the `PgLogLevels::ERROR` level.  Otherwise we'll just raise a `panic!()` with the to_string() of the error as before.

This enables users to return `Result::Err` variants that contain a more rich set of error reporting information such as a specific `PgSqlErrorCode` and optionally "hint" and "detail" lines.