### PR TITLE
enhance `PgConfig` to be able to construct itself from a set of environment variables

### DIFF
--- a/cargo-pgx/src/command/connect.rs
+++ b/cargo-pgx/src/command/connect.rs
@@ -79,7 +79,7 @@ impl CommandExecute for Connect {
             }
         };
 
-        connect_psql(pg_config, &dbname, self.pgcli)
+        connect_psql(&pg_config, &dbname, self.pgcli)
     }
 }
 

--- a/cargo-pgx/src/command/run.rs
+++ b/cargo-pgx/src/command/run.rs
@@ -79,7 +79,7 @@ impl CommandExecute for Run {
         )?;
 
         run(
-            pg_config,
+            &pg_config,
             self.manifest_path.as_ref(),
             self.package.as_ref(),
             package_manifest_path,

--- a/cargo-pgx/src/command/start.rs
+++ b/cargo-pgx/src/command/start.rs
@@ -47,7 +47,7 @@ impl CommandExecute for Start {
             let (pg_config, _) =
                 pg_config_and_version(&pgx, &package_manifest, me.pg_version, None, false)?;
 
-            start_postgres(pg_config)
+            start_postgres(&pg_config)
         }
 
         let pgx = Pgx::from_config()?;

--- a/cargo-pgx/src/command/status.rs
+++ b/cargo-pgx/src/command/status.rs
@@ -44,7 +44,7 @@ impl CommandExecute for Status {
 
         for pg_config in pgx.iter(PgConfigSelector::new(&pg_version)) {
             let pg_config = pg_config?;
-            if status_postgres(pg_config)? {
+            if status_postgres(&pg_config)? {
                 println!("Postgres v{} is {}", pg_config.major_version()?, "running".bold().green())
             } else {
                 println!("Postgres v{} is {}", pg_config.major_version()?, "stopped".bold().red())

--- a/cargo-pgx/src/command/stop.rs
+++ b/cargo-pgx/src/command/stop.rs
@@ -45,7 +45,7 @@ impl CommandExecute for Stop {
             let (pg_config, _) =
                 pg_config_and_version(&pgx, &package_manifest, me.pg_version, None, false)?;
 
-            stop_postgres(pg_config)
+            stop_postgres(&pg_config)
         }
 
         let pgx = Pgx::from_config()?;

--- a/cargo-pgx/src/command/test.rs
+++ b/cargo-pgx/src/command/test.rs
@@ -68,7 +68,7 @@ impl CommandExecute for Test {
             )?;
 
             test_extension(
-                pg_config,
+                &pg_config,
                 me.manifest_path.as_ref(),
                 me.package.as_ref(),
                 &profile,

--- a/cargo-pgx/src/manifest.rs
+++ b/cargo-pgx/src/manifest.rs
@@ -123,7 +123,7 @@ pub(crate) fn pg_config_and_version<'a>(
     specified_pg_version: Option<String>,
     user_features: Option<&mut Features>,
     verbose: bool,
-) -> eyre::Result<(&'a PgConfig, PgVersionSource)> {
+) -> eyre::Result<(PgConfig, PgVersionSource)> {
     let pg_version = {
         'outer: loop {
             if let Some(pg_version) = specified_pg_version {
@@ -176,7 +176,7 @@ pub(crate) fn pg_config_and_version<'a>(
             let pg_config = pgx.get(&pg_version.label())?;
 
             if verbose {
-                display_version_info(pg_config, &pg_version);
+                display_version_info(&pg_config, &pg_version);
             }
 
             Ok((pg_config, pg_version))

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -119,7 +119,7 @@ fn main() -> eyre::Result<()> {
     println!("cargo:rerun-if-changed=cshim");
     emit_missing_rerun_if_env_changed();
 
-    let pg_configs: Vec<(u16, &PgConfig)> = if std::env::var(
+    let pg_configs: Vec<(u16, PgConfig)> = if std::env::var(
         "PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE",
     )
     .unwrap_or("false".into())
@@ -201,6 +201,7 @@ fn main() -> eyre::Result<()> {
 fn emit_missing_rerun_if_env_changed() {
     // `pgx-pg-config` doesn't emit one for this.
     println!("cargo:rerun-if-env-changed=PGX_PG_CONFIG_PATH");
+    println!("cargo:rerun-if-env-changed=PGX_PG_CONFIG_AS_ENV");
     // Bindgen's behavior depends on these vars, but it doesn't emit them
     // directly because the output would cause issue with `bindgen-cli`. Do it
     // on bindgen's behalf.

--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -50,6 +50,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"
+#include "common/config_info.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "foreign/fdwapi.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -52,6 +52,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"
+#include "common/config_info.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "foreign/fdwapi.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -52,6 +52,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"
+#include "common/config_info.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "foreign/fdwapi.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -52,6 +52,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"
+#include "common/config_info.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "foreign/fdwapi.h"

--- a/pgx-pg-sys/include/pg15.h
+++ b/pgx-pg-sys/include/pg15.h
@@ -52,6 +52,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "commands/vacuum.h"
+#include "common/config_info.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "foreign/fdwapi.h"


### PR DESCRIPTION
... that are prefixed with `PGX_PG_CONFIG_`.  Also adjusts how `Pgx::iter(PgConfigSelector::All)` behaves if we detect we have a "pg_config" defined as environment variables.

- Also adds Postgres' `common/config_info.h` header to pgx' bindings.

- Some minor API breakage as we now return owned `PgConfig` instances.