### PR TITLE
Move generated SRF code into managed code

### DIFF
--- a/pgx-examples/srf/src/lib.rs
+++ b/pgx-examples/srf/src/lib.rs
@@ -17,6 +17,17 @@ fn generate_series(start: i64, finish: i64, step: default!(i64, 1)) -> SetOfIter
 }
 
 #[pg_extern]
+fn generate_series_table(
+    start: i64,
+    finish: i64,
+    step: default!(i64, 1),
+) -> TableIterator<'static, (name!(id, i64), name!(val, i64))> {
+    TableIterator::new(
+        (start..=finish).step_by(step as usize).enumerate().map(|(idx, val)| (idx as _, val)),
+    )
+}
+
+#[pg_extern]
 fn random_values(num_rows: i32) -> TableIterator<'static, (name!(index, i32), name!(value, f64))> {
     TableIterator::new((1..=num_rows).map(|i| (i, rand::random::<f64>())))
 }

--- a/pgx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/mod.rs
@@ -474,9 +474,7 @@ impl PgExtern {
                     }
                 }
             }
-            Returning::SetOf { ty: retval_ty, optional, result } => {
-                let result_ident = syn::Ident::new("result", self.func.sig.span());
-                let retval_ty_resolved = &retval_ty.original_ty;
+            Returning::SetOf { ty: _retval_ty, optional, result } => {
                 let result_handler = if *optional {
                     // don't need unsafe annotations because of the larger unsafe block coming up
                     quote_spanned! { self.func.sig.span() =>
@@ -499,85 +497,19 @@ impl PgExtern {
                     #[::pgx::pgx_macros::pg_guard]
                     #[warn(unsafe_op_in_unsafe_fn)]
                     pub unsafe extern "C" fn #func_name_wrapper #func_generics(#fcinfo_ident: ::pgx::pg_sys::FunctionCallInfo) -> ::pgx::pg_sys::Datum {
-                        use core::ptr::NonNull;
-                        struct IteratorHolder<'__pgx_internal_lifetime, T: std::panic::UnwindSafe + std::panic::RefUnwindSafe> {
-                            iter: NonNull<::pgx::iter::SetOfIterator<'__pgx_internal_lifetime, T>>,
-                        }
-
-                        let mut funcctx: ::pgx::pgbox::PgBox<::pgx::pg_sys::FuncCallContext>;
-                        let mut iterator_holder: ::pgx::pgbox::PgBox<IteratorHolder<#retval_ty_resolved>>;
-
                         unsafe {
-                            if ::pgx::fcinfo::srf_is_first_call(#fcinfo_ident) {
-                                funcctx = ::pgx::fcinfo::srf_first_call_init(#fcinfo_ident);
-                                funcctx.user_fctx = ::pgx::memcxt::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).palloc_struct::<IteratorHolder<#retval_ty_resolved>>() as *mut ::core::ffi::c_void;
-                                iterator_holder = ::pgx::pgbox::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_ty_resolved>);
-
-                                // function arguments need to be "fetched" while in the function call's
-                                // multi-call-memory-context to ensure that any detoasted datums will
-                                // live long enough for the SRF to use them over each call
-                                let #result_ident = match ::pgx::memcxt::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).switch_to(|_| {
-                                    #( #arg_fetches )*
-                                    #result_handler
-                                }) {
-                                    Some(result) => result,
-                                    None => {
-                                        ::pgx::fcinfo::srf_return_done(#fcinfo_ident, &mut funcctx);
-                                        return ::pgx::fcinfo::pg_return_null(#fcinfo_ident)
-                                    }
-                                };
-
-                                iterator_holder.iter = NonNull::new_unchecked(::pgx::memcxt::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).leak_trivial_alloc(result));
-                            }
-
-                            funcctx = ::pgx::fcinfo::srf_per_call_setup(#fcinfo_ident);
-                            iterator_holder = ::pgx::pgbox::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_ty_resolved>);
-                        }
-
-                        // SAFETY: should have been set up correctly on this or previous call
-                        let iter = unsafe { iterator_holder.iter.as_mut() };
-                        match iter.next() {
-                            Some(result) => {
-                                // SAFETY: what is an srf if it does not return?
-                                unsafe { ::pgx::fcinfo::srf_return_next(#fcinfo_ident, &mut funcctx) };
-                                match ::pgx::datum::IntoDatum::into_datum(result) {
-                                    Some(datum) => datum,
-                                    None => ::pgx::fcinfo::pg_return_null(#fcinfo_ident),
-                                }
-                            },
-                            None => {
-                                // SAFETY: seem to be finished
-                                unsafe { ::pgx::fcinfo::srf_return_done(#fcinfo_ident, &mut funcctx) };
-                                ::pgx::fcinfo::pg_return_null(#fcinfo_ident)
-                            },
+                            // SAFETY: the caller has asserted that `fcinfo` is a valid FunctionCallInfo pointer, allocated by Postgres
+                            // with all its fields properly setup.  Unless the user is calling this wrapper function directly, this
+                            // will always be the case
+                            ::pgx::iter::SetOfIterator::srf_next(#fcinfo_ident, || {
+                                #( #arg_fetches )*
+                                #result_handler
+                            })
                         }
                     }
                 }
             }
-            Returning::Iterated { tys: retval_tys, optional, result } => {
-                let result_ident = syn::Ident::new("result", self.func.sig.span());
-                let funcctx_ident = syn::Ident::new("funcctx", self.func.sig.span());
-                let retval_tys_resolved = retval_tys.iter().map(|v| &v.used_ty.resolved_ty);
-                let retval_tys_tuple = quote! { (#(#retval_tys_resolved,)*) };
-
-                let retval_tuple_indexes = (0..retval_tys.len()).map(syn::Index::from);
-                let retval_tuple_len = retval_tuple_indexes.len();
-                let create_heap_tuple = quote! {
-                    let mut datums: [::pgx::pg_sys::Datum; #retval_tuple_len] = [::pgx::pg_sys::Datum::from(0); #retval_tuple_len];
-                    let mut nulls: [bool; #retval_tuple_len] = [false; #retval_tuple_len];
-
-                    #(
-                        let datum = ::pgx::datum::IntoDatum::into_datum(result.#retval_tuple_indexes);
-                        match datum {
-                            Some(datum) => { datums[#retval_tuple_indexes] = datum.into(); },
-                            None => { nulls[#retval_tuple_indexes] = true; }
-                        }
-                    )*
-
-                    // SAFETY: just went to considerable trouble to make sure these are well-formed for a tuple
-                    let heap_tuple = unsafe { ::pgx::pg_sys::heap_form_tuple(#funcctx_ident.tuple_desc, datums.as_mut_ptr(), nulls.as_mut_ptr()) };
-                };
-
+            Returning::Iterated { tys: _retval_tys, optional, result } => {
                 let result_handler = if *optional {
                     // don't need unsafe annotations because of the larger unsafe block coming up
                     quote_spanned! { self.func.sig.span() =>
@@ -602,67 +534,14 @@ impl PgExtern {
                     #[::pgx::pgx_macros::pg_guard]
                     #[warn(unsafe_op_in_unsafe_fn)]
                     pub unsafe extern "C" fn #func_name_wrapper #func_generics(#fcinfo_ident: ::pgx::pg_sys::FunctionCallInfo) -> ::pgx::pg_sys::Datum {
-                        use core::ptr::NonNull;
-                        struct IteratorHolder<'__pgx_internal_lifetime, T: std::panic::UnwindSafe + std::panic::RefUnwindSafe> {
-                            iter: NonNull<::pgx::iter::TableIterator<'__pgx_internal_lifetime, T>>,
-                        }
-
-                        let mut funcctx: ::pgx::pgbox::PgBox<::pgx::pg_sys::FuncCallContext>;
-                        let mut iterator_holder: ::pgx::pgbox::PgBox<IteratorHolder<#retval_tys_tuple>>;
-
                         unsafe {
-                            if ::pgx::fcinfo::srf_is_first_call(#fcinfo_ident) {
-                                funcctx = ::pgx::fcinfo::srf_first_call_init(#fcinfo_ident);
-                                funcctx.user_fctx = ::pgx::memcxt::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).palloc_struct::<IteratorHolder<#retval_tys_tuple>>() as *mut ::core::ffi::c_void;
-                                funcctx.tuple_desc = ::pgx::memcxt::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).switch_to(|_| {
-                                    let mut tupdesc: *mut ::pgx::pg_sys::TupleDescData = std::ptr::null_mut();
-
-                                    /* Build a tuple descriptor for our result type */
-                                    if ::pgx::pg_sys::get_call_result_type(#fcinfo_ident, std::ptr::null_mut(), &mut tupdesc) != ::pgx::pg_sys::TypeFuncClass_TYPEFUNC_COMPOSITE {
-                                        ::pgx::pg_sys::error!("return type must be a row type");
-                                    }
-
-                                    ::pgx::pg_sys::BlessTupleDesc(tupdesc)
-                                });
-                                iterator_holder = ::pgx::pgbox::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_tys_tuple>);
-
-                                // function arguments need to be "fetched" while in the function call's
-                                // multi-call-memory-context to ensure that any detoasted datums will
-                                // live long enough for the SRF to use them over each call
-                                let #result_ident = match ::pgx::memcxt::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).switch_to(|_| {
-                                    #( #arg_fetches )*
-                                    #result_handler
-                                }) {
-                                    Some(result) => result,
-                                    None => {
-                                        ::pgx::fcinfo::srf_return_done(#fcinfo_ident, &mut funcctx);
-                                        return ::pgx::fcinfo::pg_return_null(#fcinfo_ident)
-                                    }
-                                };
-
-                                iterator_holder.iter = NonNull::new_unchecked(::pgx::memcxt::PgMemoryContexts::For(funcctx.multi_call_memory_ctx).leak_and_drop_on_delete(result));
-                            }
-
-                            funcctx = ::pgx::fcinfo::srf_per_call_setup(#fcinfo_ident);
-                            iterator_holder = ::pgx::pgbox::PgBox::from_pg(funcctx.user_fctx as *mut IteratorHolder<#retval_tys_tuple>);
-                        }
-
-                        // SAFETY: should have been set up correctly on this or previous call
-                        let iter = unsafe { iterator_holder.iter.as_mut() };
-                        match iter.next() {
-                            Some(result) => {
-                                #create_heap_tuple
-
-                                let datum = ::pgx::htup::heap_tuple_get_datum(heap_tuple);
-                                // SAFETY: what is an srf if it does not return?
-                                unsafe { ::pgx::fcinfo::srf_return_next(#fcinfo_ident, &mut funcctx) };
-                                datum
-                            },
-                            None => {
-                                // SAFETY: seem to be finished
-                                unsafe { ::pgx::fcinfo::srf_return_done(#fcinfo_ident, &mut funcctx) };
-                                ::pgx::fcinfo::pg_return_null(#fcinfo_ident)
-                            },
+                            // SAFETY: the caller has asserted that `fcinfo` is a valid FunctionCallInfo pointer, allocated by Postgres
+                            // with all its fields properly setup.  Unless the user is calling this wrapper function directly, this
+                            // will always be the case
+                            ::pgx::iter::TableIterator::srf_next(#fcinfo_ident, || {
+                                #( #arg_fetches )*
+                                #result_handler
+                            })
                         }
                     }
                 }

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -404,47 +404,37 @@ pub unsafe fn direct_pg_extern_function_call_as_datum(
 
 #[inline]
 pub unsafe fn srf_is_first_call(fcinfo: pg_sys::FunctionCallInfo) -> bool {
-    let fcinfo = PgBox::from_pg(fcinfo);
-    let flinfo = PgBox::from_pg(fcinfo.flinfo);
-
-    flinfo.fn_extra.is_null()
+    (*(*fcinfo).flinfo).fn_extra.is_null()
 }
 
 #[inline]
 pub unsafe fn srf_first_call_init(
     fcinfo: pg_sys::FunctionCallInfo,
-) -> PgBox<pg_sys::FuncCallContext> {
-    let funcctx = pg_sys::init_MultiFuncCall(fcinfo);
-    PgBox::from_pg(funcctx)
+) -> *mut pg_sys::FuncCallContext {
+    pg_sys::init_MultiFuncCall(fcinfo)
 }
 
 #[inline]
-pub unsafe fn srf_per_call_setup(
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> PgBox<pg_sys::FuncCallContext> {
-    let funcctx = pg_sys::per_MultiFuncCall(fcinfo);
-    PgBox::from_pg(funcctx)
+pub unsafe fn srf_per_call_setup(fcinfo: pg_sys::FunctionCallInfo) -> *mut pg_sys::FuncCallContext {
+    pg_sys::per_MultiFuncCall(fcinfo)
 }
 
 #[inline]
 pub unsafe fn srf_return_next(
     fcinfo: pg_sys::FunctionCallInfo,
-    funcctx: &mut PgBox<pg_sys::FuncCallContext>,
+    funcctx: *mut pg_sys::FuncCallContext,
 ) {
-    funcctx.call_cntr += 1;
-
-    let fcinfo = PgBox::from_pg(fcinfo);
-    let mut rsi = PgBox::from_pg(fcinfo.resultinfo as *mut pg_sys::ReturnSetInfo);
-    rsi.isDone = pg_sys::ExprDoneCond_ExprMultipleResult;
+    (*funcctx).call_cntr += 1;
+    (*((*fcinfo).resultinfo as *mut pg_sys::ReturnSetInfo)).isDone =
+        pg_sys::ExprDoneCond_ExprMultipleResult;
 }
 
 #[inline]
 pub unsafe fn srf_return_done(
     fcinfo: pg_sys::FunctionCallInfo,
-    funcctx: &mut PgBox<pg_sys::FuncCallContext>,
+    funcctx: *mut pg_sys::FuncCallContext,
 ) {
-    pg_sys::end_MultiFuncCall(fcinfo, funcctx.as_ptr());
-    let fcinfo = PgBox::from_pg(fcinfo);
-    let mut rsi = PgBox::from_pg(fcinfo.resultinfo as *mut pg_sys::ReturnSetInfo);
-    rsi.isDone = pg_sys::ExprDoneCond_ExprEndResult;
+    pg_sys::end_MultiFuncCall(fcinfo, funcctx);
+    (*((*fcinfo).resultinfo as *mut pg_sys::ReturnSetInfo)).isDone =
+        pg_sys::ExprDoneCond_ExprEndResult;
 }

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -9,6 +9,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 //! Utility functions for working with [`pg_sys::HeapTuple`][crate::pg_sys::HeapTuple] and [`pg_sys::HeapTupleHeader`][crate::pg_sys::HeapTupleHeader] structs
 use crate::*;
+use seq_macro::seq;
 use std::num::NonZeroUsize;
 
 /// Given a `pg_sys::Datum` representing a composite row type, return a boxed `HeapTupleData`,
@@ -173,3 +174,30 @@ pub fn heap_getattr_datum_ex(
 
     DatumWithTypeInfo { datum, is_null, typoid, typlen, typbyval }
 }
+
+/// Implemented for Rust tuples that can be represented as a Postgres [`pg_sys::HeapTupleData`].
+pub trait IntoHeapTuple {
+    fn into_heap_tuple(self, tupdesc: *mut pg_sys::TupleDescData) -> *mut pg_sys::HeapTupleData;
+}
+
+seq!(I in 0..32 {
+    #(
+        seq!(N in 0..I {
+            impl<#(T~N: IntoDatum,)*> IntoHeapTuple for (#(T~N,)*) {
+                fn into_heap_tuple(self, tupdesc: pg_sys::TupleDesc) -> *mut pg_sys::HeapTupleData {
+                    let mut datums = [pg_sys::Datum::from(0); I];
+                    let mut nulls = [false; I];
+
+                    #(
+                        match self.N.into_datum() {
+                            Some(datum) => datums[N] = datum,
+                            None => nulls[N] = true,
+                        }
+                    )*
+
+                    unsafe { pg_sys::heap_form_tuple(tupdesc, datums.as_mut_ptr(), nulls.as_mut_ptr()) }
+                }
+            }
+        });
+    )*
+});

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -181,7 +181,7 @@ pub trait IntoHeapTuple {
     ///
     /// # Safety
     ///
-    /// This function is unsafe as it cannot guarantee the specific `tupdesc` is valid.
+    /// This function is unsafe as it cannot guarantee the specified `tupdesc` is valid.
     unsafe fn into_heap_tuple(
         self,
         tupdesc: *mut pg_sys::TupleDescData,

--- a/pgx/src/iter.rs
+++ b/pgx/src/iter.rs
@@ -77,7 +77,7 @@ where
 /// Support for a `TABLE (...)` from an SQL function.
 ///
 /// [`TableIterator`] is typically used as the return type of a `#[pg_extern]`-style function,
-/// indication that the function returns a table of named rows and columns.  [`TableIterator`] is
+/// indicating that the function returns a table of named rows and columns.  [`TableIterator`] is
 /// generic over `T`, but that `T` must be a Rust tuple containing one or more elements.  They
 /// must also be "named" using pgx' [`name!`] macro.  See the examples below.
 ///

--- a/pgx/src/iter.rs
+++ b/pgx/src/iter.rs
@@ -77,7 +77,7 @@ where
 /// Support for a `TABLE (...)` from an SQL function.
 ///
 /// [`TableIterator`] is typically used as the return type of a `#[pg_extern]`-style function,
-/// indicating that the function returns a table of named rows and columns.  [`TableIterator`] is
+/// indicating that the function returns a table of named columns.  [`TableIterator`] is
 /// generic over `T`, but that `T` must be a Rust tuple containing one or more elements.  They
 /// must also be "named" using pgx' [`name!`] macro.  See the examples below.
 ///

--- a/pgx/src/iter.rs
+++ b/pgx/src/iter.rs
@@ -1,9 +1,8 @@
+use std::iter::once;
+
 use pgx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
-use std::iter::once;
-
-use crate::{pg_sys, IntoDatum};
 
 pub struct SetOfIterator<'a, T> {
     iter: Box<dyn Iterator<Item = T> + 'a>,
@@ -21,6 +20,7 @@ impl<'a, T> SetOfIterator<'a, T> {
 impl<'a, T> Iterator for SetOfIterator<'a, T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
@@ -66,21 +66,9 @@ impl<'a, T> TableIterator<'a, T> {
 impl<'a, T> Iterator for TableIterator<'a, T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
-    }
-}
-
-impl<'a, T> IntoDatum for TableIterator<'a, T>
-where
-    T: SqlTranslatable,
-{
-    fn into_datum(self) -> Option<pg_sys::Datum> {
-        todo!()
-    }
-
-    fn type_oid() -> pg_sys::Oid {
-        todo!()
     }
 }
 
@@ -90,7 +78,7 @@ seq_macro::seq!(I in 0..=32 {
             unsafe impl<'a, #(Input~N,)*> SqlTranslatable for TableIterator<'a, (#(Input~N,)*)>
             where
                 #(
-                    Input~N: SqlTranslatable + 'static,
+                    Input~N: SqlTranslatable + 'a,
                 )*
             {
                 fn argument_sql() -> Result<SqlMapping, ArgumentError> {

--- a/pgx/src/iter.rs
+++ b/pgx/src/iter.rs
@@ -1,9 +1,40 @@
 use std::iter::once;
 
+use crate::IntoHeapTuple;
 use pgx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
 
+/// Support for returning a `SETOF T` from an SQL function.
+///
+/// [`SetOfIterator`] is typically used as a return type on `#[pg_extern]`-style functions
+/// and indicates that the SQL function should return a `SETOF` over the generic argument `T`.
+///
+/// It is a lightweight wrapper around an iterator, which you provide during construction.  The
+/// iterator *can* borrow from its environment, following Rust's normal borrowing rules.  If no
+/// borrowing is necessary, the `'static` lifetime should be used.
+///
+/// # Examples
+///
+/// This example simply returns a set of integers in the range `1..=5`.
+///
+/// ```rust,no_run
+/// use pgx::prelude::*;
+/// #[pg_extern]
+/// fn return_ints() -> SetOfIterator<'static, i32> {
+///     SetOfIterator::new(1..=5)
+/// }
+/// ```
+///
+/// Here we return a set of `&str`s, borrowed from an argument:
+///
+/// ```rust,no_run
+/// use pgx::prelude::*;
+/// #[pg_extern]
+/// fn split_string<'a>(input: &'a str) -> SetOfIterator<'a, &'a str> {
+///     SetOfIterator::new(input.split_whitespace())
+/// }
+/// ```
 pub struct SetOfIterator<'a, T> {
     iter: Box<dyn Iterator<Item = T> + 'a>,
 }
@@ -43,23 +74,64 @@ where
     }
 }
 
+/// Support for a `TABLE (...)` from an SQL function.
+///
+/// [`TableIterator`] is typically used as the return type of a `#[pg_extern]`-style function,
+/// indication that the function returns a table of named rows and columns.  [`TableIterator`] is
+/// generic over `T`, but that `T` must be a Rust tuple containing one or more elements.  They
+/// must also be "named" using pgx' [`name!`] macro.  See the examples below.
+///
+/// It is a lightweight wrapper around an iterator, which you provide during construction.  The
+/// iterator *can* borrow from its environment, following Rust's normal borrowing rules.  If no
+/// borrowing is necessary, the `'static` lifetime should be used.
+///
+/// # Examples
+///
+/// This example returns a table of employee information.
+///
+/// ```rust,no_run
+/// use pgx::prelude::*;
+/// #[pg_extern]
+/// fn employees() -> TableIterator<'static,
+///         (
+///             name!(id, i64),
+///             name!(dept_code, String),
+///             name!(full_text, &'static str)
+///         )
+/// > {
+///     TableIterator::new(vec![
+///         (42, "ARQ".into(), "John Hammond"),
+///         (87, "EGA".into(), "Mary Kinson"),
+///         (3,  "BLA".into(), "Perry Johnson"),
+///     ])
+/// }
+/// ```
+///
+/// And here we return a simple numbered list of words, borrowed from the input `&str`.
+///
+/// ```rust,no_run
+/// use pgx::prelude::*;
+/// #[pg_extern]
+/// fn split_string<'a>(input: &'a str) -> TableIterator<'a, ( name!(num, i32), name!(word, &'a str) )> {
+///     TableIterator::new(input.split_whitespace().enumerate().map(|(n, w)| (n as i32, w)))
+/// }
+/// ```
 pub struct TableIterator<'a, T> {
     iter: Box<dyn Iterator<Item = T> + 'a>,
 }
 
-impl<'a, T> TableIterator<'a, T> {
+impl<'a, T> TableIterator<'a, T>
+where
+    T: IntoHeapTuple + 'a,
+{
     pub fn new<I>(iter: I) -> Self
     where
-        I: Iterator<Item = T> + 'a,
-        T: 'a,
+        I: IntoIterator<Item = T> + 'a,
     {
-        Self { iter: Box::new(iter) }
+        Self { iter: Box::new(iter.into_iter()) }
     }
 
-    pub fn once(value: T) -> Self
-    where
-        T: 'a,
-    {
+    pub fn once(value: T) -> Self {
         Self::new(once(value))
     }
 }

--- a/pgx/src/iter.rs
+++ b/pgx/src/iter.rs
@@ -51,15 +51,16 @@ impl<'a, T> TableIterator<'a, T> {
     pub fn new<I>(iter: I) -> Self
     where
         I: Iterator<Item = T> + 'a,
+        T: 'a,
     {
         Self { iter: Box::new(iter) }
     }
 
-    pub fn once(value: T) -> TableIterator<'a, T>
+    pub fn once(value: T) -> Self
     where
         T: 'a,
     {
-        Self { iter: Box::new(once(value)) }
+        Self::new(once(value))
     }
 }
 

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -66,6 +66,7 @@ pub mod shmem;
 pub mod spi;
 #[cfg(feature = "cshim")]
 pub mod spinlock;
+pub mod srf;
 pub mod stringinfo;
 pub mod trigger_support;
 pub mod tupdesc;

--- a/pgx/src/srf.rs
+++ b/pgx/src/srf.rs
@@ -67,7 +67,7 @@ impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
 impl<'a, T: IntoHeapTuple> TableIterator<'a, T> {
     #[doc(hidden)]
     pub unsafe fn srf_next<F: FnOnce() -> Option<TableIterator<'a, T>>>(
-        fcinfo: *mut pg_sys::FunctionCallInfoBaseData,
+        fcinfo: pg_sys::FunctionCallInfo,
         first_call_func: F,
     ) -> pg_sys::Datum {
         if srf_is_first_call(fcinfo) {

--- a/pgx/src/srf.rs
+++ b/pgx/src/srf.rs
@@ -9,7 +9,7 @@ use crate::{
 impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
     #[doc(hidden)]
     pub unsafe fn srf_next<F: FnOnce() -> Option<SetOfIterator<'a, T>>>(
-        fcinfo: *mut pg_sys::FunctionCallInfoBaseData,
+        fcinfo: pg_sys::FunctionCallInfo,
         first_call_func: F,
     ) -> pg_sys::Datum {
         if srf_is_first_call(fcinfo) {

--- a/pgx/src/srf.rs
+++ b/pgx/src/srf.rs
@@ -1,0 +1,132 @@
+use crate::iter::{SetOfIterator, TableIterator};
+use crate::{
+    pg_return_null, pg_sys, srf_first_call_init, srf_is_first_call, srf_per_call_setup,
+    srf_return_done, srf_return_next, IntoDatum, IntoHeapTuple, PgMemoryContexts,
+};
+
+impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
+    #[doc(hidden)]
+    pub unsafe fn srf_next<F: FnOnce() -> Option<SetOfIterator<'a, T>>>(
+        fcinfo: *mut pg_sys::FunctionCallInfoBaseData,
+        first_call_func: F,
+    ) -> pg_sys::Datum {
+        if srf_is_first_call(fcinfo) {
+            let mut funcctx = srf_first_call_init(fcinfo);
+
+            let (setof_iterator, memcxt) = PgMemoryContexts::For((*funcctx).multi_call_memory_ctx)
+                .switch_to(|_| {
+                    // first off, ask the user's function to do the needful and return Option<SetOfIterator<T>>
+                    let setof_iterator = first_call_func();
+
+                    //
+                    // and if we're here, it worked, so carry on with the initial SRF setup dance
+                    //
+
+                    // allocate and return a Context for holding our SrfIterator which is used on every call
+                    (setof_iterator, (*funcctx).multi_call_memory_ctx)
+                });
+
+            let setof_iterator = match setof_iterator {
+                // user's function returned None, so there's nothing for us to later iterate
+                None => {
+                    srf_return_done(fcinfo, funcctx);
+                    return pg_return_null(fcinfo);
+                }
+
+                // user's function returned Some(TableIterator), so we need to leak it into the
+                // memory context Postgres has decided is to be used for multi-call SRF functions
+                Some(iter) => PgMemoryContexts::For(memcxt).leak_and_drop_on_delete(iter),
+            };
+
+            // it's the first call so we need to finish setting up `funcctx`
+            (*funcctx).user_fctx = setof_iterator.cast();
+        }
+
+        let funcctx = srf_per_call_setup(fcinfo);
+
+        // SAFETY: we created `funcctx.user_fctx` on the first call into this function so
+        // we know it's valid
+        let setof_iterator =
+            (*funcctx).user_fctx.cast::<SetOfIterator<T>>().as_mut().unwrap_unchecked();
+
+        match setof_iterator.next() {
+            Some(datum) => {
+                srf_return_next(fcinfo, funcctx);
+                datum.into_datum().unwrap_or_else(|| pg_return_null(fcinfo))
+            }
+            None => {
+                srf_return_done(fcinfo, funcctx);
+                pg_return_null(fcinfo)
+            }
+        }
+    }
+}
+
+impl<'a, T: IntoHeapTuple> TableIterator<'a, T> {
+    #[doc(hidden)]
+    pub unsafe fn srf_next<F: FnOnce() -> Option<TableIterator<'a, T>>>(
+        fcinfo: *mut pg_sys::FunctionCallInfoBaseData,
+        first_call_func: F,
+    ) -> pg_sys::Datum {
+        if srf_is_first_call(fcinfo) {
+            let mut funcctx = srf_first_call_init(fcinfo);
+
+            let (table_iterator, tupdesc, memcxt) =
+                PgMemoryContexts::For((*funcctx).multi_call_memory_ctx).switch_to(|_| {
+                    // first off, ask the user's function to do the needful and return Option<TableIterator<T>>
+                    let table_iterator = first_call_func();
+
+                    //
+                    // and if we're here, it worked, so carry on with the initial SRF setup dance
+                    //
+
+                    // Build a tuple descriptor for our result type
+                    let mut tupdesc = std::ptr::null_mut();
+                    if pg_sys::get_call_result_type(fcinfo, std::ptr::null_mut(), &mut tupdesc)
+                        != pg_sys::TypeFuncClass_TYPEFUNC_COMPOSITE
+                    {
+                        pg_sys::error!("return type must be a row type");
+                    }
+                    pg_sys::BlessTupleDesc(tupdesc);
+
+                    // allocate and return a Context for holding our SrfIterator which is used on every call
+                    (table_iterator, tupdesc, (*funcctx).multi_call_memory_ctx)
+                });
+
+            let table_iterator = match table_iterator {
+                // user's function returned None, so there's nothing for us to later iterate
+                None => {
+                    srf_return_done(fcinfo, funcctx);
+                    return pg_return_null(fcinfo);
+                }
+
+                // user's function returned Some(TableIterator), so we need to leak it into the
+                // memory context Postgres has decided is to be used for multi-call SRF functions
+                Some(iter) => PgMemoryContexts::For(memcxt).leak_and_drop_on_delete(iter),
+            };
+
+            // it's the first call so we need to finish setting up `funcctx`
+            (*funcctx).tuple_desc = tupdesc;
+            (*funcctx).user_fctx = table_iterator.cast();
+        }
+
+        let funcctx = srf_per_call_setup(fcinfo);
+
+        // SAFETY: we created `funcctx.user_fctx` on the first call into this function so
+        // we know it's valid
+        let table_iterator =
+            (*funcctx).user_fctx.cast::<TableIterator<T>>().as_mut().unwrap_unchecked();
+
+        match table_iterator.next() {
+            Some(tuple) => {
+                let heap_tuple = tuple.into_heap_tuple((*funcctx).tuple_desc);
+                srf_return_next(fcinfo, funcctx);
+                pg_sys::HeapTupleHeaderGetDatum((*heap_tuple).t_data)
+            }
+            None => {
+                srf_return_done(fcinfo, funcctx);
+                pg_return_null(fcinfo)
+            }
+        }
+    }
+}

--- a/pgx/src/srf.rs
+++ b/pgx/src/srf.rs
@@ -1,3 +1,5 @@
+#![doc(hidden)]
+//! Helper implementations for returning sets and tables from `#[pg_extern]`-style functions
 use crate::iter::{SetOfIterator, TableIterator};
 use crate::{
     pg_return_null, pg_sys, srf_first_call_init, srf_is_first_call, srf_per_call_setup,


### PR DESCRIPTION
This takes out nearly all of the code generation for `TableIterator`- and `SetOfIterator`-returning functions and moves it into actual code in the new `pgx/src/srf.rs`.
    
Also updates the various `srf_xxx()` functions in `pgx/src/fcinfo.rs` to not use PgBox -- that was showing up in profiling, even in --release.
    
We also have a new trait called `IntoHeapTuple` that knows how to convert, given a TupleDesc, Rust tuples (up to 32 elements) into a Postgres `pg_sys::HeapTuple`.  It requires that each element be `IntoDatum`.  This is used by the srf implementation for `TableIterator`.

No functional changes here.  Trying to maintain code in `syn::quote!()` blocks is nearly impossible, and the SRF code is complex and important enough to warrant being moved out.  Especially after the bug I found in #982 -- which is now handled even differently, and better!, here in this PR.