### PR TITLE
impl Display for `pg_sys::Oid`

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -320,10 +320,7 @@ fn extract_oids(code: &syn::File) -> BTreeMap<syn::Ident, Box<syn::Expr>> {
 
                 // This heuristic identifies "OIDs"
                 // We're going to warp the const declarations to be our newtype Oid
-                if ty_str == "u32"
-                    && (name.ends_with("OID") | name.ends_with("RelationId"))
-                    && name != "HEAP_HASOID"
-                {
+                if ty_str == "u32" && is_builtin_oid(&name) {
                     oids.insert(ident.clone(), expr.clone());
                 }
             }
@@ -331,6 +328,18 @@ fn extract_oids(code: &syn::File) -> BTreeMap<syn::Ident, Box<syn::Expr>> {
         }
     }
     oids
+}
+
+fn is_builtin_oid(name: &str) -> bool {
+    if name.ends_with("OID") && name != "HEAP_HASOID" {
+        true
+    } else if name.ends_with("RelationId") {
+        true
+    } else if name == "TemplateDbOid" {
+        true
+    } else {
+        false
+    }
 }
 
 fn rewrite_oid_consts(

--- a/pgx-pg-sys/src/submodules/oids.rs
+++ b/pgx-pg-sys/src/submodules/oids.rs
@@ -11,6 +11,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 use crate as pg_sys;
 use crate::BuiltinOid;
 use crate::Datum;
+use core::fmt;
 use pgx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
@@ -82,6 +83,18 @@ impl Oid {
 impl Default for Oid {
     fn default() -> Oid {
         Oid::INVALID
+    }
+}
+
+impl fmt::Display for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match PgOid::from(*self) {
+            PgOid::Invalid => write!(f, "oid={{#0, Invalid OID}}"),
+            // if we think we know the name, include it
+            PgOid::BuiltIn(builtin) => write!(f, "oid={{#{}, builtin: {:?}}}", self.0, builtin),
+            // no idea? print it anyways!
+            PgOid::Custom(oid) => write!(f, "oid=#{}", oid.0),
+        }
     }
 }
 

--- a/pgx-tests/src/tests/from_into_datum_tests.rs
+++ b/pgx-tests/src/tests/from_into_datum_tests.rs
@@ -21,10 +21,10 @@ mod tests {
             String::try_from_datum(
                 pg_sys::Datum::from(false),
                 true,
-                pg_sys::PgBuiltInOids::BOOLOID.value(),
+                pg_sys::BuiltinOid::BOOLOID.value(),
             )
         };
         assert!(result.is_err());
-        assert_eq!("Postgres type boolean `Oid(16)` is not compatible with the Rust type alloc::string::String `Oid(25)`", result.unwrap_err().to_string());
+        assert_eq!("Postgres type boolean oid={#16, builtin: BOOLOID} is not compatible with the Rust type alloc::string::String oid={#25, builtin: TEXTOID}", result.unwrap_err().to_string());
     }
 }

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -19,7 +19,7 @@ use std::num::NonZeroUsize;
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum TryFromDatumError {
-    #[error("Postgres type {datum_type} `{datum_oid:?}` is not compatible with the Rust type {rust_type} `{rust_oid:?}`")]
+    #[error("Postgres type {datum_type} {datum_oid} is not compatible with the Rust type {rust_type} {rust_oid}")]
     IncompatibleTypes {
         rust_type: &'static str,
         rust_oid: pg_sys::Oid,


### PR DESCRIPTION
Implement Display for `pg_sys::Oid`, adding formatting rules that identify whether or not it  is a "recognized" OID# and giving the appropriate name so that programmers will not have to scour Postgres source code as often when debugging with PGX.

Also adds in another `BuiltinOid` that was missed due to not falling into the existing heuristics. Unfortunately it's harder to generalize this case.