### PR TITLE
Support extensions on i686-unknown-linux-gnu

### DIFF
--- a/pgx-pg-sys/src/submodules/datum.rs
+++ b/pgx-pg-sys/src/submodules/datum.rs
@@ -196,3 +196,48 @@ impl From<NullableDatum> for Option<Datum> {
         Some(Datum::try_from(nd).ok()?)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn roundtrip_integers() {
+        #[cfg(target_pointer_width = "64")]
+        mod types {
+            pub type UnsignedInt = u64;
+            pub type SignedInt = i64;
+        }
+        #[cfg(target_pointer_width = "32")]
+        mod types {
+            // 64-bit integers would be truncated on 32 bit platforms
+            pub type UnsignedInt = u32;
+            pub type SignedInt = i32;
+        }
+        use types::*;
+
+        let val: SignedInt = 123456;
+        let datum = Datum::from(val);
+        assert_eq!(datum.value() as SignedInt, val);
+
+        let val: isize = 123456;
+        let datum = Datum::from(val);
+        assert_eq!(datum.value() as isize, val);
+
+        let val: SignedInt = -123456;
+        let datum = Datum::from(val);
+        assert_eq!(datum.value() as SignedInt, val);
+
+        let val: isize = -123456;
+        let datum = Datum::from(val);
+        assert_eq!(datum.value() as isize, val);
+
+        let val: UnsignedInt = 123456;
+        let datum = Datum::from(val);
+        assert_eq!(datum.value() as UnsignedInt, val);
+
+        let val: usize = 123456;
+        let datum = Datum::from(val);
+        assert_eq!(datum.value() as usize, val);
+    }
+}

--- a/pgx/src/bgworkers.rs
+++ b/pgx/src/bgworkers.rs
@@ -591,7 +591,7 @@ impl<'a> Into<pg_sys::BackgroundWorker> for &'a BackgroundWorkerBuilder {
     }
 }
 
-fn wait_latch(timeout: i64, wakeup_flags: WLflags) -> i32 {
+fn wait_latch(timeout: libc::c_long, wakeup_flags: WLflags) -> i32 {
     unsafe {
         let latch = pg_sys::WaitLatch(
             pg_sys::MyLatch,

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -217,6 +217,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
         }
         match (self.elem_layout.size_matches::<T>(), self.raw.as_ref()) {
             // SAFETY: Rust slice layout matches Postgres data layout and this array is "owned"
+            #[allow(unreachable_patterns)] // happens on 32-bit when DATUM_SIZE = 4
             (Some(1 | 2 | 4 | DATUM_SIZE), Some(raw)) => unsafe {
                 raw.assume_init_data_slice::<T>()
             },

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -90,7 +90,9 @@ impl Date {
 
     #[inline]
     pub fn to_posix_time(&self) -> libc::time_t {
-        libc::time_t::from(self.to_unix_epoch_days()) * libc::time_t::from(pg_sys::SECS_PER_DAY)
+        let secs_per_day: libc::time_t =
+            pg_sys::SECS_PER_DAY.try_into().expect("couldn't fit time into time_t");
+        libc::time_t::from(self.to_unix_epoch_days()) * secs_per_day
     }
 }
 

--- a/pgx/src/layout.rs
+++ b/pgx/src/layout.rs
@@ -65,13 +65,12 @@ impl Layout {
     }
 }
 
-#[repr(usize)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum Align {
-    Byte = mem::align_of::<u8>(),
-    Short = mem::align_of::<libc::c_short>(),
-    Int = mem::align_of::<libc::c_int>(),
-    Double = mem::align_of::<f64>(),
+    Byte,
+    Short,
+    Int,
+    Double,
 }
 
 impl TryFrom<libc::c_char> for Align {

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -200,7 +200,7 @@ macro_rules! pg_magic_func {
                 indexmaxkeys: pgx::pg_sys::INDEX_MAX_KEYS as i32,
                 namedatalen: pgx::pg_sys::NAMEDATALEN as i32,
                 float4byval: pgx::pg_sys::USE_FLOAT4_BYVAL as i32,
-                float8byval: pgx::pg_sys::USE_FLOAT8_BYVAL as i32,
+                float8byval: cfg!(target_pointer_width = "64") as i32,
             };
 
             #[cfg(any(feature = "pg13", feature = "pg14"))]
@@ -210,7 +210,7 @@ macro_rules! pg_magic_func {
                 funcmaxargs: pgx::pg_sys::FUNC_MAX_ARGS as i32,
                 indexmaxkeys: pgx::pg_sys::INDEX_MAX_KEYS as i32,
                 namedatalen: pgx::pg_sys::NAMEDATALEN as i32,
-                float8byval: pgx::pg_sys::USE_FLOAT8_BYVAL as i32,
+                float8byval: cfg!(target_pointer_width = "64") as i32,
             };
 
             #[cfg(any(feature = "pg15"))]
@@ -220,7 +220,7 @@ macro_rules! pg_magic_func {
                 funcmaxargs: pgx::pg_sys::FUNC_MAX_ARGS as i32,
                 indexmaxkeys: pgx::pg_sys::INDEX_MAX_KEYS as i32,
                 namedatalen: pgx::pg_sys::NAMEDATALEN as i32,
-                float8byval: pgx::pg_sys::USE_FLOAT8_BYVAL as i32,
+                float8byval: cfg!(target_pointer_width = "64") as i32,
                 abi_extra: {
                     // array::from_fn isn't const yet, boohoo, so const-copy a bstr
                     let magic = b"PostgreSQL";


### PR DESCRIPTION
pgx assumes it's running on a 64-bit processor in a few places:
- it assumes `long` and `time_t` are always an `i64`
- it assumes `double`s always have a different alignment than `int`s

This PR fixes pgx to work on 32-bit systems. I've verified that pgx successfully compiles on `i686-unknown-linux-gnu` with this.