### PR TITLE
Proper error handling for SPI

### DIFF
--- a/pgx-examples/aggregate/src/lib.rs
+++ b/pgx-examples/aggregate/src/lib.rs
@@ -157,18 +157,20 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_integer_avg_state_sql() {
-        Spi::run("CREATE TABLE demo_table (value INTEGER);");
-        Spi::run("INSERT INTO demo_table (value) VALUES (1), (2), (3);");
+    fn test_integer_avg_state_sql() -> Result<(), spi::Error> {
+        Spi::run("CREATE TABLE demo_table (value INTEGER);")?;
+        Spi::run("INSERT INTO demo_table (value) VALUES (1), (2), (3);")?;
         let retval = Spi::get_one::<i32>("SELECT DEMOAVG(value) FROM demo_table;");
         assert_eq!(retval, Ok(Some(2)));
+        Ok(())
     }
     #[pg_test]
-    fn test_integer_avg_with_null() {
-        Spi::run("CREATE TABLE demo_table (value INTEGER);");
-        Spi::run("INSERT INTO demo_table (value) VALUES (1), (NULL), (3);");
+    fn test_integer_avg_with_null() -> Result<(), spi::Error> {
+        Spi::run("CREATE TABLE demo_table (value INTEGER);")?;
+        Spi::run("INSERT INTO demo_table (value) VALUES (1), (NULL), (3);")?;
         let retval = Spi::get_one::<i32>("SELECT DEMOAVG(value) FROM demo_table;");
         assert_eq!(retval, Ok(Some(2)));
+        Ok(())
     }
 }
 

--- a/pgx-examples/custom_sql/src/lib.rs
+++ b/pgx-examples/custom_sql/src/lib.rs
@@ -87,14 +87,16 @@ mod tests {
     #[pg_test]
     fn test_ordering() -> Result<(), spi::Error> {
         let buf = Spi::connect(|client| {
-            Ok(client
-                .select("SELECT * FROM extension_sql", None, None)?
-                .flat_map(|tup| {
-                    tup.get_datum_by_ordinal(1)
-                        .ok()
-                        .and_then(|ord| ord.value::<String>().ok().unwrap())
-                })
-                .collect::<Vec<String>>())
+            Ok::<_, spi::Error>(
+                client
+                    .select("SELECT * FROM extension_sql", None, None)?
+                    .flat_map(|tup| {
+                        tup.get_datum_by_ordinal(1)
+                            .ok()
+                            .and_then(|ord| ord.value::<String>().ok().unwrap())
+                    })
+                    .collect::<Vec<String>>(),
+            )
         })?;
 
         assert_eq!(

--- a/pgx-examples/schemas/src/lib.rs
+++ b/pgx-examples/schemas/src/lib.rs
@@ -99,20 +99,21 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_my_some_schema_type() {
+    fn test_my_some_schema_type() -> Result<(), spi::Error> {
         Spi::connect(|mut c| {
             // "MySomeSchemaType" is in 'some_schema', so it needs to be discoverable
-            c.update("SET search_path TO some_schema,public", None, None);
+            c.update("SET search_path TO some_schema,public", None, None)?;
             assert_eq!(
                 String::from("test"),
-                c.select("SELECT '\"test\"'::MySomeSchemaType", None, None)
+                c.select("SELECT '\"test\"'::MySomeSchemaType", None, None)?
                     .first()
                     .get_one::<MySomeSchemaType>()
                     .expect("get_one::<MySomeSchemaType>() failed")
                     .unwrap()
                     .0
             );
-        });
+            Ok(())
+        })
     }
 
     #[pg_test]

--- a/pgx-examples/spi/src/lib.rs
+++ b/pgx-examples/spi/src/lib.rs
@@ -29,8 +29,16 @@ INSERT INTO spi_example (title) VALUES ('I like pudding');
 );
 
 #[pg_extern]
-fn spi_return_query(
-) -> TableIterator<'static, (name!(oid, Option<pg_sys::Oid>), name!(name, Option<String>))> {
+fn spi_return_query() -> Result<
+    TableIterator<
+        'static,
+        (
+            name!(oid, Result<Option<pg_sys::Oid>, pgx::spi::Error>),
+            name!(name, Result<Option<String>, pgx::spi::Error>),
+        ),
+    >,
+    spi::Error,
+> {
     #[cfg(feature = "pg11")]
     let query = "SELECT oid, relname::text || '-pg11' FROM pg_class";
     #[cfg(feature = "pg12")]
@@ -43,10 +51,10 @@ fn spi_return_query(
     let query = "SELECT oid, relname::text || '-pg15' FROM pg_class";
 
     let results = Spi::connect(|client| {
-        client.select(query, None, None).map(|row| (row["oid"].value(), row[2].value()))
-    });
+        Ok(client.select(query, None, None)?.map(|row| (row["oid"].value(), row[2].value())))
+    })?;
 
-    TableIterator::new(results)
+    Ok(TableIterator::new(results))
 }
 
 #[pg_extern(immutable, parallel_safe)]
@@ -70,7 +78,7 @@ fn spi_query_by_id(id: i64) -> Result<Option<String>, spi::Error> {
                 "SELECT id, title FROM spi.spi_example WHERE id = $1",
                 None,
                 Some(vec![(PgBuiltInOids::INT8OID.oid(), id.into_datum())]),
-            )
+            )?
             .first();
 
         tuptable.get_two::<i64, String>()

--- a/pgx-examples/spi/src/lib.rs
+++ b/pgx-examples/spi/src/lib.rs
@@ -50,11 +50,10 @@ fn spi_return_query() -> Result<
     #[cfg(feature = "pg15")]
     let query = "SELECT oid, relname::text || '-pg15' FROM pg_class";
 
-    let results = Spi::connect(|client| {
+    Spi::connect(|client| {
         Ok(client.select(query, None, None)?.map(|row| (row["oid"].value(), row[2].value())))
-    })?;
-
-    Ok(TableIterator::new(results))
+    })
+    .map(|results| TableIterator::new(results))
 }
 
 #[pg_extern(immutable, parallel_safe)]

--- a/pgx-examples/triggers/src/lib.rs
+++ b/pgx-examples/triggers/src/lib.rs
@@ -61,10 +61,10 @@ mod tests {
     use pgx::prelude::*;
 
     #[pg_test]
-    fn test_insert() {
+    fn test_insert() -> Result<(), spi::Error> {
         Spi::run(
             r#"INSERT INTO test (title, description, payload) VALUES ('a different title', 'a different description', '{"key": "value"}')"#,
-        );
+        )
     }
 }
 

--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -231,8 +231,8 @@ mod tests {
     }
 
     #[pg_test(error = "array contains NULL")]
-    fn test_array_deny_nulls() {
-        Spi::run("SELECT iterate_array_with_deny_null(ARRAY[1,2,3, NULL]::int[])");
+    fn test_array_deny_nulls() -> Result<(), spi::Error> {
+        Spi::run("SELECT iterate_array_with_deny_null(ARRAY[1,2,3, NULL]::int[])")
     }
 
     #[pg_test]
@@ -288,7 +288,7 @@ mod tests {
                         PgBuiltInOids::INT4ARRAYOID.oid(),
                         owned_vec.as_slice().into_datum(),
                     )]),
-                )
+                )?
                 .first()
                 .get_one::<Json>()
         })?

--- a/pgx-tests/src/tests/bgworker_tests.rs
+++ b/pgx-tests/src/tests/bgworker_tests.rs
@@ -24,21 +24,21 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
 
     if arg > 0 {
         BackgroundWorker::transaction(|| {
-            Spi::run("CREATE TABLE tests.bgworker_test (v INTEGER);");
+            Spi::run("CREATE TABLE tests.bgworker_test (v INTEGER);")?;
             Spi::connect(|mut client| {
                 client.update(
                     "INSERT INTO tests.bgworker_test VALUES ($1);",
                     None,
                     Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())]),
-                );
-            });
-        });
+                )
+            })
+        })
+        .expect("bgworker transaction failed");
     }
     while BackgroundWorker::wait_latch(Some(Duration::from_millis(100))) {}
     if arg > 0 {
-        BackgroundWorker::transaction(|| {
-            Spi::run("UPDATE tests.bgworker_test SET v = v + 1;");
-        });
+        BackgroundWorker::transaction(|| Spi::run("UPDATE tests.bgworker_test SET v = v + 1;"))
+            .expect("bgworker transaction failed")
     }
 }
 
@@ -58,13 +58,13 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
 
     let val = if arg > 0 {
         BackgroundWorker::transaction(|| {
-            Spi::run("CREATE TABLE tests.bgworker_test_return (v INTEGER);");
+            Spi::run("CREATE TABLE tests.bgworker_test_return (v INTEGER);")?;
             Spi::get_one_with_args::<i32>(
                 "SELECT $1",
                 vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())],
             )
         })
-        .expect("SPI failed")
+        .expect("bgworker transaction failed")
         .unwrap()
     } else {
         0
@@ -76,9 +76,10 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
                 "INSERT INTO tests.bgworker_test_return VALUES ($1)",
                 None,
                 Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), val.into_datum())]),
-            );
+            )
         })
     })
+    .expect("bgworker transaction failed");
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgx-tests/src/tests/cfg_tests.rs
+++ b/pgx-tests/src/tests/cfg_tests.rs
@@ -25,7 +25,7 @@ mod tests {
     use pgx::prelude::*;
 
     #[pg_test]
-    fn test_cfg_exists() {
-        Spi::run("SELECT func_test_cfg();");
+    fn test_cfg_exists() -> Result<(), spi::Error> {
+        Spi::run("SELECT func_test_cfg();")
     }
 }

--- a/pgx-tests/src/tests/datetime_tests.rs
+++ b/pgx-tests/src/tests/datetime_tests.rs
@@ -377,7 +377,7 @@ mod tests {
         .unwrap();
 
         // prevents PG's timestamp serialization from imposing the local servers time zone
-        Spi::run("SET TIME ZONE 'UTC'");
+        Spi::run("SET TIME ZONE 'UTC'").expect("SPI failed");
         let json = json!({ "time stamp with timezone test": time_stamp_with_timezone });
 
         // but we serialize timestamps at UTC
@@ -387,7 +387,7 @@ mod tests {
     #[pg_test]
     fn test_timestamp_serialization() {
         // prevents PG's timestamp serialization from imposing the local servers time zone
-        Spi::run("SET TIME ZONE 'UTC'");
+        Spi::run("SET TIME ZONE 'UTC'").expect("SPI failed");
 
         let datetime = PrimitiveDateTime::new(
             time::Date::from_calendar_date(2020, time::Month::try_from(1).unwrap(), 1).unwrap(),

--- a/pgx-tests/src/tests/guc_tests.rs
+++ b/pgx-tests/src/tests/guc_tests.rs
@@ -28,10 +28,10 @@ mod tests {
         );
         assert_eq!(GUC.get(), true);
 
-        Spi::run("SET test.bool TO false;");
+        Spi::run("SET test.bool TO false;").expect("SPI failed");
         assert_eq!(GUC.get(), false);
 
-        Spi::run("SET test.bool TO true;");
+        Spi::run("SET test.bool TO true;").expect("SPI failed");
         assert_eq!(GUC.get(), true);
     }
 
@@ -49,10 +49,10 @@ mod tests {
         );
         assert_eq!(GUC.get(), 42);
 
-        Spi::run("SET test.int = -1");
+        Spi::run("SET test.int = -1").expect("SPI failed");
         assert_eq!(GUC.get(), -1);
 
-        Spi::run("SET test.int = 12");
+        Spi::run("SET test.int = 12").expect("SPI failed");
         assert_eq!(GUC.get(), 12);
     }
 
@@ -70,13 +70,13 @@ mod tests {
         );
         assert_eq!(GUC.get(), 42.42);
 
-        Spi::run("SET test.float = -1");
+        Spi::run("SET test.float = -1").expect("SPI failed");
         assert_eq!(GUC.get(), -1.0);
 
-        Spi::run("SET test.float = 12");
+        Spi::run("SET test.float = 12").expect("SPI failed");
         assert_eq!(GUC.get(), 12.0);
 
-        Spi::run("SET test.float = 3.333");
+        Spi::run("SET test.float = 3.333").expect("SPI failed");
         assert_eq!(GUC.get(), 3.333);
     }
 
@@ -93,10 +93,10 @@ mod tests {
         assert!(GUC.get().is_some());
         assert_eq!(GUC.get().unwrap(), "this is a test");
 
-        Spi::run("SET test.string = 'foo'");
+        Spi::run("SET test.string = 'foo'").expect("SPI failed");
         assert_eq!(GUC.get().unwrap(), "foo");
 
-        Spi::run("SET test.string = DEFAULT");
+        Spi::run("SET test.string = DEFAULT").expect("SPI failed");
         assert_eq!(GUC.get().unwrap(), "this is a test");
     }
 
@@ -112,10 +112,10 @@ mod tests {
         );
         assert!(GUC.get().is_none());
 
-        Spi::run("SET test.string = 'foo'");
+        Spi::run("SET test.string = 'foo'").expect("SPI failed");
         assert_eq!(GUC.get().unwrap(), "foo");
 
-        Spi::run("SET test.string = DEFAULT");
+        Spi::run("SET test.string = DEFAULT").expect("SPI failed");
         assert!(GUC.get().is_none());
     }
 
@@ -137,10 +137,10 @@ mod tests {
         );
         assert_eq!(GUC.get(), TestEnum::Two);
 
-        Spi::run("SET test.enum = 'One'");
+        Spi::run("SET test.enum = 'One'").expect("SPI failed");
         assert_eq!(GUC.get(), TestEnum::One);
 
-        Spi::run("SET test.enum = 'three'");
+        Spi::run("SET test.enum = 'three'").expect("SPI failed");
         assert_eq!(GUC.get(), TestEnum::Three);
     }
 }

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -802,7 +802,7 @@ mod tests {
 
     #[pg_test]
     fn test_new_composite_type() {
-        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);");
+        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);").expect("SPI failed");
         let mut heap_tuple = PgHeapTuple::new_composite_type("DogWithAge").unwrap();
 
         assert_eq!(heap_tuple.get_by_name::<String>("name").unwrap(), None);
@@ -832,7 +832,7 @@ mod tests {
 
     #[pg_test]
     fn test_missing_field() {
-        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);");
+        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);").expect("SPI failed");
         let mut heap_tuple = PgHeapTuple::new_composite_type("DogWithAge").unwrap();
 
         const NON_EXISTING_ATTRIBUTE: &str = "DEFINITELY_NOT_EXISTING";
@@ -849,7 +849,7 @@ mod tests {
 
     #[pg_test]
     fn test_missing_number() {
-        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);");
+        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);").expect("SPI failed");
         let mut heap_tuple = PgHeapTuple::new_composite_type("DogWithAge").unwrap();
 
         const NON_EXISTING_ATTRIBUTE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(9001) };
@@ -866,7 +866,7 @@ mod tests {
 
     #[pg_test]
     fn test_wrong_type_assumed() {
-        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);");
+        Spi::run("CREATE TYPE DogWithAge AS (name text, age int);").expect("SPI failed");
         let mut heap_tuple = PgHeapTuple::new_composite_type("DogWithAge").unwrap();
 
         // These are **deliberately** the wrong types.

--- a/pgx-tests/src/tests/name_tests.rs
+++ b/pgx-tests/src/tests/name_tests.rs
@@ -21,6 +21,6 @@ mod tests {
 
     #[pg_test]
     fn renamed_func() {
-        Spi::run("SELECT renamed_func();");
+        Spi::run("SELECT renamed_func();").expect("SPI failed");
     }
 }

--- a/pgx-tests/src/tests/pg_try_tests.rs
+++ b/pgx-tests/src/tests/pg_try_tests.rs
@@ -74,7 +74,8 @@ mod tests {
     // see: c5cd61d7bfdfb5236ef0f8b98f433b35a2444346
     #[pg_test]
     fn test_we_dont_blow_out_errdata_stack_size() {
-        Spi::run("SELECT get_relation_name(x) FROM generate_series(1, 1000) x");
+        Spi::run("SELECT get_relation_name(x) FROM generate_series(1, 1000) x")
+            .expect("SPI failed");
     }
 
     #[pg_test(error = "panic in walker")]

--- a/pgx-tests/src/tests/result_tests.rs
+++ b/pgx-tests/src/tests/result_tests.rs
@@ -129,22 +129,22 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_return_result_table_iterator() {
+    fn test_return_result_table_iterator() -> Result<(), spi::Error> {
         Spi::run("SELECT * FROM tests.return_result_table_iterator()")
     }
 
     #[pg_test(error = "SpiTupleTable positioned before the start or after the end")]
-    fn test_return_result_table_iterator_error() {
+    fn test_return_result_table_iterator_error() -> Result<(), spi::Error> {
         Spi::run("SELECT * FROM tests.return_result_table_iterator_error()")
     }
 
     #[pg_test]
-    fn test_return_result_set_of() {
+    fn test_return_result_set_of() -> Result<(), spi::Error> {
         Spi::run("SELECT * FROM tests.return_result_set_of()")
     }
 
     #[pg_test(error = "SpiTupleTable positioned before the start or after the end")]
-    fn test_return_result_set_of_error() {
+    fn test_return_result_set_of_error() -> Result<(), spi::Error> {
         Spi::run("SELECT * FROM tests.return_result_set_of_error()")
     }
 }

--- a/pgx-tests/src/tests/schema_tests.rs
+++ b/pgx-tests/src/tests/schema_tests.rs
@@ -91,17 +91,17 @@ mod tests {
 
     #[pg_test]
     fn test_in_different_schema() {
-        Spi::run("SELECT test_schema.func_in_diff_schema();");
+        Spi::run("SELECT test_schema.func_in_diff_schema();").expect("SPI failed");
     }
 
     #[pg_test]
     fn test_in_different_schema2() {
-        Spi::run("SELECT test_schema.func_in_diff_schema2();");
+        Spi::run("SELECT test_schema.func_in_diff_schema2();").expect("SPI failed");
     }
 
     #[pg_test]
     fn test_type_in_different_schema() {
-        Spi::run("SELECT type_in_diff_schema();");
+        Spi::run("SELECT type_in_diff_schema();").expect("SPI failed");
     }
 
     #[pg_test]
@@ -140,7 +140,7 @@ mod tests {
         let result = Spi::get_one::<bool>("SELECT exists(SELECT 1 FROM pg_proc WHERE proname = 'func_generated_with_custom_name');");
         assert_eq!(result, Ok(Some(true)));
 
-        Spi::run("SELECT test_schema.func_generated_with_custom_name();");
+        Spi::run("SELECT test_schema.func_generated_with_custom_name();").expect("SPI failed");
     }
 
     #[pg_test]

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -193,7 +193,7 @@ mod tests {
         Ok(())
     }
 
-    fn sum_all(table: pgx::SpiTupleTable) -> i32 {
+    fn sum_all(table: pgx::spi::SpiTupleTable) -> i32 {
         table
             .map(|r| r.get_datum_by_ordinal(1)?.value::<i32>())
             .map(|r| r.expect("failed to get ordinal #1").expect("ordinal #1 was null"))

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -18,112 +18,106 @@ mod tests {
     use pgx::spi;
 
     #[pg_test(error = "syntax error at or near \"THIS\"")]
-    fn test_spi_failure() {
-        Spi::connect(|client| {
-            client.select("THIS IS NOT A VALID QUERY", None, None);
-        });
+    fn test_spi_failure() -> Result<(), spi::Error> {
+        Spi::connect(|client| client.select("THIS IS NOT A VALID QUERY", None, None)).map(|_| ())
     }
 
     #[pg_test]
-    fn test_spi_can_nest() {
+    fn test_spi_can_nest() -> Result<(), spi::Error> {
         Spi::connect(|_| {
-            Spi::connect(|_| {
-                Spi::connect(|_| {
-                    Spi::connect(|_| {
-                        Spi::connect(|_| {});
-                    });
-                });
-            });
-        });
+            Spi::connect(|_| Spi::connect(|_| Spi::connect(|_| Spi::connect(|_| Ok(())))))
+        })
     }
 
     #[pg_test]
     fn test_spi_returns_primitive() -> Result<(), spi::Error> {
-        let rc = Spi::connect(|client| {
-            client.select("SELECT 42", None, None).first().get_datum::<i32>(1)
-        })?;
+        let rc =
+            Spi::connect(|client| client.select("SELECT 42", None, None)?.first().get::<i32>(1))?;
 
-        assert_eq!(42, rc.expect("SPI failed to return proper value"));
+        assert_eq!(Some(42), rc);
         Ok(())
     }
 
     #[pg_test]
     fn test_spi_returns_str() -> Result<(), spi::Error> {
         let rc = Spi::connect(|client| {
-            client.select("SELECT 'this is a test'", None, None).first().get_datum::<&str>(1)
+            client.select("SELECT 'this is a test'", None, None)?.first().get::<&str>(1)
         })?;
 
-        assert_eq!("this is a test", rc.expect("SPI failed to return proper value"));
+        assert_eq!(Some("this is a test"), rc);
         Ok(())
     }
 
     #[pg_test]
     fn test_spi_returns_string() -> Result<(), spi::Error> {
         let rc = Spi::connect(|client| {
-            client.select("SELECT 'this is a test'", None, None).first().get_datum::<String>(1)
+            client.select("SELECT 'this is a test'", None, None)?.first().get::<&str>(1)
         })?;
 
-        assert_eq!("this is a test", rc.expect("SPI failed to return proper value"));
+        assert_eq!(Some("this is a test"), rc);
         Ok(())
     }
 
     #[pg_test]
-    fn test_spi_get_one() {
+    fn test_spi_get_one() -> spi::Result<()> {
         Spi::connect(|client| {
-            let i = client
-                .select("SELECT 42::bigint", None, None)
-                .first()
-                .get_one::<i64>()
-                .expect("SPI failed");
+            let i = client.select("SELECT 42::bigint", None, None)?.first().get_one::<i64>()?;
             assert_eq!(Some(42), i);
-        });
+            Ok(())
+        })
     }
 
     #[pg_test]
-    fn test_spi_get_two() {
+    fn test_spi_get_two() -> Result<(), spi::Error> {
         Spi::connect(|client| {
-            let (i, s) = client
-                .select("SELECT 42, 'test'", None, None)
-                .first()
-                .get_two::<i64, &str>()
-                .expect("SPI failed");
+            let (i, s) =
+                client.select("SELECT 42, 'test'", None, None)?.first().get_two::<i64, &str>()?;
 
             assert_eq!(Some(42), i);
             assert_eq!(Some("test"), s);
-        });
+            Ok(())
+        })
     }
 
     #[pg_test]
-    fn test_spi_get_three() {
+    fn test_spi_get_three() -> Result<(), spi::Error> {
         Spi::connect(|client| {
             let (i, s, b) = client
-                .select("SELECT 42, 'test', true", None, None)
+                .select("SELECT 42, 'test', true", None, None)?
                 .first()
-                .get_three::<i64, &str, bool>()
-                .expect("SPI failed");
+                .get_three::<i64, &str, bool>()?;
 
             assert_eq!(Some(42), i);
             assert_eq!(Some("test"), s);
             assert_eq!(Some(true), b);
-        });
+            Ok(())
+        })
     }
 
     #[pg_test]
     fn test_spi_get_two_with_failure() {
         Spi::connect(|client| {
-            assert!(client.select("SELECT 42", None, None).first().get_two::<i64, &str>().is_err());
-        });
+            assert!(client
+                .select("SELECT 42", None, None)?
+                .first()
+                .get_two::<i64, &str>()
+                .is_err());
+            Ok(())
+        })
+        .ok();
     }
 
     #[pg_test]
     fn test_spi_get_three_failure() {
         Spi::connect(|client| {
             assert!(client
-                .select("SELECT 42, 'test'", None, None)
+                .select("SELECT 42, 'test'", None, None)?
                 .first()
                 .get_three::<i64, &str, bool>()
                 .is_err());
-        });
+            Ok(())
+        })
+        .ok();
     }
 
     #[pg_test]
@@ -133,7 +127,7 @@ mod tests {
 
     #[pg_test]
     fn test_spi_run() {
-        Spi::run("SELECT 1")
+        assert!(Spi::run("SELECT 1").is_ok());
     }
 
     #[pg_test]
@@ -141,13 +135,14 @@ mod tests {
         let i = 1 as i32;
         let j = 2 as i64;
 
-        Spi::run_with_args(
+        assert!(Spi::run_with_args(
             "SELECT $1 + $2 = 3",
             Some(vec![
                 (PgBuiltInOids::INT4OID.oid(), Some(i.into())),
                 (PgBuiltInOids::INT8OID.oid(), Some(j.into())),
             ]),
         )
+        .is_ok());
     }
 
     #[pg_test]
@@ -181,14 +176,14 @@ mod tests {
 
     #[pg_test(error = "did a panic")]
     fn test_panic_via_spi() {
-        Spi::run("SELECT tests.do_panic();");
+        Spi::run("SELECT tests.do_panic();").expect("SPI failed");
     }
 
     #[pg_test]
     fn test_inserting_null() -> Result<(), pgx::spi::Error> {
         Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.null_test (id uuid)", None, None);
-        });
+            client.update("CREATE TABLE tests.null_test (id uuid)", None, None)
+        })?;
         assert_eq!(
             Spi::get_one_with_args::<i32>(
                 "INSERT INTO tests.null_test VALUES ($1) RETURNING 1",
@@ -200,48 +195,50 @@ mod tests {
         Ok(())
     }
 
+    fn sum_all(table: pgx::SpiTupleTable) -> i32 {
+        table
+            .map(|r| r.get_datum_by_ordinal(1)?.value::<i32>())
+            .map(|r| r.expect("failed to get ordinal #1").expect("ordinal #1 was null"))
+            .sum()
+    }
+
     #[pg_test]
-    fn test_cursor() {
+    fn test_cursor() -> Result<(), spi::Error> {
         Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
             SELECT i FROM generate_series(1, 10) AS t(i)",
                 None,
                 None,
-            );
-            let mut portal = client.open_cursor("SELECT * FROM tests.cursor_table", None).unwrap();
+            )?;
+            let mut portal = client.open_cursor("SELECT * FROM tests.cursor_table", None);
 
-            fn sum_all(table: pgx::SpiTupleTable) -> i32 {
-                table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
-            }
-            assert_eq!(sum_all(portal.fetch(3)), 1 + 2 + 3);
-            assert_eq!(sum_all(portal.fetch(3)), 4 + 5 + 6);
-            assert_eq!(sum_all(portal.fetch(3)), 7 + 8 + 9);
-            assert_eq!(sum_all(portal.fetch(3)), 10);
-        });
+            assert_eq!(sum_all(portal.fetch(3)?), 1 + 2 + 3);
+            assert_eq!(sum_all(portal.fetch(3)?), 4 + 5 + 6);
+            assert_eq!(sum_all(portal.fetch(3)?), 7 + 8 + 9);
+            assert_eq!(sum_all(portal.fetch(3)?), 10);
+            Ok(())
+        })
     }
 
     #[pg_test]
     fn test_cursor_prepared_statement() -> Result<(), pgx::spi::Error> {
         Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
             SELECT i FROM generate_series(1, 10) AS t(i)",
                 None,
                 None,
-            );
-            let prepared = client.prepare("SELECT * FROM tests.cursor_table", None);
-            let mut portal = client.open_cursor(&prepared, None)?;
+            )?;
+            let prepared = client.prepare("SELECT * FROM tests.cursor_table", None)?;
+            let mut portal = client.open_cursor(&prepared, None);
 
-            fn sum_all(table: pgx::SpiTupleTable) -> i32 {
-                table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
-            }
-            assert_eq!(sum_all(portal.fetch(3)), 1 + 2 + 3);
-            assert_eq!(sum_all(portal.fetch(3)), 4 + 5 + 6);
-            assert_eq!(sum_all(portal.fetch(3)), 7 + 8 + 9);
-            assert_eq!(sum_all(portal.fetch(3)), 10);
+            assert_eq!(sum_all(portal.fetch(3)?), 1 + 2 + 3);
+            assert_eq!(sum_all(portal.fetch(3)?), 4 + 5 + 6);
+            assert_eq!(sum_all(portal.fetch(3)?), 7 + 8 + 9);
+            assert_eq!(sum_all(portal.fetch(3)?), 10);
             Ok(())
         })
     }
@@ -249,41 +246,41 @@ mod tests {
     #[pg_test]
     fn test_cursor_by_name() -> Result<(), pgx::spi::Error> {
         let cursor_name = Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.cursor_table (id int)", None, None);
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
             SELECT i FROM generate_series(1, 10) AS t(i)",
                 None,
                 None,
-            );
-            client.open_cursor("SELECT * FROM tests.cursor_table", None).map(|mut cursor| {
-                assert_eq!(sum_all(cursor.fetch(3)), 1 + 2 + 3);
-                cursor.detach_into_name()
-            })
-        })?;
-
-        fn sum_all(table: pgx::SpiTupleTable) -> i32 {
-            table.map(|r| r.by_ordinal(1).unwrap().value::<i32>().unwrap()).sum()
-        }
-        Spi::connect(|client| {
-            client.find_cursor(&cursor_name).map(|mut cursor| {
-                assert_eq!(sum_all(cursor.fetch(3)), 4 + 5 + 6);
-                assert_eq!(sum_all(cursor.fetch(3)), 7 + 8 + 9);
-                cursor.detach_into_name();
-            })
+            )?;
+            let mut cursor = client.open_cursor("SELECT * FROM tests.cursor_table", None);
+            assert_eq!(sum_all(cursor.fetch(3)?), 1 + 2 + 3);
+            Ok(cursor.detach_into_name())
         })?;
 
         Spi::connect(|client| {
-            client.find_cursor(&cursor_name).map(|mut cursor| {
-                assert_eq!(sum_all(cursor.fetch(3)), 10);
-            })
+            let mut cursor = client.find_cursor(&cursor_name)?;
+            assert_eq!(sum_all(cursor.fetch(3)?), 4 + 5 + 6);
+            assert_eq!(sum_all(cursor.fetch(3)?), 7 + 8 + 9);
+            cursor.detach_into_name();
+            Ok(())
+        })?;
+
+        Spi::connect(|client| {
+            let mut cursor = client.find_cursor(&cursor_name)?;
+            assert_eq!(sum_all(cursor.fetch(3)?), 10);
+            Ok(())
         })?;
         Ok(())
     }
 
     #[pg_test(error = "syntax error at or near \"THIS\"")]
     fn test_cursor_failure() {
-        Spi::connect(|client| client.open_cursor("THIS IS NOT SQL", None).map(|_| ())).unwrap();
+        Spi::connect(|client| {
+            client.open_cursor("THIS IS NOT SQL", None);
+            Ok(())
+        })
+        .ok();
     }
 
     #[pg_test(error = "cursor: CursorNotFound(\"NOT A CURSOR\")")]
@@ -292,84 +289,79 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_columns() {
-        use pgx::{PgBuiltInOids, PgOid};
+    fn test_columns() -> Result<(), spi::Error> {
         Spi::connect(|client| {
-            let res = client.select("SELECT 42 AS a, 'test' AS b", None, None);
+            let res = client.select("SELECT 42 AS a, 'test' AS b", None, None)?;
 
-            assert_eq!(2, res.columns());
-
+            assert_eq!(Ok(2), res.columns());
             assert_eq!(res.column_type_oid(1).unwrap(), PgOid::BuiltIn(PgBuiltInOids::INT4OID));
-
             assert_eq!(res.column_type_oid(2).unwrap(), PgOid::BuiltIn(PgBuiltInOids::TEXTOID));
-
             assert_eq!(res.column_name(1).unwrap(), "a");
-
             assert_eq!(res.column_name(2).unwrap(), "b");
-        });
+            Ok(())
+        })?;
 
         Spi::connect(|mut client| {
-            let res = client.update("SET TIME ZONE 'PST8PDT'", None, None);
+            let res = client.update("SET TIME ZONE 'PST8PDT'", None, None)?;
 
-            assert_eq!(0, res.columns());
-        });
+            assert_eq!(Err(spi::Error::NoTupleTable), res.columns());
+            Ok(())
+        })
     }
 
     #[pg_test]
     fn test_connect_return_anything() {
         struct T;
-        assert!(matches!(Spi::connect(|_| Ok::<_, ()>(Some(T))).unwrap().unwrap(), T));
+        assert!(matches!(Spi::connect(|_| Ok(Some(T))).unwrap().unwrap(), T));
     }
 
     #[pg_test]
     fn test_spi_non_mut() -> Result<(), pgx::spi::Error> {
         // Ensures update and cursor APIs do not need mutable reference to SpiClient
         Spi::connect(|mut client| {
-            client.update("SELECT 1", None, None);
-            let cursor = client.open_cursor("SELECT 1", None)?.detach_into_name();
+            client.update("SELECT 1", None, None).expect("SPI failed");
+            let cursor = client.open_cursor("SELECT 1", None).detach_into_name();
             client.find_cursor(&cursor).map(|_| ())
         })
     }
 
     #[pg_test]
-    fn test_open_multiple_tuptables() {
+    fn test_open_multiple_tuptables() -> Result<(), spi::Error> {
         // Regression test to ensure a new `SpiTupTable` instance does not override the
         // effective length of an already open one due to misuse of Spi statics
         Spi::connect(|client| {
-            let a = client.select("SELECT 1", None, None).first();
-            let _b = client.select("SELECT 1 WHERE 'f'", None, None);
+            let a = client.select("SELECT 1", None, None)?.first();
+            let _b = client.select("SELECT 1 WHERE 'f'", None, None)?;
             assert!(!a.is_empty());
             assert_eq!(1, a.len());
-            assert!(a.get_heap_tuple().is_some());
-            assert_eq!(Ok(Some(1)), a.get_datum::<i32>(1));
+            assert!(a.get_heap_tuple().is_ok());
+            assert_eq!(Ok(Some(1)), a.get::<i32>(1));
+            Ok(())
         })
     }
 
     #[pg_test]
-    fn test_open_multiple_tuptables_rev() {
+    fn test_open_multiple_tuptables_rev() -> Result<(), spi::Error> {
         // Regression test to ensure a new `SpiTupTable` instance does not override the
         // effective length of an already open one.
         // Same as `test_open_multiple_tuptables`, but with the second tuptable being empty
         Spi::connect(|client| {
-            let a = client.select("SELECT 1 WHERE 'f'", None, None).first();
-            let _b = client.select("SELECT 1", None, None);
+            let a = client.select("SELECT 1 WHERE 'f'", None, None)?.first();
+            let _b = client.select("SELECT 1", None, None)?;
             assert!(a.is_empty());
             assert_eq!(0, a.len());
-            assert!(a.get_heap_tuple().is_none());
-            assert_eq!(Err(pgx::spi::Error::InvalidPosition), a.get_datum::<i32>(1));
-        });
+            assert!(a.get_heap_tuple().is_ok());
+            assert_eq!(Err(pgx::spi::Error::InvalidPosition), a.get::<i32>(1));
+            Ok(())
+        })
     }
 
     #[pg_test]
     fn test_prepared_statement() -> Result<(), spi::Error> {
         let rc = Spi::connect(|client| {
             let prepared =
-                client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]));
-            client
-                .select(&prepared, None, Some(vec![42.into_datum()]))
-                .unwrap()
-                .first()
-                .get_datum::<i32>(1)
+                client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]))?;
+            client.select(&prepared, None, Some(vec![42.into_datum()]))?.first().get::<i32>(1)
         })?;
 
         assert_eq!(42, rc.expect("SPI failed to return proper value"));
@@ -378,35 +370,32 @@ mod tests {
 
     #[pg_test]
     fn test_prepared_statement_argument_mismatch() {
-        use pgx::PreparedStatementError;
         let err = Spi::connect(|client| {
             let prepared =
-                client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]));
+                client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]))?;
             client.select(&prepared, None, None)
         })
         .unwrap_err();
 
         assert!(matches!(
             err,
-            PreparedStatementError::ArgumentCountMismatch { expected: 1, got: 0 }
+            spi::Error::PreparedStatementArgumentMismatch { expected: 1, got: 0 }
         ));
     }
 
     #[pg_test]
-    fn test_owned_prepared_statement() {
+    fn test_owned_prepared_statement() -> Result<(), spi::Error> {
         let prepared = Spi::connect(|client| {
-            client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)])).keep()
-        });
+            Ok(client
+                .prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]))?
+                .keep())
+        })?;
         let rc = Spi::connect(|client| {
-            client
-                .select(&prepared, None, Some(vec![42.into_datum()]))
-                .unwrap()
-                .first()
-                .get_datum::<i32>(1)
-        })
-        .unwrap();
+            client.select(&prepared, None, Some(vec![42.into_datum()]))?.first().get::<i32>(1)
+        })?;
 
-        assert_eq!(42, rc.expect("SPI failed to return proper value"))
+        assert_eq!(Some(42), rc);
+        Ok(())
     }
 
     #[pg_test]
@@ -415,18 +404,19 @@ mod tests {
     }
 
     #[pg_test(error = "CREATE TABLE is not allowed in a non-volatile function")]
-    fn test_readwrite_in_readonly() {
+    fn test_readwrite_in_readonly() -> Result<(), spi::Error> {
         // This is supposed to run in read-only
-        Spi::connect(|client| client.select("CREATE TABLE a ()", None, None));
+        Spi::connect(|client| client.select("CREATE TABLE a ()", None, None)).map(|_| ())
     }
 
     #[pg_test]
-    fn test_readwrite_in_select_readwrite() {
+    fn test_readwrite_in_select_readwrite() -> Result<(), spi::Error> {
         Spi::connect(|mut client| {
             // This is supposed to switch connection to read-write and run it there
-            client.update("CREATE TABLE a (id INT)", None, None);
+            client.update("CREATE TABLE a (id INT)", None, None)?;
             // This is supposed to run in read-write
-            client.select("INSERT INTO a VALUES (1)", None, None);
-        });
+            client.select("INSERT INTO a VALUES (1)", None, None)?;
+            Ok(())
+        })
     }
 }

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -88,7 +88,7 @@ mod tests {
     fn test_generate_series() {
         let cnt = Spi::connect(|client| {
             let mut table =
-                client.select("SELECT * FROM example_generate_series(1, 10)", None, None);
+                client.select("SELECT * FROM example_generate_series(1, 10)", None, None)?;
 
             let mut expect = 0;
             while table.next().is_some() {
@@ -98,7 +98,7 @@ mod tests {
                 assert_eq!(value, Some(expect));
             }
 
-            Ok::<_, pgx::spi::Error>(expect)
+            Ok(expect)
         })
         .unwrap();
 
@@ -108,7 +108,7 @@ mod tests {
     #[pg_test]
     fn test_composite_set() {
         let cnt = Spi::connect(|client| {
-            let mut table = client.select("SELECT * FROM example_composite_set()", None, None);
+            let mut table = client.select("SELECT * FROM example_composite_set()", None, None)?;
 
             let mut expect = 0;
             while table.next().is_some() {
@@ -124,7 +124,7 @@ mod tests {
                 }
             }
 
-            Ok::<_, pgx::spi::Error>(expect)
+            Ok(expect)
         })
         .unwrap();
 
@@ -134,80 +134,80 @@ mod tests {
     #[pg_test]
     fn test_return_some_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_some_iterator();", None, None);
+            let table = client.select("SELECT * from return_some_iterator();", None, None)?;
 
-            table.len() as i64
+            Ok(table.len() as i64)
         });
 
-        assert_eq!(cnt, 3)
+        assert_eq!(cnt, Ok(3))
     }
 
     #[pg_test]
     fn test_return_none_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_none_iterator();", None, None);
+            let table = client.select("SELECT * from return_none_iterator();", None, None)?;
 
-            table.len() as i64
+            Ok(table.len() as i64)
         });
 
-        assert_eq!(cnt, 0)
+        assert_eq!(cnt, Ok(0))
     }
 
     #[pg_test]
     fn test_return_some_setof_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_some_setof_iterator();", None, None);
+            let table = client.select("SELECT * from return_some_setof_iterator();", None, None)?;
 
-            table.len() as i64
+            Ok(table.len() as i64)
         });
 
-        assert_eq!(cnt, 3)
+        assert_eq!(cnt, Ok(3))
     }
 
     #[pg_test]
     fn test_return_none_setof_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_none_setof_iterator();", None, None);
+            let table = client.select("SELECT * from return_none_setof_iterator();", None, None)?;
 
-            table.len() as i64
+            Ok(table.len() as i64)
         });
 
-        assert_eq!(cnt, 0)
+        assert_eq!(cnt, Ok(0))
     }
 
     #[pg_test]
     fn test_srf_setof_datum_detoasting_with_borrow() {
         let cnt = Spi::connect(|mut client| {
             // build up a table with one large column that Postgres will be forced to TOAST
-            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None);
+            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None)?;
 
             // and make sure we can use the DETOASTED value with our SRF function
             let table = client.select(
                 "SELECT split_set_with_borrow(s, ' ') FROM test_srf_datum_detoasting",
                 None,
                 None,
-            );
+            )?;
 
-            table.len() as i64
+            Ok(table.len() as i64)
         });
-        assert_eq!(cnt, 1000000)
+        assert_eq!(cnt, Ok(1000000))
     }
 
     #[pg_test]
     fn test_srf_table_datum_detoasting_with_borrow() {
         let cnt = Spi::connect(|mut client| {
             // build up a table with one large column that Postgres will be forced to TOAST
-            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None);
+            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None)?;
 
             // and make sure we can use the DETOASTED value with our SRF function
             let table = client.select(
                 "SELECT split_table_with_borrow(s, ' ') FROM test_srf_datum_detoasting",
                 None,
                 None,
-            );
+            )?;
 
-            table.len() as i64
+            Ok(table.len() as i64)
         });
-        assert_eq!(cnt, 1000000)
+        assert_eq!(cnt, Ok(1000000))
     }
 }

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -98,7 +98,7 @@ mod tests {
                 assert_eq!(value, Some(expect));
             }
 
-            Ok(expect)
+            Ok::<_, spi::Error>(expect)
         })
         .unwrap();
 
@@ -124,7 +124,7 @@ mod tests {
                 }
             }
 
-            Ok(expect)
+            Ok::<_, spi::Error>(expect)
         })
         .unwrap();
 
@@ -136,7 +136,7 @@ mod tests {
         let cnt = Spi::connect(|client| {
             let table = client.select("SELECT * from return_some_iterator();", None, None)?;
 
-            Ok(table.len() as i64)
+            Ok::<_, spi::Error>(table.len() as i64)
         });
 
         assert_eq!(cnt, Ok(3))
@@ -147,7 +147,7 @@ mod tests {
         let cnt = Spi::connect(|client| {
             let table = client.select("SELECT * from return_none_iterator();", None, None)?;
 
-            Ok(table.len() as i64)
+            Ok::<_, spi::Error>(table.len() as i64)
         });
 
         assert_eq!(cnt, Ok(0))
@@ -158,7 +158,7 @@ mod tests {
         let cnt = Spi::connect(|client| {
             let table = client.select("SELECT * from return_some_setof_iterator();", None, None)?;
 
-            Ok(table.len() as i64)
+            Ok::<_, spi::Error>(table.len() as i64)
         });
 
         assert_eq!(cnt, Ok(3))
@@ -169,7 +169,7 @@ mod tests {
         let cnt = Spi::connect(|client| {
             let table = client.select("SELECT * from return_none_setof_iterator();", None, None)?;
 
-            Ok(table.len() as i64)
+            Ok::<_, spi::Error>(table.len() as i64)
         });
 
         assert_eq!(cnt, Ok(0))
@@ -188,7 +188,7 @@ mod tests {
                 None,
             )?;
 
-            Ok(table.len() as i64)
+            Ok::<_, spi::Error>(table.len() as i64)
         });
         assert_eq!(cnt, Ok(1000000))
     }
@@ -206,7 +206,7 @@ mod tests {
                 None,
             )?;
 
-            Ok(table.len() as i64)
+            Ok::<_, spi::Error>(table.len() as i64)
         });
         assert_eq!(cnt, Ok(1000000))
     }

--- a/pgx-tests/src/tests/struct_type_tests.rs
+++ b/pgx-tests/src/tests/struct_type_tests.rs
@@ -86,17 +86,17 @@ mod tests {
     use pgx::prelude::*;
 
     #[pg_test]
-    fn test_complex_in() {
+    fn test_complex_in() -> Result<(), pgx::spi::Error> {
         Spi::connect(|client| {
             let complex = client
-                .select("SELECT '1.1,2.2'::complex;", None, None)
+                .select("SELECT '1.1,2.2'::complex;", None, None)?
                 .first()
-                .get_one::<PgBox<Complex>>()
-                .expect("SPI failed")
-                .unwrap();
+                .get_one::<PgBox<Complex>>()?
+                .expect("datum was null");
 
             assert_eq!(&complex.x, &1.1);
             assert_eq!(&complex.y, &2.2);
+            Ok(())
         })
     }
 
@@ -108,18 +108,18 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_complex_from_text() {
+    fn test_complex_from_text() -> Result<(), pgx::spi::Error> {
         Spi::connect(|client| {
             let complex = client
-                .select("SELECT '1.1, 2.2'::complex;", None, None)
+                .select("SELECT '1.1, 2.2'::complex;", None, None)?
                 .first()
-                .get_one::<PgBox<Complex>>()
-                .expect("SPI failed")
-                .unwrap();
+                .get_one::<PgBox<Complex>>()?
+                .expect("datum was null");
 
             assert_eq!(&complex.x, &1.1);
             assert_eq!(&complex.y, &2.2);
-        });
+            Ok(())
+        })
     }
 
     #[pg_test]
@@ -127,7 +127,7 @@ mod tests {
         let complex = Spi::connect(|mut client| {
             client.update(
                 "CREATE TABLE complex_test AS SELECT s as id, (s || '.0, 2.0' || s)::complex as value FROM generate_series(1, 1000) s;\
-                SELECT value FROM complex_test ORDER BY id;", None, None).first().get_one::<PgBox<Complex>>()
+                SELECT value FROM complex_test ORDER BY id;", None, None)?.first().get_one::<PgBox<Complex>>()
         })?.expect("datum was null");
 
         assert_eq!(&complex.x, &1.0);

--- a/pgx-tests/src/tests/trigger_tests.rs
+++ b/pgx-tests/src/tests/trigger_tests.rs
@@ -113,7 +113,8 @@ mod tests {
             r#"
             CREATE TABLE tests.before_insert_field_update (species TEXT)
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -122,14 +123,16 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.field_species_fox_to_bear()
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.before_insert_field_update (species)
                 VALUES ('Fox')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let retval = Spi::get_one::<&str>("SELECT species FROM tests.before_insert_field_update;");
         assert_eq!(retval, Ok(Some("Bear")));
@@ -157,7 +160,8 @@ mod tests {
             r#"
             CREATE TABLE tests.before_insert_add_field (name TEXT, booper TEXT)
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -166,14 +170,16 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.add_field_boopers()
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.before_insert_add_field (name)
                 VALUES ('Nami')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let retval = Spi::get_one::<&str>("SELECT booper FROM tests.before_insert_add_field;");
         assert_eq!(retval, Ok(Some("Swooper")));
@@ -204,7 +210,8 @@ mod tests {
             r#"
             CREATE TABLE tests.before_update_skip (title TEXT)
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -213,20 +220,24 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.intercept_bears()
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.before_update_skip (title)
                 VALUES ('Fox')
         "#,
-        );
+        )
+        .expect("SPI failed");
+
         Spi::run(
             r#"
             UPDATE tests.before_update_skip SET title = 'Bear'
                 WHERE title = 'Fox'
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let retval = Spi::get_one::<&str>("SELECT title FROM tests.before_update_skip;");
         assert_eq!(retval, Ok(Some("Fox")));
@@ -292,7 +303,8 @@ mod tests {
                 trigger_extra_args TEXT[]
             )
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -301,14 +313,16 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.inserts_trigger_metadata('Bears', 'Dogs')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.before_insert_trigger_metadata (marker)
                 VALUES ('Fox')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let marker =
             Spi::get_one::<&str>("SELECT marker FROM tests.before_insert_trigger_metadata;")?
@@ -419,7 +433,8 @@ mod tests {
                 trigger_extra_args TEXT[]
             )
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -428,14 +443,16 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.inserts_trigger_metadata_safe('Bears', 'Dogs')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.before_insert_trigger_metadata_safe (marker)
                 VALUES ('Fox')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let marker =
             Spi::get_one::<&str>("SELECT marker FROM tests.before_insert_trigger_metadata_safe;")?
@@ -513,7 +530,8 @@ mod tests {
             r#"
             CREATE TABLE tests.has_sql_option_set (species TEXT)
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -522,14 +540,16 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.has_sql_option_set_and_respects_it()
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.has_sql_option_set (species)
                 VALUES ('Fox')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let retval = Spi::get_one::<&str>("SELECT species FROM tests.has_sql_option_set;");
         assert_eq!(retval, Ok(Some("Fox")));
@@ -548,7 +568,8 @@ mod tests {
             r#"
             CREATE TABLE tests.has_noop_postgres (species TEXT)
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -557,14 +578,16 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.noop_postgres()
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.has_noop_postgres (species)
                 VALUES ('Fox')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let retval = Spi::get_one::<&str>("SELECT species FROM tests.has_noop_postgres;");
         assert_eq!(retval, Ok(Some("Fox")));
@@ -583,7 +606,8 @@ mod tests {
             r#"
             CREATE TABLE tests.has_noop_rust (species TEXT)
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
@@ -592,14 +616,16 @@ mod tests {
                 FOR EACH ROW
                 EXECUTE PROCEDURE tests.noop_rust()
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         Spi::run(
             r#"
             INSERT INTO tests.has_noop_rust (species)
                 VALUES ('Fox')
         "#,
-        );
+        )
+        .expect("SPI failed");
 
         let retval = Spi::get_one::<&str>("SELECT species FROM tests.has_noop_rust;");
         assert_eq!(retval, Ok(Some("Fox")));

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -102,7 +102,7 @@ pub use nodes::*;
 pub use pgbox::*;
 pub use rel::*;
 pub use shmem::*;
-pub use spi::*;
+pub use spi::Spi; // only Spi.  We don't want the top-level namespace polluted with spi::Result and spi::Error
 pub use stringinfo::*;
 pub use trigger_support::*;
 pub use tupdesc::*;

--- a/pgx/src/prelude.rs
+++ b/pgx/src/prelude.rs
@@ -38,6 +38,7 @@ pub use crate::pg_sys::utils::name_data_to_str;
 pub use crate::pg_sys::PgBuiltInOids;
 
 // It's a database, gotta query it somehow.
+pub use crate::spi;
 pub use crate::spi::Spi;
 
 // Logging and Error support


### PR DESCRIPTION
The long story short is that pretty much everything returns a Result now: the getter methods on PgTupleTable and SpiHeapTupleData go through try_from_datum(), and many methods like `Spi::run`, `SpiClient::update`, `SpiClient::select` now return a `Result<R, spi::Error>`.

~~`Spi::connect()` now requires the user to return a `Result<R, spi::Error>` because, believe it or not, `pg_sys::SPI_connect()` is documented as being able to return an error (even tho in practice it doesn't).~~

Also do some cleanups to the `spi::Error` variants, make a few internal pointers we track `NonNull`, added some comments here and there, and updated all the tests/examples accordingly.

/cc @EdMcBane & @yrashk -- y'all have had a lot of work and interest in Spi here recently, so I'd appreciate your eyes.

There's no functional changes here, just user-facing API changes (hence so many tests being touched) along with internal cleanup. 

~~Probably the most controversial change is that `Spi::connect()` now returns `-> Result<R, spi::Error>`.  It really needs to as `pg_sys::SPI_connect()` is documented as being able to return an error (even tho it doesn't!).~~  
UPDATE:  `Spi::connect()` makes the executive decision to `panic!()` if `pg_sys::SPI_connect()` doesn't return a `SpiOk`.  As such, it is now capable of simply returning `-> R` and everyone can sleep at night.

Prior to this PR spi.rs was silently transforming non SpiOK returns into a panic!, and now those are pushed forward to the user as a `spi::SpiError` (either directly or indirectly as a variant of `spi::Error`).  If a Postgres SPI function returns an error that means its recoverable, so we really need to pass them back to the user.  This includes methods like `Spi::run()`, `SpiClient::update()`, etc.