### PR TITLE
Mark functions `unsafe` that should be

### DIFF
--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -159,6 +159,16 @@ pub use internal::pg15::*;
 /// A trait applied to all Postgres `pg_sys::Node` types and subtypes
 pub trait PgNode: seal::Sealed {
     /// Format this node
+    ///
+    /// # Safety
+    ///
+    /// While pgx controls the types for which [`PgNode`] is implemented and only pgx can implement
+    /// [`PgNode`] it cannot control the members of those types and a user could assign any pointer
+    /// type member to something invalid that Postgres wouldn't understand.
+    ///
+    /// Because this function is used by `impl Display` we purposely don't mark it `unsafe`.  The
+    /// assumption here, which might be a bad one, is that only intentional misuse would actually
+    /// cause undefined behavior.
     #[inline]
     fn display_node(&self) -> std::string::String {
         // SAFETY: The trait is pub but this impl is private, and

--- a/pgx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -64,7 +64,7 @@ impl PgTrigger {
         let tokens = quote! {
             #[no_mangle]
             #[::pgx::pgx_macros::pg_guard]
-            extern "C" fn #extern_func_ident(fcinfo: ::pgx::pg_sys::FunctionCallInfo) -> ::pgx::pg_sys::Datum {
+            unsafe extern "C" fn #extern_func_ident(fcinfo: ::pgx::pg_sys::FunctionCallInfo) -> ::pgx::pg_sys::Datum {
                 let maybe_pg_trigger = unsafe { ::pgx::trigger_support::PgTrigger::from_fcinfo(fcinfo) };
                 let pg_trigger = maybe_pg_trigger.expect("PgTrigger::from_fcinfo failed");
                 let trigger_fn_result: Result<

--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -32,17 +32,19 @@ mod tests {
     fn test_leak_and_drop() {
         let did_drop = Arc::new(AtomicBool::new(false));
 
-        PgMemoryContexts::Transient {
-            parent: PgMemoryContexts::CurrentMemoryContext.value(),
-            name: "test",
-            min_context_size: 4096,
-            initial_block_size: 4096,
-            max_block_size: 4096,
+        unsafe {
+            PgMemoryContexts::Transient {
+                parent: PgMemoryContexts::CurrentMemoryContext.value(),
+                name: "test",
+                min_context_size: 4096,
+                initial_block_size: 4096,
+                max_block_size: 4096,
+            }
+            .switch_to(|context| {
+                let test_object = TestObject { did_drop: did_drop.clone() };
+                context.leak_and_drop_on_delete(test_object);
+            });
         }
-        .switch_to(|context| {
-            let test_object = TestObject { did_drop: did_drop.clone() };
-            context.leak_and_drop_on_delete(test_object);
-        });
 
         assert!(did_drop.load(Ordering::SeqCst))
     }
@@ -57,9 +59,9 @@ mod tests {
     fn switch_to_should_switch_back_on_panic() {
         let mut ctx = PgMemoryContexts::new("test");
         let ctx_sys = ctx.value();
-        PgTryBuilder::new(move || {
+        PgTryBuilder::new(move || unsafe {
             ctx.switch_to(|_| {
-                assert_eq!(unsafe { pg_sys::CurrentMemoryContext }, ctx_sys);
+                assert_eq!(pg_sys::CurrentMemoryContext, ctx_sys);
                 panic!();
             });
         })

--- a/pgx-tests/src/tests/memcxt_tests.rs
+++ b/pgx-tests/src/tests/memcxt_tests.rs
@@ -51,8 +51,11 @@ mod tests {
 
     #[pg_test]
     fn parent() {
-        assert!(PgMemoryContexts::TopMemoryContext.parent().is_none());
-        assert!(PgMemoryContexts::CurrentMemoryContext.parent().is_some());
+        unsafe {
+            // SAFETY:  We know these two PgMemoryContext variants are valid b/c pgx sets them up for us
+            assert!(PgMemoryContexts::TopMemoryContext.parent().is_none());
+            assert!(PgMemoryContexts::CurrentMemoryContext.parent().is_some());
+        }
     }
 
     #[pg_test]

--- a/pgx-tests/src/tests/pgbox_tests.rs
+++ b/pgx-tests/src/tests/pgbox_tests.rs
@@ -12,11 +12,11 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgx_tests;
     use pgx::prelude::*;
-    use pgx::{AllocatedByRust, PgMemoryContexts};
+    use pgx::AllocatedByRust;
 
     #[pg_test]
     fn pgbox_alloc() {
-        let mut ptr: PgBox<i32, AllocatedByRust> = PgBox::<i32>::alloc();
+        let mut ptr: PgBox<i32, AllocatedByRust> = unsafe { PgBox::<i32>::alloc() };
         // ptr is uninitialized data!!! This is dangerous to read from!!!
         *ptr = 5;
 
@@ -25,56 +25,12 @@ mod tests {
 
     #[pg_test]
     fn pgbox_alloc0() {
-        let mut ptr: PgBox<i32, AllocatedByRust> = PgBox::<i32>::alloc0();
+        let mut ptr: PgBox<i32, AllocatedByRust> = unsafe { PgBox::<i32>::alloc0() };
 
         assert_eq!(*ptr, 0);
 
         *ptr = 5;
 
         assert_eq!(*ptr, 5);
-    }
-
-    #[pg_test]
-    fn pgbox_new() {
-        let ptr: PgBox<i32, AllocatedByRust> = PgBox::new(5);
-        assert_eq!(*ptr, 5);
-
-        let mut ptr: PgBox<Vec<i32>, AllocatedByRust> = PgBox::new(vec![]);
-        assert_eq!(*ptr, Vec::<i32>::default());
-
-        ptr.push(1);
-        assert_eq!(*ptr, vec![1]);
-
-        ptr.push(2);
-        assert_eq!(*ptr, vec![1, 2]);
-
-        ptr.push(3);
-        assert_eq!(*ptr, vec![1, 2, 3]);
-
-        let drained = ptr.drain(..).collect::<Vec<_>>();
-        assert_eq!(drained, vec![1, 2, 3])
-    }
-
-    #[pg_test]
-    fn pgbox_new_in_context() {
-        let ptr: PgBox<i32, AllocatedByRust> =
-            PgBox::new_in_context(5, PgMemoryContexts::CurrentMemoryContext);
-        assert_eq!(*ptr, 5);
-
-        let mut ptr: PgBox<Vec<i32>, AllocatedByRust> =
-            PgBox::new_in_context(vec![], PgMemoryContexts::CurrentMemoryContext);
-        assert_eq!(*ptr, Vec::<i32>::default());
-
-        ptr.push(1);
-        assert_eq!(*ptr, vec![1]);
-
-        ptr.push(2);
-        assert_eq!(*ptr, vec![1, 2]);
-
-        ptr.push(3);
-        assert_eq!(*ptr, vec![1, 2, 3]);
-
-        let drained = ptr.drain(..).collect::<Vec<_>>();
-        assert_eq!(drained, vec![1, 2, 3])
     }
 }

--- a/pgx-tests/src/tests/struct_type_tests.rs
+++ b/pgx-tests/src/tests/struct_type_tests.rs
@@ -48,7 +48,7 @@ fn complex_in(input: &std::ffi::CStr) -> PgBox<Complex, AllocatedByRust> {
     .unwrap();
     let x = get_named_capture(&re, "x", input_as_str).unwrap();
     let y = get_named_capture(&re, "y", input_as_str).unwrap();
-    let mut complex = PgBox::<Complex>::alloc();
+    let mut complex = unsafe { PgBox::<Complex>::alloc() };
 
     complex.x = str::parse::<f64>(&x).unwrap_or_else(|_| panic!("{} isn't a f64", x));
     complex.y = str::parse::<f64>(&y).unwrap_or_else(|_| panic!("{} isn't a f64", y));

--- a/pgx/src/aggregate.rs
+++ b/pgx/src/aggregate.rs
@@ -439,10 +439,14 @@ where
         fcinfo: FunctionCallInfo,
         f: F,
     ) -> R {
-        let aggregate_memory_context =
-            unsafe { Self::memory_context(fcinfo) }.unwrap_or_else(|| {
+        unsafe {
+            let aggregate_memory_context = Self::memory_context(fcinfo).unwrap_or_else(|| {
                 error!("Cannot access Aggregate memory contexts when not an aggregate.")
             });
-        PgMemoryContexts::For(aggregate_memory_context).switch_to(f)
+
+            // SAFETY: Self::memory_context() will always give us a valid MemoryContext in which
+            // to operate
+            PgMemoryContexts::For(aggregate_memory_context).switch_to(f)
+        }
     }
 }

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -35,8 +35,10 @@ impl IntoDatum for pg_sys::ItemPointerData {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         let tid = self;
-        let tid_ptr =
-            PgMemoryContexts::CurrentMemoryContext.palloc_struct::<pg_sys::ItemPointerData>();
+        let tid_ptr = unsafe {
+            // SAFETY:  CurrentMemoryContext is always valid
+            PgMemoryContexts::CurrentMemoryContext.palloc_struct::<pg_sys::ItemPointerData>()
+        };
         let (blockno, offno) = item_pointer_get_both(tid);
 
         item_pointer_set_all(unsafe { &mut *tid_ptr }, blockno, offno);

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -47,7 +47,7 @@ impl FromDatum for TimeWithTimeZone {
 impl IntoDatum for TimeWithTimeZone {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let mut timetz = PgBox::<pg_sys::TimeTzADT>::alloc();
+        let mut timetz = unsafe { PgBox::<pg_sys::TimeTzADT>::alloc() };
         timetz.zone = self.tz_secs;
         timetz.time = self.t.0 as i64;
 

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -24,7 +24,10 @@ pub struct Uuid(UuidBytes);
 impl IntoDatum for Uuid {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let ptr = PgMemoryContexts::CurrentMemoryContext.palloc_slice::<u8>(UUID_BYTES_LEN);
+        let ptr = unsafe {
+            // SAFETY:  CurrentMemoryContext is always valid
+            PgMemoryContexts::CurrentMemoryContext.palloc_slice::<u8>(UUID_BYTES_LEN)
+        };
         ptr.clone_from_slice(&self.0);
 
         Some(ptr.as_ptr().into())

--- a/pgx/src/htup.rs
+++ b/pgx/src/htup.rs
@@ -24,7 +24,7 @@ pub fn composite_row_type_make_tuple(
 ) -> PgBox<pg_sys::HeapTupleData, AllocatedByRust> {
     let htup_header =
         unsafe { pg_sys::pg_detoast_datum_packed(row.cast_mut_ptr()) } as pg_sys::HeapTupleHeader;
-    let mut tuple = PgBox::<pg_sys::HeapTupleData>::alloc0();
+    let mut tuple = unsafe { PgBox::<pg_sys::HeapTupleData>::alloc0() };
 
     tuple.t_len = heap_tuple_header_get_datum_length(htup_header) as u32;
     tuple.t_data = htup_header;

--- a/pgx/src/itemptr.rs
+++ b/pgx/src/itemptr.rs
@@ -121,7 +121,7 @@ pub fn new_item_pointer(
     blockno: pg_sys::BlockNumber,
     offno: pg_sys::OffsetNumber,
 ) -> PgBox<pg_sys::ItemPointerData, AllocatedByRust> {
-    let mut tid = PgBox::<pg_sys::ItemPointerData>::alloc();
+    let mut tid = unsafe { PgBox::<pg_sys::ItemPointerData>::alloc() };
     tid.ip_blkid.bi_hi = (blockno >> 16) as u16;
     tid.ip_blkid.bi_lo = (blockno & 0xffff) as u16;
     tid.ip_posid = offno;

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -15,8 +15,8 @@ Use of this source code is governed by the MIT license that can be found in the 
 //! An enum-based interface (`PgMemoryContexts`) around Postgres' various `MemoryContext`s provides
 //! simple accessibility to working with MemoryContexts in a compiler-checked manner
 //!
+use crate::pg_sys;
 use crate::pg_sys::AsPgCStr;
-use crate::{pg_sys, PgBox};
 use core::ptr;
 use std::fmt::Debug;
 use std::ptr::NonNull;
@@ -287,9 +287,36 @@ impl PgMemoryContexts {
         }
     }
 
-    /// Release all space allocated within a context and delete all its descendant contexts (but not
-    /// the context itself).
-    pub fn reset(&mut self) {
+    /// Release all space allocated within a context (ie, free the memory) and delete all its
+    /// descendant contexts (but not the context itself).
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as it can lead easy lead to use-after-free of Postgres allocated
+    /// memory:
+    ///
+    /// ```rust,no_run
+    /// use pgx::memcxt::PgMemoryContexts;
+    /// struct Thing(Option<String>);
+    /// let mut thing = unsafe {
+    ///     // SAFETY:  CurrentMemoryContext is always valid and Thing can be allocated as a zero'd struct
+    ///     PgMemoryContexts::CurrentMemoryContext.palloc0_struct::<Thing>()
+    /// };
+    /// let mut thing = unsafe {
+    ///     // SAFETY:  We just allocated it, so it must be a valid Thing
+    ///     thing.as_mut().unwrap()
+    /// };
+    /// thing.0 = Some("hello, world".into());
+    ///
+    /// unsafe {
+    ///     // SAFETY:  We promise not to use anything allocated by CurrentMemoryContext prior to
+    ///     // this call to reset(), specifically `thing`.
+    ///     PgMemoryContexts::CurrentMemoryContext.reset();
+    /// }
+    ///
+    /// assert_eq!(thing.0, Some("hello, world".into()))  // we lied! UAF happens here
+    /// ```
+    pub unsafe fn reset(&mut self) {
         unsafe {
             pg_sys::MemoryContextReset(self.value());
         }
@@ -321,6 +348,8 @@ impl PgMemoryContexts {
     /// use pgx::PgMemoryContexts;
     ///
     /// pub fn do_something() -> pg_sys::ItemPointer {
+    ///     unsafe {
+    ///     // SAFETY:  We know for a fact that `PgMemoryContexts::TopTransactionContext` is always valid
     ///     PgMemoryContexts::TopTransactionContext.switch_to(|context| {
     ///         // allocate a new ItemPointerData, but inside the TopTransactionContext
     ///         let tid = PgBox::<pg_sys::ItemPointerData>::alloc();
@@ -329,9 +358,19 @@ impl PgMemoryContexts {
     ///         // Note that it stays allocated here in the TopTransactionContext
     ///         tid.into_pg()
     ///     })
+    ///     }
     /// }
     /// ```
-    pub fn switch_to<R, F: FnOnce(&mut PgMemoryContexts) -> R>(&mut self, f: F) -> R {
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn switch_to<R, F: FnOnce(&mut PgMemoryContexts) -> R>(&mut self, f: F) -> R {
         match self {
             PgMemoryContexts::Transient {
                 parent,
@@ -369,15 +408,39 @@ impl PgMemoryContexts {
     ///
     /// ```rust,no_run
     /// use pgx::PgMemoryContexts;
-    /// let copy = PgMemoryContexts::CurrentMemoryContext.pstrdup("make a copy of this");
+    /// // SAFETY:  `CurrentMemoryContext` is always valid, and we promise not to use `copy` after
+    /// // `CurrentMemoryContext` has been free'd.
+    /// let copy = unsafe { PgMemoryContexts::CurrentMemoryContext.pstrdup("make a copy of this") };
     /// ```
-    pub fn pstrdup(&self, s: &str) -> *mut std::os::raw::c_char {
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn pstrdup(&self, s: &str) -> *mut std::os::raw::c_char {
         let cstring = std::ffi::CString::new(s).unwrap();
         unsafe { pg_sys::MemoryContextStrdup(self.value(), cstring.as_ptr()) }
     }
 
     /// Copies `len` bytes, starting at `src` into this memory context and
     /// returns a raw `*mut T` pointer to the newly allocated location
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `src` is a null pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
     #[warn(unsafe_op_in_unsafe_fn)]
     pub unsafe fn copy_ptr_into<T>(&mut self, src: *mut T, len: usize) -> *mut T {
         if src.is_null() {
@@ -394,37 +457,102 @@ impl PgMemoryContexts {
     }
 
     /// Allocate memory in this context, which will be free'd whenever Postgres deletes this MemoryContext
-    pub fn palloc(&mut self, len: usize) -> *mut std::os::raw::c_void {
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn palloc(&mut self, len: usize) -> *mut std::os::raw::c_void {
         unsafe { pg_sys::MemoryContextAlloc(self.value(), len) }
     }
 
-    pub fn palloc_struct<T>(&mut self) -> *mut T {
-        self.palloc(std::mem::size_of::<T>()) as *mut T
+    /// Allocate a struct in this memory context, returning a pointer to it.  The memory will be
+    /// uninitialized and will be freed whenever Postgres deletes this MemoryContext.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn palloc_struct<T>(&mut self) -> *mut T {
+        unsafe { self.palloc(std::mem::size_of::<T>()) as *mut T }
     }
 
-    pub fn palloc0_struct<T>(&mut self) -> *mut T {
-        self.palloc0(std::mem::size_of::<T>()) as *mut T
+    /// Allocate a struct in this memory context, returning a pointer to it.  The memory will be
+    /// zeroed and will be freed whenever Postgres deletes this MemoryContext.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn palloc0_struct<T>(&mut self) -> *mut T {
+        unsafe { self.palloc0(std::mem::size_of::<T>()) as *mut T }
     }
 
     /// Allocate a slice in this context, which will be free'd whenever Postgres deletes this MemoryContext
-    pub fn palloc_slice<'a, T>(&mut self, len: usize) -> &'a mut [T] {
-        let buffer = self.palloc(std::mem::size_of::<T>() * len) as *mut T;
-        unsafe { std::slice::from_raw_parts_mut(buffer, len) }
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn palloc_slice<'a, T>(&mut self, len: usize) -> &'a mut [T] {
+        unsafe {
+            let buffer = self.palloc(std::mem::size_of::<T>() * len) as *mut T;
+            std::slice::from_raw_parts_mut(buffer, len)
+        }
     }
 
     /// Allocate a slice in this context, where the memory is zero'd, which will be free'd whenever Postgres deletes this MemoryContext
-    pub fn palloc0_slice<'a, T>(&mut self, len: usize) -> &'a mut [T] {
-        let buffer = self.palloc0(std::mem::size_of::<T>() * len) as *mut T;
-        unsafe { std::slice::from_raw_parts_mut(buffer, len) }
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn palloc0_slice<'a, T>(&mut self, len: usize) -> &'a mut [T] {
+        unsafe {
+            let buffer = self.palloc0(std::mem::size_of::<T>() * len) as *mut T;
+            std::slice::from_raw_parts_mut(buffer, len)
+        }
     }
 
     /// Allocate memory in this context, which will be free'd whenever Postgres deletes this MemoryContext
     ///
     /// The allocated memory is zero'd
-    pub fn palloc0(&mut self, len: usize) -> *mut std::os::raw::c_void {
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    ///
+    /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
+    /// borrow checker thinks it will.
+    pub unsafe fn palloc0(&mut self, len: usize) -> *mut std::os::raw::c_void {
         unsafe { pg_sys::MemoryContextAllocZero(self.value(), len) }
     }
 
+    /// Consumes an instance of `T` and leaks it.  Whenever Postgres deletes
+    /// this MemoryContext, the original instance of `T` will be resurrected and its `impl Drop`
+    /// will be called.
     pub fn leak_and_drop_on_delete<T>(&mut self, v: T) -> *mut T {
         unsafe extern "C" fn drop_on_delete<T>(ptr: void_mut_ptr) {
             let boxed = Box::from_raw(ptr as *mut T);
@@ -432,13 +560,15 @@ impl PgMemoryContexts {
         }
 
         let leaked_ptr = Box::leak(Box::new(v));
-        // SAFETY:  we know the result of `self.palloc_struct()` is a valid pointer
-        let mut memcxt_callback =
-            unsafe { PgBox::from_pg(self.palloc_struct::<pg_sys::MemoryContextCallback>()) };
-        memcxt_callback.func = Some(drop_on_delete::<T>);
-        memcxt_callback.arg = leaked_ptr as *mut T as void_mut_ptr;
         unsafe {
-            pg_sys::MemoryContextRegisterResetCallback(self.value(), memcxt_callback.into_pg());
+            // SAFETY:  we know the result of `self.palloc_struct()` is a valid pointer and its
+            // okay that it's uninitialized because its fields are just pointers and we set them
+            // immediately after
+            let callback = self.palloc_struct::<pg_sys::MemoryContextCallback>();
+            (*callback).func = Some(drop_on_delete::<T>);
+            (*callback).arg = leaked_ptr as *mut T as void_mut_ptr;
+
+            pg_sys::MemoryContextRegisterResetCallback(self.value(), callback);
         }
         leaked_ptr
     }
@@ -481,59 +611,5 @@ impl PgMemoryContexts {
         }
 
         result
-    }
-
-    pub fn unguarded_switch_to<R, F: FnOnce(&mut PgMemoryContexts) -> R>(&mut self, f: F) -> R {
-        fn unguarded_exec_in_context<R, F: FnOnce(&mut PgMemoryContexts) -> R>(
-            context: pg_sys::MemoryContext,
-            f: F,
-        ) -> R {
-            let prev_context;
-
-            // mimic what palloc.h does for switching memory contexts
-            unsafe {
-                prev_context = pg_sys::CurrentMemoryContext;
-                pg_sys::CurrentMemoryContext = context;
-            }
-
-            let result = f(&mut PgMemoryContexts::For(context));
-
-            // restore our understanding of the current memory context
-            unsafe {
-                pg_sys::CurrentMemoryContext = prev_context;
-            }
-
-            result
-        }
-
-        match self {
-            PgMemoryContexts::Transient {
-                parent,
-                name,
-                min_context_size,
-                initial_block_size,
-                max_block_size,
-            } => {
-                let context: pg_sys::MemoryContext = unsafe {
-                    let name = std::ffi::CString::new(*name).unwrap();
-                    pg_sys::AllocSetContextCreateExtended(
-                        *parent,
-                        name.into_raw(),
-                        *min_context_size as usize,
-                        *initial_block_size as usize,
-                        *max_block_size as usize,
-                    )
-                };
-
-                let result = unguarded_exec_in_context(context, f);
-
-                unsafe {
-                    pg_sys::MemoryContextDelete(context);
-                }
-
-                result
-            }
-            _ => unguarded_exec_in_context(self.value(), f),
-        }
     }
 }

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -323,7 +323,13 @@ impl PgMemoryContexts {
     }
 
     /// Returns parent memory context if any
-    pub fn parent(&self) -> Option<PgMemoryContexts> {
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because we cannot ensure that any of the [`PgMemoryContexts`] variants,
+    /// specifically those with payloads, actually represent valid Postgres [`pg_sys::MemoryContextData`]
+    /// pointers.
+    pub unsafe fn parent(&self) -> Option<PgMemoryContexts> {
         // SAFETY: We do this instead of simply plucking the .parent field ourselves
         // mostly to let Postgres check the context validity if --enable-cassert is on
         let parent = unsafe { pg_sys::MemoryContextGetParent(self.value()) };

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -292,7 +292,7 @@ impl PgMemoryContexts {
     ///
     /// # Safety
     ///
-    /// This function is unsafe as it can lead easy lead to use-after-free of Postgres allocated
+    /// This function is unsafe as it can easily lead to use-after-free of Postgres allocated
     /// memory:
     ///
     /// ```rust,no_run

--- a/pgx/src/pgbox.rs
+++ b/pgx/src/pgbox.rs
@@ -38,7 +38,7 @@ use std::ptr::NonNull;
 ///
 /// pub fn do_something() -> pg_sys::ItemPointer {
 ///     // postgres-allocate an ItemPointerData structure
-///     let mut tid = PgBox::<pg_sys::ItemPointerData>::alloc();
+///     let mut tid = unsafe { PgBox::<pg_sys::ItemPointerData>::alloc() };
 ///
 ///     // set its position to 42
 ///     tid.ip_posid = 42;
@@ -56,7 +56,7 @@ use std::ptr::NonNull;
 ///
 /// pub fn do_something()  {
 ///     // postgres-allocate an ItemPointerData structure
-///     let mut tid = PgBox::<pg_sys::ItemPointerData>::alloc();
+///     let mut tid = unsafe { PgBox::<pg_sys::ItemPointerData>::alloc() };
 ///
 ///     // set its position to 42
 ///     tid.ip_posid = 42;
@@ -118,7 +118,7 @@ impl WhoAllocated for AllocatedByPostgres {
     unsafe fn maybe_pfree(_ptr: *mut std::os::raw::c_void) {}
 }
 impl WhoAllocated for AllocatedByRust {
-    /// Uses [pg_sys::pfree] to free the specified pointer
+    /// Uses [`pg_sys::pfree`] to free the specified pointer
     #[inline]
     unsafe fn maybe_pfree(ptr: *mut std::os::raw::c_void) {
         pg_sys::pfree(ptr.cast());
@@ -126,72 +126,13 @@ impl WhoAllocated for AllocatedByRust {
 }
 
 impl<T> PgBox<T, AllocatedByPostgres> {
-    /// Box a pointer that cames from Postgres.
+    /// Box a pointer that comes from Postgres.
     ///
     /// When this `PgBox<T>` is dropped, the boxed memory is **not** freed.  Since Postgres
     /// allocated it, Postgres is responsible for freeing it.
     #[inline]
     pub unsafe fn from_pg(ptr: *mut T) -> PgBox<T, AllocatedByPostgres> {
         PgBox::<T, AllocatedByPostgres> { ptr: NonNull::new(ptr), __marker: PhantomData }
-    }
-}
-
-impl<T> PgBox<T, AllocatedByRust> {
-    /**
-    Allocates memory in PostgreSQL and then places `val` into it.
-
-    This value is managed by Rust, so gets dropped via normal [`Drop`][std::ops::Drop]
-    semantics.
-
-    If you need to give the boxed pointer to Postgres, call [`.into_pg()`][PgBox::into_pg].
-
-    ```rust,no_run
-    use pgx::{PgBox, AllocatedByRust};
-
-    let ptr: PgBox<i32, AllocatedByRust> = PgBox::new(5);
-    assert_eq!(*ptr, 5);
-
-    let mut ptr: PgBox<Vec<i32>, AllocatedByRust> = PgBox::new(vec![]);
-    assert_eq!(*ptr, Vec::<i32>::default());
-
-    ptr.push(1);
-    assert_eq!(*ptr, vec![1]);
-
-    ptr.push(2);
-    assert_eq!(*ptr, vec![1, 2]);
-
-    ptr.push(3);
-    assert_eq!(*ptr, vec![1, 2, 3]);
-
-    let drained = ptr.drain(..).collect::<Vec<_>>();
-    assert_eq!(drained, vec![1, 2, 3])
-    ```
-     */
-    pub fn new(val: T) -> PgBox<T, AllocatedByRust> {
-        let ptr = Self::alloc0();
-        unsafe { core::ptr::write(ptr.as_ptr(), val) };
-        ptr
-    }
-
-    /**
-    Allocates memory in PostgreSQL and then places `val` into it.
-
-    This value is managed by Rust, so gets dropped via normal [`Drop`][std::ops::Drop]
-    semantics.
-
-    If you need to give the boxed pointer to Postgres, call [`.into_pg()`][PgBox::into_pg].
-
-    ```rust,no_run
-    use pgx::{PgBox, PgMemoryContexts, AllocatedByRust};
-
-    let ptr: PgBox<i32, AllocatedByRust> = PgBox::new_in_context(5, PgMemoryContexts::CurrentMemoryContext);
-    assert_eq!(*ptr, 5);
-    ```
-     */
-    pub fn new_in_context(val: T, memory_context: PgMemoryContexts) -> PgBox<T, AllocatedByRust> {
-        let ptr = Self::alloc0_in_context(memory_context);
-        unsafe { core::ptr::write(ptr.as_ptr(), val) };
-        ptr
     }
 }
 
@@ -217,10 +158,18 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     /// ## Examples
     /// ```rust,no_run
     /// use pgx::{PgBox, pg_sys};
-    /// let ctid = PgBox::<pg_sys::ItemPointerData>::alloc();
+    /// let ctid = unsafe { PgBox::<pg_sys::ItemPointerData>::alloc() };
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as we cannot ensure that the MemoryContext used to allocate will
+    /// live as long as Rust's borrow checker expects it to.
+    ///
+    /// It is also unsafe because the allocated `T` will be uninitialized and that may or may not
+    /// be a valid state for `T`.
     #[inline]
-    pub fn alloc() -> PgBox<T, AllocatedByRust> {
+    pub unsafe fn alloc() -> PgBox<T, AllocatedByRust> {
         PgBox::<T, AllocatedByRust> {
             ptr: Some(unsafe {
                 NonNull::new_unchecked(pg_sys::palloc(std::mem::size_of::<T>()) as *mut T)
@@ -239,10 +188,18 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     /// ## Examples
     /// ```rust,no_run
     /// use pgx::{PgBox, pg_sys};
-    /// let ctid = PgBox::<pg_sys::ItemPointerData>::alloc0();
+    /// let ctid = unsafe { PgBox::<pg_sys::ItemPointerData>::alloc0() };
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as we cannot ensure that the MemoryContext used to allocate will
+    /// live as long as Rust's borrow checker expects it to.
+    ///
+    /// It is also unsafe because the allocated `T`'s memory will be zerod and that may or may not
+    /// be a valid state for `T`.
     #[inline]
-    pub fn alloc0() -> PgBox<T, AllocatedByRust> {
+    pub unsafe fn alloc0() -> PgBox<T, AllocatedByRust> {
         PgBox::<T, AllocatedByRust> {
             ptr: Some(unsafe {
                 NonNull::new_unchecked(pg_sys::palloc0(std::mem::size_of::<T>()) as *mut T)
@@ -261,10 +218,18 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     /// ## Examples
     /// ```rust,no_run
     /// use pgx::{PgBox, pg_sys, PgMemoryContexts};
-    /// let ctid = PgBox::<pg_sys::ItemPointerData>::alloc_in_context(PgMemoryContexts::TopTransactionContext);
+    /// let ctid = unsafe { PgBox::<pg_sys::ItemPointerData>::alloc_in_context(PgMemoryContexts::TopTransactionContext) };
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as we cannot ensure that the MemoryContext used to allocate will
+    /// live as long as Rust's borrow checker expects it to.
+    ///
+    /// It is also unsafe because the allocated `T` will be uninitialized and that may or may not
+    /// be a valid state for `T`.
     #[inline]
-    pub fn alloc_in_context(memory_context: PgMemoryContexts) -> PgBox<T, AllocatedByRust> {
+    pub unsafe fn alloc_in_context(memory_context: PgMemoryContexts) -> PgBox<T, AllocatedByRust> {
         PgBox::<T, AllocatedByRust> {
             ptr: Some(unsafe {
                 NonNull::new_unchecked(pg_sys::MemoryContextAlloc(
@@ -286,10 +251,18 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     /// ## Examples
     /// ```rust,no_run
     /// use pgx::{PgBox, pg_sys, PgMemoryContexts};
-    /// let ctid = PgBox::<pg_sys::ItemPointerData>::alloc0_in_context(PgMemoryContexts::TopTransactionContext);
+    /// let ctid = unsafe { PgBox::<pg_sys::ItemPointerData>::alloc0_in_context(PgMemoryContexts::TopTransactionContext) };
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as we cannot ensure that the MemoryContext used to allocate will
+    /// live as long as Rust's borrow checker expects it to.
+    ///
+    /// It is also unsafe because the allocated `T`'s memory will be zeroed and that may or may not
+    /// be a valid state for `T`.
     #[inline]
-    pub fn alloc0_in_context(memory_context: PgMemoryContexts) -> PgBox<T, AllocatedByRust> {
+    pub unsafe fn alloc0_in_context(memory_context: PgMemoryContexts) -> PgBox<T, AllocatedByRust> {
         PgBox::<T, AllocatedByRust> {
             ptr: Some(unsafe {
                 NonNull::new_unchecked(pg_sys::MemoryContextAllocZero(
@@ -309,10 +282,15 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     /// ## Examples
     /// ```rust,no_run
     /// use pgx::{PgBox, pg_sys};
-    /// let create_trigger_statement = PgBox::<pg_sys::CreateTrigStmt>::alloc_node(pg_sys::NodeTag_T_CreateTrigStmt);
+    /// let create_trigger_statement = unsafe { PgBox::<pg_sys::CreateTrigStmt>::alloc_node(pg_sys::NodeTag_T_CreateTrigStmt) };
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as we cannot ensure that the MemoryContext used to allocate will
+    /// live as long as Rust's borrow checker expects it to.
     #[inline]
-    pub fn alloc_node(node_tag: pg_sys::NodeTag) -> PgBox<T, AllocatedByRust> {
+    pub unsafe fn alloc_node(node_tag: pg_sys::NodeTag) -> PgBox<T, AllocatedByRust> {
         let node = PgBox::<T>::alloc0();
         let ptr = node.as_ptr();
 
@@ -369,6 +347,11 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     }
 
     /// Execute a closure with a mutable, `PgBox`'d form of the specified `ptr`
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as we cannot ensure that `ptr` is a valid pointer that can be
+    /// wrapped with [`PgBox`].
     #[inline]
     pub unsafe fn with<F: FnOnce(&mut PgBox<T>)>(ptr: *mut T, func: F) {
         func(&mut PgBox::from_pg(ptr))


### PR DESCRIPTION
By no means is this an exhaustive audit.  I'm specifically targeting things that are exposed through the `trusted-pgx` crate over in https://github.com/tcdi/plrust/pull/142

### Note

I deleted `PgBox::new()` and `PgBox::new_in_context()` as I think they were incredibly broken by design and aren't used by pgx itself.  There were two test functions around them, but that's it.

If users were using them, they'll need to find a different way of doing what those did -- and hopefully one that isn't fundamentally broken.