### PR TITLE
Add type/oid details to Datum conversion errors

### DIFF
--- a/pgx-tests/src/tests/from_into_datum_tests.rs
+++ b/pgx-tests/src/tests/from_into_datum_tests.rs
@@ -1,0 +1,30 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+
+    use pgx::prelude::*;
+
+    #[pg_test]
+    fn test_incompatible_datum_returns_error() {
+        let result = unsafe {
+            String::try_from_datum(
+                pg_sys::Datum::from(false),
+                true,
+                pg_sys::PgBuiltInOids::BOOLOID.value(),
+            )
+        };
+        assert!(result.is_err());
+        assert_eq!("Postgres type boolean (oid=16) is not compatible with the Rust type alloc::string::String (oid=25)", result.unwrap_err().to_string());
+    }
+}

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -880,28 +880,28 @@ mod tests {
         );
 
         // These are **deliberately** the wrong types.
-        assert_eq!(
+        assert!(matches!(
             heap_tuple.set_by_name("name", 1_i32),
-            Err(TryFromDatumError::IncompatibleTypes),
-        );
-        assert_eq!(
+            Err(TryFromDatumError::IncompatibleTypes { .. })
+        ));
+        assert!(matches!(
             heap_tuple.set_by_name("age", "Brandy"),
-            Err(TryFromDatumError::IncompatibleTypes),
-        );
+            Err(TryFromDatumError::IncompatibleTypes { .. }),
+        ));
 
         // Now set them properly, to test that we get errors when they're set...
         heap_tuple.set_by_name("name", "Brandy".to_string()).unwrap();
         heap_tuple.set_by_name("age", 42).unwrap();
 
         // These are **deliberately** the wrong types.
-        assert_eq!(
+        assert!(matches!(
             heap_tuple.get_by_name::<i32>("name"),
-            Err(TryFromDatumError::IncompatibleTypes),
-        );
-        assert_eq!(
+            Err(TryFromDatumError::IncompatibleTypes { .. }),
+        ));
+        assert!(matches!(
             heap_tuple.get_by_name::<String>("age"),
-            Err(TryFromDatumError::IncompatibleTypes),
-        );
+            Err(TryFromDatumError::IncompatibleTypes { .. }),
+        ));
     }
 
     #[pg_test]
@@ -914,7 +914,7 @@ mod tests {
         match not_a_dog {
             Ok(_dog) => panic!("got a Dog when we shouldn't have"),
             Err(e) => {
-                assert_eq!(e, pgx::spi::Error::DatumError(TryFromDatumError::IncompatibleTypes))
+                assert!(matches!(e, pgx::spi::Error::DatumError(TryFromDatumError::IncompatibleTypes { .. })))
             }
         }
     }

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -914,7 +914,10 @@ mod tests {
         match not_a_dog {
             Ok(_dog) => panic!("got a Dog when we shouldn't have"),
             Err(e) => {
-                assert!(matches!(e, pgx::spi::Error::DatumError(TryFromDatumError::IncompatibleTypes { .. })))
+                assert!(matches!(
+                    e,
+                    pgx::spi::Error::DatumError(TryFromDatumError::IncompatibleTypes { .. })
+                ))
             }
         }
     }

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -19,6 +19,7 @@ mod default_arg_value_tests;
 mod derive_pgtype_lifetimes;
 mod enum_type_tests;
 mod fcinfo_tests;
+mod from_into_datum_tests;
 mod guc_tests;
 mod heap_tuple;
 #[cfg(feature = "cshim")]

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -20,11 +20,7 @@ use std::num::NonZeroUsize;
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum TryFromDatumError {
     #[error("The specified type of the Datum (oid {rust_oid}) is not compatible with the desired Rust type ({rust_type}, primary oid {rust_oid})")]
-    IncompatibleTypes {
-        rust_type: &'static str,
-        rust_oid: pg_sys::Oid,
-        datum_oid: pg_sys::Oid,
-    },
+    IncompatibleTypes { rust_type: &'static str, rust_oid: pg_sys::Oid, datum_oid: pg_sys::Oid },
 
     #[error("The specified attribute number `{0}` is not present")]
     NoSuchAttributeNumber(NonZeroUsize),
@@ -120,7 +116,8 @@ pub trait FromDatum {
             Err(TryFromDatumError::IncompatibleTypes {
                 rust_type: std::any::type_name::<Self>(),
                 rust_oid: Self::type_oid(),
-                datum_oid: type_oid})
+                datum_oid: type_oid,
+            })
         } else {
             Ok(FromDatum::from_polymorphic_datum(datum, is_null, type_oid))
         }
@@ -141,7 +138,8 @@ pub trait FromDatum {
             Err(TryFromDatumError::IncompatibleTypes {
                 rust_type: std::any::type_name::<Self>(),
                 rust_oid: Self::type_oid(),
-                datum_oid: type_oid})
+                datum_oid: type_oid,
+            })
         } else {
             Ok(FromDatum::from_datum_in_memory_context(memory_context, datum, is_null, type_oid))
         }

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -274,7 +274,8 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
                         return Err(TryFromDatumError::IncompatibleTypes {
                             rust_type: std::any::type_name::<T>(),
                             rust_oid: att.atttypid,
-                            datum_oid: type_oid });
+                            datum_oid: type_oid,
+                        });
                     }
                 }
             }

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -1,6 +1,7 @@
 //! Provides a safe interface to Postgres `HeapTuple` objects.
 //!
 //! [`PgHeapTuple`]s also describe composite types as defined by [`pgx::composite_type!()`][crate::composite_type].
+use crate::datum::lookup_type_name;
 use crate::pg_sys::{Datum, Oid};
 use crate::{
     heap_getattr_raw, pg_sys, AllocatedByPostgres, AllocatedByRust, FromDatum, IntoDatum, PgBox,
@@ -274,6 +275,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
                         return Err(TryFromDatumError::IncompatibleTypes {
                             rust_type: std::any::type_name::<T>(),
                             rust_oid: att.atttypid,
+                            datum_type: lookup_type_name(type_oid),
                             datum_oid: type_oid,
                         });
                     }

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -271,7 +271,10 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
                     let is_compatible_composite_types =
                         type_oid == pg_sys::RECORDOID && composite_type_oid == Some(att.atttypid);
                     if !is_compatible_composite_types && !T::is_compatible_with(att.atttypid) {
-                        return Err(TryFromDatumError::IncompatibleTypes { preferred: att.atttypid, got: type_oid });
+                        return Err(TryFromDatumError::IncompatibleTypes {
+                            rust_type: std::any::type_name::<T>(),
+                            rust_oid: att.atttypid,
+                            datum_oid: type_oid });
                     }
                 }
             }

--- a/pgx/src/heap_tuple.rs
+++ b/pgx/src/heap_tuple.rs
@@ -271,7 +271,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
                     let is_compatible_composite_types =
                         type_oid == pg_sys::RECORDOID && composite_type_oid == Some(att.atttypid);
                     if !is_compatible_composite_types && !T::is_compatible_with(att.atttypid) {
-                        return Err(TryFromDatumError::IncompatibleTypes);
+                        return Err(TryFromDatumError::IncompatibleTypes { preferred: att.atttypid, got: type_oid });
                     }
                 }
             }


### PR DESCRIPTION
Adds rust type+oid and datum oid to `TryFromDatumError::IncompatibleTypes` variant. Updates error message to report the additional metadata.