### PR TITLE
Set returning `#[pg_extern]` functions can cause segfault

### DIFF
--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -210,4 +210,24 @@ mod tests {
         });
         assert_eq!(cnt, Ok(1000000))
     }
+
+    #[pg_test(error = "column \"cause_an_error\" does not exist")]
+    pub fn spi_in_iterator(
+    ) -> TableIterator<'static, (name!(id, i32), name!(relname, Result<Option<String>, spi::Error>))>
+    {
+        let oids = vec![1213, 1214, 1232, 1233, 1247, 1249, 1255];
+
+        TableIterator::new(oids.into_iter().map(|oid| {
+            (oid, Spi::get_one(&format!("SELECT CAUSE_AN_ERROR FROM pg_class WHERE oid = {oid}")))
+        }))
+    }
+
+    #[pg_test(error = "column \"cause_an_error\" does not exist")]
+    pub fn spi_in_setof() -> SetOfIterator<'static, Result<Option<String>, spi::Error>> {
+        let oids = vec![1213, 1214, 1232, 1233, 1247, 1249, 1255];
+
+        SetOfIterator::new(oids.into_iter().map(|oid| {
+            Spi::get_one(&format!("SELECT CAUSE_AN_ERROR FROM pg_class WHERE oid = {oid}"))
+        }))
+    }
 }


### PR DESCRIPTION
If a `#[pg_extern]`-style function raises a Postgres ERROR during its iteration process, Postgres will segfault.

This fixes the problem by not trying to re-create/re-leak the pointer we initially leaked with `PgMemoryContexts.leak_and_drop_on_delete/leak_trivial_alloc()`.  Instead, we track it in our "iterator holder" as a `NonNull` pointer, which is all we need.

Once `Box::from_raw()` takes ownership of the pointer we can't know what happens to it, so assuming the type instance it points to can be dropped before we re-leak it is wrong wrong wrong.  Now we just understand that it's some pointer out there.