### PR TITLE
Support returning `Result<TableIterator/SetOfIterator, E>`

### DIFF
--- a/pgx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -289,7 +289,7 @@ impl ToSql for PgExternEntity {
                         full_path = ty.full_path
                     )
                 }
-                PgExternReturnEntity::SetOf { ty, optional: _ } => {
+                PgExternReturnEntity::SetOf { ty, optional: _, result: _ } => {
                     let graph_index = context
                         .graph
                         .neighbors_undirected(self_index)
@@ -325,7 +325,7 @@ impl ToSql for PgExternEntity {
                         full_path = ty.full_path
                     )
                 }
-                PgExternReturnEntity::Iterated { tys: table_items, optional: _ } => {
+                PgExternReturnEntity::Iterated { tys: table_items, optional: _, result: _ } => {
                     let mut items = String::new();
                     let metadata_retval = self.metadata.retval.clone().ok_or_else(|| eyre!("Macro expansion time and SQL resolution time had differing opinions about the return value existing"))?;
                     let metadata_retval_sqls = match metadata_retval.return_sql {

--- a/pgx-sql-entity-graph/src/pg_extern/entity/returning.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/entity/returning.rs
@@ -25,10 +25,12 @@ pub enum PgExternReturnEntity {
     SetOf {
         ty: UsedTypeEntity,
         optional: bool, /* Eg `Option<SetOfIterator<T>>` */
+        result: bool,   /* Eg `Result<SetOfIterator<T>, E>` */
     },
     Iterated {
         tys: Vec<PgExternReturnEntityIteratedItem>,
         optional: bool, /* Eg `Option<TableIterator<T>>` */
+        result: bool,   /* Eg `Result<TableIterator<T>, E>` */
     },
     Trigger,
 }

--- a/pgx-sql-entity-graph/src/pgx_sql.rs
+++ b/pgx-sql-entity-graph/src/pgx_sql.rs
@@ -832,7 +832,7 @@ fn initialize_externs(
                     });
                 }
             }
-            PgExternReturnEntity::Iterated { tys: iterated_returns, optional: _ } => {
+            PgExternReturnEntity::Iterated { tys: iterated_returns, optional: _, result: _ } => {
                 for PgExternReturnEntityIteratedItem { ty: return_ty_entity, .. } in
                     iterated_returns
                 {
@@ -1025,7 +1025,7 @@ fn connect_externs(
                     }
                 }
             }
-            PgExternReturnEntity::Iterated { tys: iterated_returns, optional: _ } => {
+            PgExternReturnEntity::Iterated { tys: iterated_returns, optional: _, result: _ } => {
                 for PgExternReturnEntityIteratedItem { ty: type_entity, .. } in iterated_returns {
                     let mut found = false;
                     for (ty_item, &ty_index) in types {

--- a/pgx-tests/src/tests/result_tests.rs
+++ b/pgx-tests/src/tests/result_tests.rs
@@ -46,6 +46,28 @@ mod tests {
         ))
     }
 
+    #[pg_extern]
+    fn return_result_table_iterator(
+    ) -> Result<TableIterator<'static, (name!(a, i32), name!(b, i32))>, pgx::spi::Error> {
+        Ok(TableIterator::new(std::iter::once((1, 2))))
+    }
+
+    #[pg_extern]
+    fn return_result_table_iterator_error(
+    ) -> Result<TableIterator<'static, (name!(a, i32), name!(b, i32))>, pgx::spi::Error> {
+        Err(pgx::spi::Error::InvalidPosition)
+    }
+
+    #[pg_extern]
+    fn return_result_set_of() -> Result<SetOfIterator<'static, i32>, pgx::spi::Error> {
+        Ok(SetOfIterator::new(std::iter::once(1)))
+    }
+
+    #[pg_extern]
+    fn return_result_set_of_error() -> Result<SetOfIterator<'static, i32>, pgx::spi::Error> {
+        Err(pgx::spi::Error::InvalidPosition)
+    }
+
     #[pg_test(error = "No such file or directory (os error 2)")]
     fn test_return_io_error() -> Result<(), std::io::Error> {
         std::fs::read("/tmp/i-sure-hope-this-doest-exist.pgx-tests::test_result_result").map(|_| ())
@@ -104,5 +126,25 @@ mod tests {
             "raised custom ereport",
             function_name!(),
         ))
+    }
+
+    #[pg_test]
+    fn test_return_result_table_iterator() {
+        Spi::run("SELECT * FROM tests.return_result_table_iterator()")
+    }
+
+    #[pg_test(error = "SpiTupleTable positioned before the start or after the end")]
+    fn test_return_result_table_iterator_error() {
+        Spi::run("SELECT * FROM tests.return_result_table_iterator_error()")
+    }
+
+    #[pg_test]
+    fn test_return_result_set_of() {
+        Spi::run("SELECT * FROM tests.return_result_set_of()")
+    }
+
+    #[pg_test(error = "SpiTupleTable positioned before the start or after the end")]
+    fn test_return_result_set_of_error() {
+        Spi::run("SELECT * FROM tests.return_result_set_of_error()")
     }
 }


### PR DESCRIPTION
Add the ability to return a Result of a TableIterator or SetOfIterator.  This just helps to make things more consistent with the other cases where we can now return a Result of something.

Also introduce a new trait, `pg_sys::panic::ErrorReportable` that when its `.report()` method is called will return a value or raise an error depending on the context.  We provide a default implementation for `Result<T, E: Any+Display>` that understands how to downcast the error to look for an `ErrorReport` instance.  This moves that code out of the `impl IntoDatum for Result` code.