### PR TITLE
Add the ability for `#[pg_extern]`-style functions to return `Result<Option<SetOfIterator>>`.

### DIFF
--- a/pgx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/mod.rs
@@ -483,12 +483,12 @@ impl PgExtern {
                 } else if *result {
                     if *optional {
                         quote_spanned! { self.func.sig.span() =>
-                            use pgx::pg_sys::panic::ErrorReportable;
+                            use ::pgx::pg_sys::panic::ErrorReportable;
                             #func_name(#(#arg_pats),*).report()
                         }
                     } else {
                         quote_spanned! { self.func.sig.span() =>
-                            use pgx::pg_sys::panic::ErrorReportable;
+                            use ::pgx::pg_sys::panic::ErrorReportable;
                             Some(#func_name(#(#arg_pats),*).report())
                         }
                     }

--- a/pgx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/mod.rs
@@ -475,15 +475,22 @@ impl PgExtern {
                 }
             }
             Returning::SetOf { ty: _retval_ty, optional, result } => {
-                let result_handler = if *optional {
+                let result_handler = if *optional && !*result {
                     // don't need unsafe annotations because of the larger unsafe block coming up
                     quote_spanned! { self.func.sig.span() =>
                         #func_name(#(#arg_pats),*)
                     }
                 } else if *result {
-                    quote_spanned! { self.func.sig.span() =>
-                        use ::pgx::pg_sys::panic::ErrorReportable;
-                        Some(#func_name(#(#arg_pats),*).report())
+                    if *optional {
+                        quote_spanned! { self.func.sig.span() =>
+                            use pgx::pg_sys::panic::ErrorReportable;
+                            #func_name(#(#arg_pats),*).report()
+                        }
+                    } else {
+                        quote_spanned! { self.func.sig.span() =>
+                            use pgx::pg_sys::panic::ErrorReportable;
+                            Some(#func_name(#(#arg_pats),*).report())
+                        }
                     }
                 } else {
                     quote_spanned! { self.func.sig.span() =>

--- a/pgx-tests/src/tests/srf_tests.rs
+++ b/pgx-tests/src/tests/srf_tests.rs
@@ -64,6 +64,23 @@ fn return_none_setof_iterator() -> Option<SetOfIterator<'static, i32>> {
 }
 
 #[pg_extern]
+fn return_none_result_setof_iterator(
+) -> Result<Option<SetOfIterator<'static, String>>, Box<dyn std::error::Error>> {
+    Ok(None)
+}
+
+// TODO:  We don't yet support returning Result<Option<TableIterator>> because the code generator
+//        is inscrutable. But when we do, this function will help ensure it works
+//
+// #[pg_extern]
+// fn return_none_result_tableiterator_iterator() -> Result<
+//     Option<TableIterator<'static, (name!(idx, i32), name!(some_value, &'static str))>>,
+//     Box<dyn std::error::Error>,
+// > {
+//     Ok(None)
+// }
+
+#[pg_extern]
 fn split_set_with_borrow<'a>(input: &'a str, pattern: &'a str) -> SetOfIterator<'a, &'a str> {
     SetOfIterator::new(input.split_terminator(pattern))
 }


### PR DESCRIPTION
This does **not** support `Result<Option<TableIterator<...>>>`.  I'm fixing some things to make plrust work the way we want, specifically this:   https://github.com/tcdi/plrust/pull/158#discussion_r1069982749

Please don't look at the code.  If the tests pass I'm just gonna merge.  The code generator is spaghetti