### PR TITLE
Add pg_tablespace catalog header

### DIFF
--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -37,6 +37,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"
 #include "commands/comment.h"

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -46,6 +46,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/event_trigger.h"
 #include "commands/explain.h"
 #include "commands/proclang.h"
+#include "commands/tablespace.h"
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -39,6 +39,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"
 #include "commands/comment.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -48,6 +48,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/event_trigger.h"
 #include "commands/explain.h"
 #include "commands/proclang.h"
+#include "commands/tablespace.h"
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -39,6 +39,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"
 #include "commands/comment.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -48,6 +48,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/event_trigger.h"
 #include "commands/explain.h"
 #include "commands/proclang.h"
+#include "commands/tablespace.h"
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -39,6 +39,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"
 #include "commands/comment.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -48,6 +48,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/event_trigger.h"
 #include "commands/explain.h"
 #include "commands/proclang.h"
+#include "commands/tablespace.h"
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"

--- a/pgx-pg-sys/include/pg15.h
+++ b/pgx-pg-sys/include/pg15.h
@@ -39,6 +39,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"
 #include "commands/comment.h"

--- a/pgx-pg-sys/include/pg15.h
+++ b/pgx-pg-sys/include/pg15.h
@@ -48,6 +48,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/event_trigger.h"
 #include "commands/explain.h"
 #include "commands/proclang.h"
+#include "commands/tablespace.h"
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"


### PR DESCRIPTION
Adds a missing header so that extensions can work on the pg_tablespace catalog.