### PR TITLE
PgLwLock: skip releasing the lock when unwinding from an `elog` call in postgres code

### DIFF
--- a/pgx-tests/src/lib.rs
+++ b/pgx-tests/src/lib.rs
@@ -23,6 +23,6 @@ pub mod pg_test {
     }
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
-        vec![]
+        vec!["shared_preload_libraries='pgx_tests'"]
     }
 }

--- a/pgx-tests/src/tests/shmem_tests.rs
+++ b/pgx-tests/src/tests/shmem_tests.rs
@@ -7,13 +7,49 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 use pgx::prelude::*;
-use pgx::{pg_shmem_init, PgAtomic, PgSharedMemoryInitialization};
+use pgx::{pg_shmem_init, PgAtomic, PgLwLock, PgSharedMemoryInitialization};
 use std::sync::atomic::AtomicBool;
 
 static ATOMIC: PgAtomic<AtomicBool> = PgAtomic::new();
+static LWLOCK: PgLwLock<bool> = PgLwLock::new();
 
 #[pg_guard]
 pub extern "C" fn _PG_init() {
     // This ensures that this functionality works across PostgreSQL versions
     pg_shmem_init!(ATOMIC);
+    pg_shmem_init!(LWLOCK);
+}
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+
+    use crate::tests::shmem_tests::LWLOCK;
+    use pgx::prelude::*;
+
+    #[pg_test]
+    #[should_panic(expected = "cache lookup failed for type 0")]
+    pub fn test_behaves_normally_when_elog_while_holding_lock() {
+        // Hold lock
+        let _lock = LWLOCK.exclusive();
+        // Call into pg_guarded postgres function which internally reports an error
+        unsafe { pg_sys::format_type_extended(pg_sys::InvalidOid, -1, 0) };
+    }
+
+    #[pg_test]
+    pub fn test_lock_is_released_on_drop() {
+        let lock = LWLOCK.exclusive();
+        drop(lock);
+        let _lock = LWLOCK.exclusive();
+    }
+
+    #[pg_test]
+    pub fn test_lock_is_released_on_unwind() {
+        let _res = std::panic::catch_unwind(|| {
+            let _lock = LWLOCK.exclusive();
+            panic!("get out")
+        });
+        let _lock = LWLOCK.exclusive();
+    }
 }


### PR DESCRIPTION
Avoid backend crash when trying to release the lock on drop due to `elog` resetting the interrupt holdoff section status.
The code now detects this situation and skips releasing the lock.

Fixes #988 