### PR TITLE
Fix a bug trying to return `Result<pg_sys::Oid>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "petgraph",
  "proc-macro2",
  "quote",
+ "regex",
  "seq-macro",
  "syn",
  "syntect",

--- a/pgx-sql-entity-graph/Cargo.toml
+++ b/pgx-sql-entity-graph/Cargo.toml
@@ -22,6 +22,7 @@ eyre = "0.6.8"
 petgraph = "0.6.2"
 proc-macro2 = { version = "1.0.47", features = [ "span-locations" ] }
 quote = "1.0.21"
+regex = "1.7.0"
 syn = { version = "1.0.104", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 tracing = "0.1.37"

--- a/pgx-sql-entity-graph/src/pgx_sql.rs
+++ b/pgx-sql-entity-graph/src/pgx_sql.rs
@@ -472,7 +472,7 @@ impl PgxSql {
         //
         // What we want to do is rewrite any kind of `Result<T,E>` pattern into `Result<T,_>`, which
         // is how the `map_source_only!()` macro does it.
-        let pattern = regex::Regex::new("Result<(.*?),\\s*.*?>").expect("invalid regex pattern");
+        let pattern = regex::Regex::new("Result<(.*),\\s*.*?>").expect("invalid regex pattern");
         let ty_source = match pattern.captures(ty_source) {
             Some(captures) => {
                 let rust_type = captures.get(1).unwrap();

--- a/pgx-sql-entity-graph/src/pgx_sql.rs
+++ b/pgx-sql-entity-graph/src/pgx_sql.rs
@@ -465,7 +465,23 @@ impl PgxSql {
     }
 
     pub fn source_only_to_sql_type(&self, ty_source: &str) -> Option<String> {
-        self.source_mappings.get(ty_source).map(|f| f.sql.clone())
+        // HACK for `Result<T, E>` -- we replace the `E` with an underscore
+        // specifically, this is the cases where we need to use the `map_source_only!()` macro to
+        // create a Rust type to SQL type mapping.  As of this writing that's only for the `pg_sys::Oid`
+        // type, but we'll do our best to generalize this.
+        //
+        // What we want to do is rewrite any kind of `Result<T,E>` pattern into `Result<T,_>`, which
+        // is how the `map_source_only!()` macro does it.
+        let pattern = regex::Regex::new("Result<(.*?),\\s*.*?>").expect("invalid regex pattern");
+        let ty_source = match pattern.captures(ty_source) {
+            Some(captures) => {
+                let rust_type = captures.get(1).unwrap();
+                format!("Result<{},_>", rust_type.as_str())
+            }
+            None => ty_source.to_string(),
+        };
+
+        self.source_mappings.get(&ty_source).map(|f| f.sql.clone())
     }
 
     pub fn get_module_pathname(&self) -> String {

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -151,6 +151,22 @@ macro_rules! map_source_only {
             ty
         );
 
+        let ty = stringify!(Result<$rust, _>).to_string().replace(" ", "");
+        assert_eq!(
+            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), $sql.to_string(),)),
+            true,
+            "Cannot map {} twice",
+            ty
+        );
+
+        let ty = stringify!(Result<Option<$rust>, _>).to_string().replace(" ", "");
+        assert_eq!(
+            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), $sql.to_string(),)),
+            true,
+            "Cannot map {} twice",
+            ty
+        );
+
         let ty = stringify!(Vec<$rust>).to_string().replace(" ", "");
         assert_eq!(
             $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), format!("{}[]", $sql),)),


### PR DESCRIPTION
HACK for `Result<T, E>` -- we replace the `E` with an underscore

Specifically, this is the cases where we need to use the `map_source_only!()` macro to create a Rust type to SQL type mapping.  As of this writing that's only for the `pg_sys::Oid` type, but we'll do our best to generalize this.

This also teaches `map_source_only!()` to fabricate `Result` and `Result<Option>` wrappers for the Rust type being mapped.