### PR TITLE
Convert `pg_sys::Oid` into a newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,7 @@ dependencies = [
  "pgx-sql-entity-graph",
  "proc-macro2",
  "quote",
+ "serde",
  "shlex",
  "sptr",
  "syn",

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -428,7 +428,6 @@ pub(crate) fn generate_schema(
     };
 
     let pgx_sql = pgx_sql_entity_graph::PgxSql::build(
-        pgx_sql_entity_graph::RustToSqlMapping::default(),
         entities.into_iter(),
         package_name.to_string(),
         versioned_so,

--- a/cargo-pgx/src/command/schema.rs
+++ b/cargo-pgx/src/command/schema.rs
@@ -385,7 +385,6 @@ pub(crate) fn generate_schema(
 
     tracing::debug!("Collecting {} SQL entities", fns_to_call.len());
     let mut entities = Vec::default();
-    let sql_mapping;
 
     #[rustfmt::skip] // explicit extern "Rust" is more clear here
     unsafe {
@@ -409,13 +408,6 @@ pub(crate) fn generate_schema(
             })
             .wrap_err_with(|| format!("Couldn't libload {}", lib_so.display()))?;
 
-        let sql_mappings_symbol: libloading::os::unix::Symbol<
-            unsafe extern "Rust" fn() -> pgx_sql_entity_graph::RustToSqlMapping,
-        > = lib
-            .get("__pgx_sql_mappings".as_bytes())
-            .expect("Couldn't call __pgx_sql_mappings");
-        sql_mapping = sql_mappings_symbol();
-
         let symbol: libloading::os::unix::Symbol<
             unsafe extern "Rust" fn() -> eyre::Result<pgx_sql_entity_graph::ControlFile>,
         > = lib
@@ -436,7 +428,7 @@ pub(crate) fn generate_schema(
     };
 
     let pgx_sql = pgx_sql_entity_graph::PgxSql::build(
-        sql_mapping,
+        pgx_sql_entity_graph::RustToSqlMapping::default(),
         entities.into_iter(),
         package_name.to_string(),
         versioned_so,

--- a/pgx-examples/pgtrybuilder/src/lib.rs
+++ b/pgx-examples/pgtrybuilder/src/lib.rs
@@ -42,7 +42,7 @@ fn get_relation_name(oid: pg_sys::Oid) -> String {
     })
     // in this case just return a generic string
     .catch_when(PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, |_cause| {
-        format!("<{oid} is not a relation>")
+        format!("<{oid:?} is not a relation>")
 
         // NB:  It's probably not a "good idea" to catch an ERRCODE_INTERNAL_ERROR and ignore it
         // like we are here, but for demonstration purposes, this will suffice

--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -653,7 +653,7 @@ fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                     None
                 } else {
                     // GREPME: non-primitive cast u64 as Oid
-                    let (name, _, _) = ::pgx::enum_helper::lookup_enum_by_oid(datum.value() as ::pgx::pg_sys::Oid);
+                    let (name, _, _) = ::pgx::enum_helper::lookup_enum_by_oid(unsafe { ::pgx::pg_sys::Oid::from_datum(datum, is_null)? } );
                     match name.as_str() {
                         #from_datum
                         _ => panic!("invalid enum value: {}", name)

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -32,6 +32,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 memoffset = "0.6.5"
 pgx-macros = { path = "../pgx-macros/", version = "=0.6.1" }
 pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph/", version = "=0.6.1" }
+serde = { version = "1.0.149", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
 libc = "0.2"

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -280,7 +280,7 @@ mod all_versions {
     pub use crate::submodules::htup::*;
 
     /// this comes from `postgres_ext.h`
-    pub const InvalidOid: super::Oid = 0;
+    pub const InvalidOid: crate::Oid = crate::Oid::INVALID;
     pub const InvalidOffsetNumber: super::OffsetNumber = 0;
     pub const FirstOffsetNumber: super::OffsetNumber = 1;
     pub const MaxOffsetNumber: super::OffsetNumber =

--- a/pgx-pg-sys/src/submodules/oids.rs
+++ b/pgx-pg-sys/src/submodules/oids.rs
@@ -9,41 +9,188 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 #![allow(non_camel_case_types)]
 use crate as pg_sys;
-use crate::PgBuiltInOids;
+use crate::BuiltinOid;
+use crate::Datum;
+use pgx_sql_entity_graph::metadata::{
+    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+};
 
-impl PgBuiltInOids {
-    pub fn value(self) -> pg_sys::Oid {
-        self as isize as pg_sys::Oid
+/// An [object identifier][pg_docs_oid] in Postgres.
+///
+/// This is meant to be understood purely by equality. There is no sensible "order" for Oids.
+///
+/// # Notes
+/// `Default` shall return a sensical Oid, not necessarily a useful one.
+/// Currently, this means that it returns the invalid Oid.
+///
+/// [pg_docs_oid]: https://www.postgresql.org/docs/current/datatype-oid.html
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct Oid(pub(crate) u32);
+
+impl Oid {
+    pub const INVALID: Oid = Oid(0);
+
+    /// Generate an Oid from an arbitrary u32.
+    /// # Safety
+    /// This allows you to create an Oid that Postgres won't recognize and throw it into Postgres.
+    /// Don't.
+    ///
+    /// You should know what kind of object the identifier would imply before creating it.
+    /// Postgres may sometimes call very different internal functions based on an Oid input.
+    /// The extension programming interface of Postgres can reach deep, calling functions
+    /// that assume the caller should be trusted like Postgres would trust itself. Because it is.
+    /// Postgres tables can also change at runtime, so if an Oid is not a [BuiltinOid],
+    /// what Postgres does based on an Oid can change dynamically.
+    ///
+    /// The existence of this `unsafe` requirement to create *arbitrary* Oids does not, itself,
+    /// constitute a promise any Oid from Postgres or PGX is guaranteed to be valid or sensical.
+    /// There are many existing problems in the way of this, for example:
+    /// - `Oid` includes the guaranteed-wrong values [Oid::INVALID]
+    /// - Postgres may return arbitrary-seeming Oids, like [BuiltinOid::UNKNOWNOID]
+    /// - an Oid can arrive in Rust from a table a non-superuser can write
+    /// - PGX mostly relies on Rust's type system instead of the dynamic typing of Postgres,
+    ///   thus often deliberately does not bother to remember what OID something had.
+    ///
+    /// So this function is merely a reminder. Even for extensions that work with many Oids,
+    /// it is not typical to need to create one from an arbitrary `u32`. Prefer to use a constant,
+    /// or a [BuiltinOid], or to obtain one from querying Postgres, or simply use [Oid::INVALID].
+    /// Marking it as an `unsafe fn` is an invitation to get an Oid from more trustworthy sources.
+    /// This includes [Oid::INVALID], or [BuiltinOid], or by directly calling into Postgres.
+    /// An `unsafe fn` is not an officer of the law empowered to indict C programs for felonies,
+    /// nor cite SQL statements for misdemeanors, nor even truly stop you from foolishness.
+    /// Even "trustworthy" is meant here in a similar sense to how raw pointers can be "trustworthy".
+    /// Often, you should still check if it's null.
+    pub const unsafe fn from_u32_unchecked(id: u32) -> Oid {
+        Oid(id)
     }
 
-    pub fn oid(self) -> PgOid {
-        PgOid::from(self.value())
+    /// Gets an Oid from a u32 if it is a valid builtin declared by Postgres
+    pub const fn from_builtin(id: u32) -> Result<Oid, NotBuiltinOid> {
+        match BuiltinOid::from_u32(id) {
+            Ok(oid) => Ok(oid.value()),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub const fn as_u32(self) -> u32 {
+        self.0
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
+impl Default for Oid {
+    fn default() -> Oid {
+        Oid::INVALID
+    }
+}
+
+impl From<Oid> for u32 {
+    fn from(oid: Oid) -> u32 {
+        oid.0
+    }
+}
+
+impl From<Oid> for crate::Datum {
+    fn from(oid: Oid) -> Self {
+        Datum::from(oid.0)
+    }
+}
+
+impl From<BuiltinOid> for Oid {
+    fn from(builtin: BuiltinOid) -> Oid {
+        builtin.value()
+    }
+}
+
+unsafe impl SqlTranslatable for Oid {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("oid"))
+    }
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("oid")))
+    }
+}
+
+// Actually implemented inside pgXX_oids.rs
+pub type PgBuiltInOids = BuiltinOid;
+
+pub enum NotBuiltinOid {
+    /// the invalid OID
+    Invalid,
+    /// not a known, builtin OID
+    Ambiguous,
+    /// value too large to be a valid OID in this Postgres version
+    TooBig,
+}
+
+impl TryFrom<u32> for BuiltinOid {
+    type Error = NotBuiltinOid;
+    fn try_from(uint: u32) -> Result<BuiltinOid, NotBuiltinOid> {
+        BuiltinOid::from_u32(uint)
+    }
+}
+
+impl TryFrom<Oid> for BuiltinOid {
+    type Error = NotBuiltinOid;
+    fn try_from(oid: Oid) -> Result<BuiltinOid, NotBuiltinOid> {
+        BuiltinOid::from_u32(oid.0)
+    }
+}
+
+impl TryFrom<crate::Datum> for BuiltinOid {
+    type Error = NotBuiltinOid;
+    fn try_from(datum: crate::Datum) -> Result<BuiltinOid, NotBuiltinOid> {
+        let uint = u32::try_from(datum.value()).map_err(|_| NotBuiltinOid::TooBig)?;
+        BuiltinOid::from_u32(uint)
+    }
+}
+
+impl BuiltinOid {
+    pub const fn value(self) -> pg_sys::Oid {
+        Oid(self as u32)
+    }
+
+    pub fn oid(self) -> PgOid {
+        PgOid::from(self)
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum PgOid {
-    InvalidOid,
-    Custom(pg_sys::Oid),
-    BuiltIn(PgBuiltInOids),
+    Invalid,
+    Custom(Oid),
+    BuiltIn(BuiltinOid),
+}
+
+impl PgOid {
+    pub const fn from_untagged(oid: Oid) -> PgOid {
+        match BuiltinOid::from_u32(oid.0) {
+            Ok(builtin) => PgOid::BuiltIn(builtin),
+            Err(NotBuiltinOid::Invalid) => PgOid::Invalid,
+            Err(NotBuiltinOid::Ambiguous) => PgOid::Custom(oid),
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+    }
+}
+
+impl From<BuiltinOid> for PgOid {
+    fn from(builtin: BuiltinOid) -> PgOid {
+        PgOid::BuiltIn(builtin)
+    }
+}
+
+impl From<Oid> for PgOid {
+    fn from(oid: Oid) -> PgOid {
+        PgOid::from_untagged(oid)
+    }
 }
 
 impl PgOid {
     #[inline]
-    pub fn from(oid: pg_sys::Oid) -> PgOid {
-        match oid {
-            pg_sys::InvalidOid => PgOid::InvalidOid,
-            custom_oid => match PgBuiltInOids::from(oid) {
-                Some(builtin) => PgOid::BuiltIn(builtin),
-                None => PgOid::Custom(custom_oid),
-            },
-        }
-    }
-
-    #[inline]
-    pub fn value(self) -> pg_sys::Oid {
+    pub const fn value(self) -> pg_sys::Oid {
         match self {
-            PgOid::InvalidOid => pg_sys::InvalidOid,
+            PgOid::Invalid => pg_sys::InvalidOid,
             PgOid::Custom(custom) => custom,
             PgOid::BuiltIn(builtin) => builtin.value(),
         }

--- a/pgx-sql-entity-graph/src/lib.rs
+++ b/pgx-sql-entity-graph/src/lib.rs
@@ -23,7 +23,7 @@ pub use enrich::CodeEnrichment;
 pub use extension_sql::entity::{ExtensionSqlEntity, SqlDeclaredEntity};
 pub use extension_sql::{ExtensionSql, ExtensionSqlFile, SqlDeclared};
 pub use extern_args::{parse_extern_attributes, ExternArgs};
-pub use mapping::{RustSourceOnlySqlMapping, RustSqlMapping};
+pub use mapping::RustSqlMapping;
 pub use pg_extern::entity::{
     PgExternArgumentEntity, PgExternEntity, PgExternReturnEntity, PgExternReturnEntityIteratedItem,
     PgOperatorEntity,
@@ -32,7 +32,7 @@ pub use pg_extern::{NameMacro, PgExtern, PgExternArgument, PgOperator};
 pub use pg_trigger::attribute::PgTriggerAttribute;
 pub use pg_trigger::entity::PgTriggerEntity;
 pub use pg_trigger::PgTrigger;
-pub use pgx_sql::{PgxSql, RustToSqlMapping};
+pub use pgx_sql::PgxSql;
 pub use positioning_ref::PositioningRef;
 pub use postgres_enum::entity::PostgresEnumEntity;
 pub use postgres_enum::PostgresEnum;

--- a/pgx-sql-entity-graph/src/mapping.rs
+++ b/pgx-sql-entity-graph/src/mapping.rs
@@ -60,7 +60,7 @@ impl RustSqlMapping {
 ///     String::from("int"),
 /// );
 /// ```
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RustSourceOnlySqlMapping {
     pub rust: String,
     pub sql: String,

--- a/pgx-sql-entity-graph/src/mapping.rs
+++ b/pgx-sql-entity-graph/src/mapping.rs
@@ -47,27 +47,3 @@ impl RustSqlMapping {
         }
     }
 }
-
-/// A mapping from a Rust source fragment to a SQL type, typically for type aliases.
-///
-/// In general, this can only offer a fuzzy matching, as it does not use [`core::any::TypeId`].
-///
-/// ```rust
-/// use pgx_sql_entity_graph::RustSourceOnlySqlMapping;
-///
-/// let constructed = RustSourceOnlySqlMapping::new(
-///     String::from("Oid"),
-///     String::from("int"),
-/// );
-/// ```
-#[derive(Debug, Default, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RustSourceOnlySqlMapping {
-    pub rust: String,
-    pub sql: String,
-}
-
-impl RustSourceOnlySqlMapping {
-    pub fn new(rust: String, sql: String) -> Self {
-        Self { rust: rust.to_string(), sql: sql.to_string() }
-    }
-}

--- a/pgx-sql-entity-graph/src/pgx_sql.rs
+++ b/pgx-sql-entity-graph/src/pgx_sql.rs
@@ -50,7 +50,7 @@ pub enum SqlGraphRelationship {
     RequiredByReturn,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct RustToSqlMapping {
     pub rust_source_to_sql: std::collections::HashSet<RustSourceOnlySqlMapping>,
 }
@@ -464,24 +464,10 @@ impl PgxSql {
         })
     }
 
-    pub fn source_only_to_sql_type(&self, ty_source: &str) -> Option<String> {
-        // HACK for `Result<T, E>` -- we replace the `E` with an underscore
-        // specifically, this is the cases where we need to use the `map_source_only!()` macro to
-        // create a Rust type to SQL type mapping.  As of this writing that's only for the `pg_sys::Oid`
-        // type, but we'll do our best to generalize this.
-        //
-        // What we want to do is rewrite any kind of `Result<T,E>` pattern into `Result<T,_>`, which
-        // is how the `map_source_only!()` macro does it.
-        let pattern = regex::Regex::new("Result<(.*),\\s*.*?>").expect("invalid regex pattern");
-        let ty_source = match pattern.captures(ty_source) {
-            Some(captures) => {
-                let rust_type = captures.get(1).unwrap();
-                format!("Result<{},_>", rust_type.as_str())
-            }
-            None => ty_source.to_string(),
-        };
-
-        self.source_mappings.get(&ty_source).map(|f| f.sql.clone())
+    pub fn source_only_to_sql_type(&self, _ty_source: &str) -> Option<String> {
+        // HACK for `Result<T, E>`
+        // ...well, actually, nothing!
+        None
     }
 
     pub fn get_module_pathname(&self) -> String {

--- a/pgx-sql-entity-graph/src/pgx_sql.rs
+++ b/pgx-sql-entity-graph/src/pgx_sql.rs
@@ -29,7 +29,6 @@ use crate::aggregate::entity::PgAggregateEntity;
 use crate::control_file::ControlFile;
 use crate::extension_sql::entity::{ExtensionSqlEntity, SqlDeclaredEntity};
 use crate::extension_sql::SqlDeclared;
-use crate::mapping::RustSourceOnlySqlMapping;
 use crate::pg_extern::entity::PgExternEntity;
 use crate::pg_trigger::entity::PgTriggerEntity;
 use crate::positioning_ref::PositioningRef;
@@ -50,11 +49,6 @@ pub enum SqlGraphRelationship {
     RequiredByReturn,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct RustToSqlMapping {
-    pub rust_source_to_sql: std::collections::HashSet<RustSourceOnlySqlMapping>,
-}
-
 /// A generator for SQL.
 ///
 /// Consumes a base mapping of types (typically `pgx::DEFAULT_TYPEID_SQL_MAPPING`), a
@@ -68,7 +62,6 @@ pub struct RustToSqlMapping {
 /// out of entities collected during a `pgx::pg_module_magic!()` call in a library.
 #[derive(Debug, Clone)]
 pub struct PgxSql {
-    pub source_mappings: HashMap<String, RustSourceOnlySqlMapping>,
     pub control: ControlFile,
     pub graph: StableGraph<SqlGraphEntity, SqlGraphRelationship>,
     pub graph_root: NodeIndex,
@@ -89,15 +82,12 @@ pub struct PgxSql {
 }
 
 impl PgxSql {
-    #[instrument(level = "error", skip(sql_mappings, entities,))]
+    #[instrument(level = "error", skip(entities,))]
     pub fn build(
-        sql_mappings: RustToSqlMapping,
         entities: impl Iterator<Item = SqlGraphEntity>,
         extension_name: String,
         versioned_so: bool,
     ) -> eyre::Result<Self> {
-        let RustToSqlMapping { rust_source_to_sql: source_mappings } = sql_mappings;
-
         let mut graph = StableGraph::new();
 
         let mut entities = entities.collect::<Vec<_>>();
@@ -240,7 +230,6 @@ impl PgxSql {
         connect_triggers(&mut graph, &mapped_triggers, &mapped_schemas);
 
         let this = Self {
-            source_mappings: source_mappings.into_iter().map(|x| (x.rust.clone(), x)).collect(),
             control: control,
             schemas: mapped_schemas,
             extension_sqls: mapped_extension_sqls,

--- a/pgx-tests/src/tests/from_into_datum_tests.rs
+++ b/pgx-tests/src/tests/from_into_datum_tests.rs
@@ -25,6 +25,6 @@ mod tests {
             )
         };
         assert!(result.is_err());
-        assert_eq!("Postgres type boolean (oid=16) is not compatible with the Rust type alloc::string::String (oid=25)", result.unwrap_err().to_string());
+        assert_eq!("Postgres type boolean `Oid(16)` is not compatible with the Rust type alloc::string::String `Oid(25)`", result.unwrap_err().to_string());
     }
 }

--- a/pgx-tests/src/tests/pg_extern_tests.rs
+++ b/pgx-tests/src/tests/pg_extern_tests.rs
@@ -103,15 +103,15 @@ mod tests {
     }
 
     #[pg_extern]
-    fn anyele_type(x: pgx::AnyElement) -> i32 {
-        x.oid() as i32
+    fn anyele_type(x: pgx::AnyElement) -> pg_sys::Oid {
+        x.oid()
     }
 
     #[pg_test]
     fn test_anyele_type() {
         let interval_type =
-            Spi::get_one::<i32>(r#"SELECT tests."anyele_type"('5 hours'::interval)"#);
-        assert_eq!(interval_type, Ok(Some(pg_sys::INTERVALOID as _)));
+            Spi::get_one::<pg_sys::Oid>(r#"SELECT tests."anyele_type"('5 hours'::interval)"#);
+        assert_eq!(interval_type, Ok(Some(pg_sys::INTERVALOID)));
     }
 
     #[pg_extern(name = "custom_name")]

--- a/pgx-tests/src/tests/pg_try_tests.rs
+++ b/pgx-tests/src/tests/pg_try_tests.rs
@@ -56,7 +56,7 @@ fn get_relation_name(oid: pg_sys::Oid) -> String {
     })
     .catch_when(PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, |_error| {
         // so in the case the oid isn't a valid relation, just return a generic string
-        format!("<{oid} is not a relation>")
+        format!("<{oid:?} is not a relation>")
     })
     .execute()
 }

--- a/pgx/src/datum/anyarray.rs
+++ b/pgx/src/datum/anyarray.rs
@@ -71,7 +71,7 @@ impl IntoDatum for AnyArray {
         Some(self.datum)
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::ANYARRAYOID
     }
 }

--- a/pgx/src/datum/anyelement.rs
+++ b/pgx/src/datum/anyelement.rs
@@ -77,7 +77,7 @@ impl IntoDatum for AnyElement {
         Some(self.datum)
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::ANYELEMENTOID
     }
 }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -454,7 +454,7 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<Array<'a, T>> {
         if is_null {
             None
@@ -545,7 +545,7 @@ where
         }
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
 
@@ -592,7 +592,7 @@ where
         }
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
 

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -32,7 +32,7 @@ impl IntoDatum for Date {
     fn into_datum(self) -> Option<pg_sys::Datum> {
         Some(pg_sys::Datum::from(self.0))
     }
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::DATEOID
     }
 }

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -93,7 +93,7 @@ impl FromDatum for Inet {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<Inet> {
         if is_null {
             None
@@ -114,7 +114,7 @@ impl IntoDatum for Inet {
         }
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::INETOID
     }
 }

--- a/pgx/src/datum/into.rs
+++ b/pgx/src/datum/into.rs
@@ -86,7 +86,7 @@ where
         }
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         T::type_oid()
     }
 }
@@ -124,7 +124,7 @@ impl IntoDatum for bool {
         Some(pg_sys::Datum::from(if self { 1 } else { 0 }))
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::BOOLOID
     }
 }
@@ -135,7 +135,7 @@ impl IntoDatum for i8 {
         Some(pg_sys::Datum::from(self))
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::CHAROID
     }
 }
@@ -147,7 +147,7 @@ impl IntoDatum for i16 {
         Some(pg_sys::Datum::from(self))
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::INT2OID
     }
 
@@ -163,7 +163,7 @@ impl IntoDatum for i32 {
         Some(pg_sys::Datum::from(self))
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::INT4OID
     }
 
@@ -179,7 +179,7 @@ impl IntoDatum for u32 {
         Some(pg_sys::Datum::from(self))
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::OIDOID
     }
 
@@ -198,7 +198,7 @@ impl IntoDatum for i64 {
         Some(pg_sys::Datum::from(self))
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::INT8OID
     }
 
@@ -218,7 +218,7 @@ impl IntoDatum for f32 {
         Some(self.to_bits().into())
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::FLOAT4OID
     }
 }
@@ -230,8 +230,24 @@ impl IntoDatum for f64 {
         Some(self.to_bits().into())
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::FLOAT8OID
+    }
+}
+
+impl IntoDatum for pg_sys::Oid {
+    #[inline]
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        if self == pg_sys::Oid::INVALID {
+            None
+        } else {
+            Some(pg_sys::Datum::from(self.as_u32()))
+        }
+    }
+
+    #[inline]
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::OIDOID
     }
 }
 
@@ -239,12 +255,12 @@ impl IntoDatum for PgOid {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         match self {
-            PgOid::InvalidOid => None,
+            PgOid::Invalid => None,
             oid => Some(oid.value().into()),
         }
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::OIDOID
     }
 }
@@ -256,7 +272,7 @@ impl<'a> IntoDatum for &'a str {
         self.as_bytes().into_datum()
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TEXTOID
     }
 
@@ -272,7 +288,7 @@ impl IntoDatum for String {
         self.as_str().into_datum()
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TEXTOID
     }
 
@@ -288,7 +304,7 @@ impl IntoDatum for &String {
         self.as_str().into_datum()
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TEXTOID
     }
 
@@ -304,7 +320,7 @@ impl IntoDatum for char {
         self.to_string().into_datum()
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::VARCHAROID
     }
 
@@ -325,7 +341,18 @@ impl<'a> IntoDatum for &'a std::ffi::CStr {
         Some(self.as_ptr().into())
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::CSTRINGOID
+    }
+}
+
+impl IntoDatum for std::ffi::CString {
+    #[inline]
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        Some(self.as_ptr().into())
+    }
+
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::CSTRINGOID
     }
 }
@@ -336,7 +363,7 @@ impl<'a> IntoDatum for &'a crate::cstr_core::CStr {
         Some(self.as_ptr().into())
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::CSTRINGOID
     }
 }
@@ -383,7 +410,7 @@ impl<'a> IntoDatum for &'a [u8] {
     }
 
     #[inline]
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::BYTEAOID
     }
 }
@@ -395,7 +422,7 @@ impl IntoDatum for Vec<u8> {
     }
 
     #[inline]
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::BYTEAOID
     }
 }
@@ -408,7 +435,7 @@ impl IntoDatum for () {
         Some(Datum::from(0))
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::VOIDOID
     }
 }

--- a/pgx/src/datum/item_pointer_data.rs
+++ b/pgx/src/datum/item_pointer_data.rs
@@ -16,7 +16,7 @@ impl FromDatum for pg_sys::ItemPointerData {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<pg_sys::ItemPointerData> {
         if is_null {
             None
@@ -46,7 +46,7 @@ impl IntoDatum for pg_sys::ItemPointerData {
         Some(tid_ptr.into())
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TIDOID
     }
 }

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -126,7 +126,7 @@ impl IntoDatum for Json {
         string.into_datum()
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::JSONOID
     }
 }
@@ -143,7 +143,7 @@ impl IntoDatum for JsonB {
         }
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::JSONBOID
     }
 }
@@ -154,7 +154,7 @@ impl IntoDatum for JsonString {
         self.0.as_str().into_datum()
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::JSONOID
     }
 }

--- a/pgx/src/datum/numeric_support/datum.rs
+++ b/pgx/src/datum/numeric_support/datum.rs
@@ -62,7 +62,7 @@ impl<const P: u32, const S: u32> IntoDatum for Numeric<P, S> {
     }
 
     #[inline]
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::NUMERICOID
     }
 }

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -27,7 +27,7 @@ impl FromDatum for Time {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<Time> {
         if is_null {
             None
@@ -45,7 +45,7 @@ impl IntoDatum for Time {
         Some(datum)
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TIMEOID
     }
 }

--- a/pgx/src/datum/time_stamp.rs
+++ b/pgx/src/datum/time_stamp.rs
@@ -109,7 +109,7 @@ impl IntoDatum for Timestamp {
     fn into_datum(self) -> Option<pg_sys::Datum> {
         Some(pg_sys::Datum::from(self.0))
     }
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TIMESTAMPOID
     }
 }

--- a/pgx/src/datum/time_stamp_with_timezone.rs
+++ b/pgx/src/datum/time_stamp_with_timezone.rs
@@ -126,7 +126,7 @@ impl IntoDatum for TimestampWithTimeZone {
     fn into_datum(self) -> Option<pg_sys::Datum> {
         Some(pg_sys::Datum::from(self.0))
     }
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TIMESTAMPTZOID
     }
 }

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -28,7 +28,7 @@ impl FromDatum for TimeWithTimeZone {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        typoid: u32,
+        typoid: pg_sys::Oid,
     ) -> Option<TimeWithTimeZone> {
         if is_null {
             None
@@ -54,7 +54,7 @@ impl IntoDatum for TimeWithTimeZone {
         Some(timetz.into_pg().into())
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::TIMETZOID
     }
 }

--- a/pgx/src/datum/tuples.rs
+++ b/pgx/src/datum/tuples.rs
@@ -20,7 +20,7 @@ where
     }
 
     fn type_oid() -> pg_sys::Oid {
-        0
+        pg_sys::Oid::INVALID
     }
 }
 
@@ -36,7 +36,7 @@ where
     }
 
     fn type_oid() -> pg_sys::Oid {
-        0
+        pg_sys::Oid::INVALID
     }
 }
 

--- a/pgx/src/datum/uuid.rs
+++ b/pgx/src/datum/uuid.rs
@@ -34,7 +34,7 @@ impl IntoDatum for Uuid {
     }
 
     #[inline]
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         pg_sys::UUIDOID
     }
 }

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -303,7 +303,7 @@ where
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<Self> {
         if is_null {
             None
@@ -316,7 +316,7 @@ where
         mut memory_context: PgMemoryContexts,
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<Self> {
         if is_null {
             None
@@ -343,7 +343,7 @@ where
         Some(cbor_encode(&self).into())
     }
 
-    fn type_oid() -> u32 {
+    fn type_oid() -> pg_sys::Oid {
         crate::rust_regtypein::<T>()
     }
 }
@@ -355,7 +355,7 @@ where
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<Self> {
         if is_null {
             None
@@ -368,7 +368,7 @@ where
         memory_context: PgMemoryContexts,
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: u32,
+        _typoid: pg_sys::Oid,
     ) -> Option<Self> {
         if is_null {
             None

--- a/pgx/src/enum_helper.rs
+++ b/pgx/src/enum_helper.rs
@@ -26,7 +26,7 @@ pub fn lookup_enum_by_oid(enumval: pg_sys::Oid) -> (String, pg_sys::Oid, f32) {
         ereport!(
             PgLogLevel::ERROR,
             PgSqlErrorCode::ERRCODE_INVALID_BINARY_REPRESENTATION,
-            format!("invalid internal value for enum: {}", enumval)
+            format!("invalid internal value for enum: {:?}", enumval)
         );
     }
 
@@ -70,7 +70,10 @@ pub fn lookup_enum_by_label(typname: &str, label: &str) -> pg_sys::Datum {
     };
 
     if tup.is_null() {
-        panic!("could not find heap tuple for enum: {}.{}, typoid={}", typname, label, enumtypoid);
+        panic!(
+            "could not find heap tuple for enum: {}.{}, typoid={:?}",
+            typname, label, enumtypoid
+        );
     }
 
     // SAFETY:  we know that `tup` is valid because we just got it from Postgres above

--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -439,7 +439,7 @@ pub unsafe fn pg_func_extra<ReturnType, DefaultValue: FnOnce() -> ReturnType>(
 ///         )
 ///     };
 ///     let oid = result.expect("failed to lookup oid for pg_class");
-///     assert_eq!(oid, 1259);  // your value could be different, maybe
+///     assert_eq!(oid, pg_sys::RelationRelationId); // your value could be different, maybe
 /// }
 /// ```
 pub unsafe fn direct_function_call<R: FromDatum>(

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -257,7 +257,7 @@ macro_rules! pg_magic_func {
 macro_rules! pg_sql_graph_magic {
     () => {
         // A marker which must exist in the root of the extension.
-#[no_mangle]
+        #[no_mangle]
         #[doc(hidden)]
         #[rustfmt::skip] // explicit extern "Rust" is more clear here
         pub extern "Rust" fn __pgx_marker(

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -130,70 +130,6 @@ pub use pgx_sql_entity_graph;
 
 pub use cstr_core;
 
-use once_cell::sync::Lazy;
-use pgx_sql_entity_graph::RustSourceOnlySqlMapping;
-use std::collections::HashSet;
-
-macro_rules! map_source_only {
-    ($map:ident, $rust:ty, $sql:expr) => {{
-        let ty = stringify!($rust).to_string().replace(" ", "");
-        assert_eq!(
-            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), $sql.to_string(),)),
-            true,
-            "Cannot map {} twice",
-            ty
-        );
-
-        let ty = stringify!(Option<$rust>).to_string().replace(" ", "");
-        assert_eq!(
-            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), $sql.to_string(),)),
-            true,
-            "Cannot map {} twice",
-            ty
-        );
-
-        let ty = stringify!(Result<$rust, _>).to_string().replace(" ", "");
-        assert_eq!(
-            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), $sql.to_string(),)),
-            true,
-            "Cannot map {} twice",
-            ty
-        );
-
-        let ty = stringify!(Result<Option<$rust>, _>).to_string().replace(" ", "");
-        assert_eq!(
-            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), $sql.to_string(),)),
-            true,
-            "Cannot map {} twice",
-            ty
-        );
-
-        let ty = stringify!(Vec<$rust>).to_string().replace(" ", "");
-        assert_eq!(
-            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), format!("{}[]", $sql),)),
-            true,
-            "Cannot map {} twice",
-            ty
-        );
-
-        let ty = stringify!(Array<$rust>).to_string().replace(" ", "");
-        assert_eq!(
-            $map.insert(RustSourceOnlySqlMapping::new(ty.clone(), format!("{}[]", $sql),)),
-            true,
-            "Cannot map {} twice",
-            ty
-        );
-    }};
-}
-
-pub static DEFAULT_RUST_SOURCE_TO_SQL: Lazy<HashSet<RustSourceOnlySqlMapping>> = Lazy::new(|| {
-    let mut m = HashSet::new();
-
-    map_source_only!(m, pg_sys::Oid, "Oid");
-
-    m
-});
-
 /// A macro for marking a library compatible with [`pgx`][crate].
 ///
 /// <div class="example-wrap" style="display:inline-block">
@@ -320,17 +256,8 @@ macro_rules! pg_magic_func {
 #[macro_export]
 macro_rules! pg_sql_graph_magic {
     () => {
-        #[no_mangle]
-        #[doc(hidden)]
-        #[rustfmt::skip] // explicit extern "Rust" is more clear here
-        pub extern "Rust" fn __pgx_sql_mappings() -> $crate::pgx_sql_entity_graph::RustToSqlMapping {
-            $crate::pgx_sql_entity_graph::RustToSqlMapping {
-                rust_source_to_sql: ::pgx::DEFAULT_RUST_SOURCE_TO_SQL.clone(),
-            }
-        }
-
         // A marker which must exist in the root of the extension.
-        #[no_mangle]
+#[no_mangle]
         #[doc(hidden)]
         #[rustfmt::skip] // explicit extern "Rust" is more clear here
         pub extern "Rust" fn __pgx_marker(

--- a/pgx/src/pgbox.rs
+++ b/pgx/src/pgbox.rs
@@ -72,8 +72,9 @@ use std::ptr::NonNull;
 /// use pgx::prelude::*;
 ///
 /// pub fn do_something()  {
+/// # let example_rel_oid = |i| { unsafe { pg_sys::Oid::from_u32_unchecked(i) } };
 ///     // open a relation and project it as a pg_sys::Relation
-///     let relid: pg_sys::Oid = 42;
+///     let relid: pg_sys::Oid = example_rel_oid(42);
 ///     let lockmode = pg_sys::AccessShareLock as i32;
 ///     let relation = unsafe { PgBox::from_pg(pg_sys::relation_open(relid, lockmode)) };
 ///

--- a/pgx/src/tupdesc.rs
+++ b/pgx/src/tupdesc.rs
@@ -115,8 +115,9 @@ impl<'a> PgTupleDesc<'a> {
     ///
     /// ```rust,no_run
     /// use pgx::{pg_sys, PgTupleDesc};
-    /// let typid = 42 as pg_sys::Oid;  // a valid pg_type "oid" value
-    /// let typmod = 0; // it's corresponding typemod value
+    /// # let example_pg_type_oid = |i| { unsafe { pg_sys::Oid::from_u32_unchecked(i) } };
+    /// let typid = example_pg_type_oid(42); // a valid pg_type Oid
+    /// let typmod = 0; // its corresponding typemod value
     /// let tupdesc = unsafe { PgTupleDesc::from_pg_is_copy(pg_sys::lookup_rowtype_tupdesc_copy(typid, typmod)) };
     ///
     /// // assert the tuple descriptor has 12 attributes
@@ -174,7 +175,7 @@ impl<'a> PgTupleDesc<'a> {
     */
     pub fn for_composite_type(name: &str) -> Option<PgTupleDesc<'a>> {
         unsafe {
-            let mut typoid = 0;
+            let mut typoid = pg_sys::Oid::INVALID;
             let mut typmod = 0;
             pg_sys::parseTypeString(name.as_pg_cstr(), &mut typoid, &mut typmod, true);
 


### PR DESCRIPTION
This enforces type safety around `pg_sys::Oid`. Vigorously.

This rewrite was... very opinionated. If this is not suitable for whatever reason I am fairly amenable to changes. It was simply easier to draft a strongly-worded letter to the codebase to open the discussion.

Effects include:
- `pg_sys::Oid` is now a `#[repr(transparent)]` newtype around a `u32`
- More `pg_sys::Oid` constants are correctly classed as an `Oid`, thus are in `BuiltinOid`
- `BuiltinOid` also is now a u32, since it need be no larger (so it's FFI-safe and transmutable into `pg_sys::Oid`), which also means `PgOid` has a smaller repr (not FFI-safe the way the others are, however)
- There are more conversions to/from the various "oidal" types
- Some nonfunctional changes to how bindings are generated happened
- `__pgx_sql_mappings` goes away, as does special-casing of translation to or from SQL, which will make it significantly easier to move schemagen "out" of the PGX library itself.

It is best to focus primarily on the action inside `pgx-pg-sys`, `cargo-pgx`, and `pgx/src/lib.rs`. Everything else is "just" a consequence of API differences.