### PR TITLE
The `cshim` feature should not be a default in `pgx-pg-sys`.

### DIFF
--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [features]
-default = [ "cshim" ]
+default = [ ]
 pg11 = [ ]
 pg12 = [ ]
 pg13 = [ ]


### PR DESCRIPTION
Users don't use the pgx-pg-sys crate as a direct dependency, and `pgx` itself has `cshim` as its default.  This makes it easy for users to expose their own feature to toggle the cshim without pgx needing knowledge of pgx-pg-sys' default feature set.