### PR TITLE
Update version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -114,7 +114,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.30.2",
+ "object 0.30.3",
  "rustc-demangle",
 ]
 
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytea"
@@ -250,12 +250,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 dependencies = [
  "atty",
  "cargo_metadata",
  "cargo_toml",
- "clap 4.1.1",
+ "clap 4.1.4",
  "clap-cargo",
  "color-eyre",
  "env_proxy",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.1"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive 4.1.0",
@@ -395,7 +395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca953650a7350560b61db95a0ab1d9c6f7b74d146a9e08fb258b834f3cf7e2c"
 dependencies = [
  "cargo_metadata",
- "clap 4.1.1",
+ "clap 4.1.4",
  "doc-comment",
 ]
 
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "glob"
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -1439,9 +1439,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 dependencies = [
  "pgx-sql-entity-graph",
  "proc-macro2",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 dependencies = [
  "dirs",
  "eyre",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-sql-entity-graph"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 dependencies = [
  "atty",
  "convert_case",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1628,16 +1628,16 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plist"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+checksum = "5329b8f106a176ab0dce4aae5da86bfcb139bb74fb00882859e03745011f3635"
 dependencies = [
  "base64",
  "indexmap",
  "line-wrap",
+ "quick-xml",
  "serde",
  "time",
- "xml-rs",
 ]
 
 [[package]]
@@ -1725,11 +1725,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1789,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1907,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -1994,9 +2003,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2007,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2296,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c215311383d25d03753375c53ab9fad8fc0cf46953c409211e065edeabf577ee"
+checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2437,9 +2446,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2491,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -2610,9 +2619,9 @@ checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -2637,9 +2646,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733b5ad78377302af52c0dbcb2623d78fe50e4b3bf215948ff29e9ee031d8566"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
  "base64",
  "flate2",

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgx' to make Postgres extension development easy"
@@ -17,20 +17,20 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.15.2"
 cargo_toml = "0.11.8"
-clap = { version = "4.1.1", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.1.4", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.16"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.0-beta.1" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.0-beta.1" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.0" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.0" }
 prettyplease = "0.1.23"
-proc-macro2 = { version = "1.0.49", features = [ "span-locations" ] }
+proc-macro2 = { version = "1.0.50", features = [ "span-locations" ] }
 quote = "1.0.23"
 rayon = "1.6.1"
 regex = "1.7.1"
-ureq = "2.6.1"
+ureq = "2.6.2"
 url = "2.3.1"
 serde = { version = "1.0.152", features = [ "derive" ] }
 serde_derive = "1.0.152"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.0-beta.1"
+pgx = "=0.7.0"
 
 [dev-dependencies]
-pgx-tests = "=0.7.0-beta.1"
+pgx-tests = "=0.7.0"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.0-beta.1"
+pgx = "=0.7.0"
 
 [dev-dependencies]
-pgx-tests = "=0.7.0-beta.1"
+pgx-tests = "=0.7.0"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-examples/bad_ideas/Cargo.toml
+++ b/pgx-examples/bad_ideas/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
 rand = "0.8.5"
-ureq = "2.6.1"
+ureq = "2.6.2"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgx'"
@@ -21,8 +21,8 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.0-beta.1" }
-proc-macro2 = "1.0.49"
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.0" }
+proc-macro2 = "1.0.50"
 quote = "1.0.23"
 syn = { version = "1.0.107", features = [ "extra-traits", "full", "fold", "parsing" ] }
 

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-config"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgx'"
@@ -20,5 +20,5 @@ owo-colors = "3.5.0"
 serde = { version = "1.0.152", features = [ "derive" ] }
 serde_derive = "1.0.152"
 serde_json = "1.0.91"
-toml = "0.5.10"
+toml = "0.5.11"
 url = "2.3.1"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgx'"
@@ -30,8 +30,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.6.5"
-pgx-macros = { path = "../pgx-macros/", version = "=0.7.0-beta.1" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph/", version = "=0.7.0-beta.1" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.7.0" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph/", version = "=0.7.0" }
 serde = { version = "1.0.152", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -39,8 +39,8 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.7.0-beta.1" }
-proc-macro2 = "1.0.49"
+pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.7.0" }
+proc-macro2 = "1.0.50"
 quote = "1.0.23"
 syn = { version = "1.0.107", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -33629,6 +33629,28 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct ConfigData {
+    pub name: *mut ::std::os::raw::c_char,
+    pub setting: *mut ::std::os::raw::c_char,
+}
+impl Default for ConfigData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn get_configdata(
+        my_exec_path: *const ::std::os::raw::c_char,
+        configdata_len: *mut usize,
+    ) -> *mut ConfigData;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct CachedPlanSource {
     pub magic: ::std::os::raw::c_int,
     pub raw_parse_tree: *mut RawStmt,

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -34165,6 +34165,28 @@ extern "C" {
 extern "C" {
     pub fn anl_get_next_S(t: f64, n: ::std::os::raw::c_int, stateptr: *mut f64) -> f64;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ConfigData {
+    pub name: *mut ::std::os::raw::c_char,
+    pub setting: *mut ::std::os::raw::c_char,
+}
+impl Default for ConfigData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn get_configdata(
+        my_exec_path: *const ::std::os::raw::c_char,
+        configdata_len: *mut usize,
+    ) -> *mut ConfigData;
+}
 pub const PlanCacheMode_PLAN_CACHE_MODE_AUTO: PlanCacheMode = 0;
 pub const PlanCacheMode_PLAN_CACHE_MODE_FORCE_GENERIC_PLAN: PlanCacheMode = 1;
 pub const PlanCacheMode_PLAN_CACHE_MODE_FORCE_CUSTOM_PLAN: PlanCacheMode = 2;

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -35573,6 +35573,28 @@ extern "C" {
 extern "C" {
     pub fn anl_get_next_S(t: f64, n: ::std::os::raw::c_int, stateptr: *mut f64) -> f64;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ConfigData {
+    pub name: *mut ::std::os::raw::c_char,
+    pub setting: *mut ::std::os::raw::c_char,
+}
+impl Default for ConfigData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn get_configdata(
+        my_exec_path: *const ::std::os::raw::c_char,
+        configdata_len: *mut usize,
+    ) -> *mut ConfigData;
+}
 pub type ResourceOwner = *mut ResourceOwnerData;
 extern "C" {
     pub static mut CurrentResourceOwner: ResourceOwner;

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -35694,6 +35694,28 @@ extern "C" {
 extern "C" {
     pub fn anl_get_next_S(t: f64, n: ::std::os::raw::c_int, stateptr: *mut f64) -> f64;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ConfigData {
+    pub name: *mut ::std::os::raw::c_char,
+    pub setting: *mut ::std::os::raw::c_char,
+}
+impl Default for ConfigData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn get_configdata(
+        my_exec_path: *const ::std::os::raw::c_char,
+        configdata_len: *mut usize,
+    ) -> *mut ConfigData;
+}
 pub const RawParseMode_RAW_PARSE_DEFAULT: RawParseMode = 0;
 pub const RawParseMode_RAW_PARSE_TYPE_NAME: RawParseMode = 1;
 pub const RawParseMode_RAW_PARSE_PLPGSQL_EXPR: RawParseMode = 2;

--- a/pgx-pg-sys/src/pg15.rs
+++ b/pgx-pg-sys/src/pg15.rs
@@ -36729,6 +36729,28 @@ extern "C" {
 extern "C" {
     pub fn anl_get_next_S(t: f64, n: ::std::os::raw::c_int, stateptr: *mut f64) -> f64;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ConfigData {
+    pub name: *mut ::std::os::raw::c_char,
+    pub setting: *mut ::std::os::raw::c_char,
+}
+impl Default for ConfigData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn get_configdata(
+        my_exec_path: *const ::std::os::raw::c_char,
+        configdata_len: *mut usize,
+    ) -> *mut ConfigData;
+}
 pub const RawParseMode_RAW_PARSE_DEFAULT: RawParseMode = 0;
 pub const RawParseMode_RAW_PARSE_TYPE_NAME: RawParseMode = 1;
 pub const RawParseMode_RAW_PARSE_PLPGSQL_EXPR: RawParseMode = 2;

--- a/pgx-sql-entity-graph/Cargo.toml
+++ b/pgx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-sql-entity-graph"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgx`"
@@ -20,7 +20,7 @@ cstr_core = "0.2"
 convert_case = "0.5.0"
 eyre = "0.6.8"
 petgraph = "0.6.2"
-proc-macro2 = { version = "1.0.49", features = [ "span-locations" ] }
+proc-macro2 = { version = "1.0.50", features = [ "span-locations" ] }
 quote = "1.0.23"
 regex = "1.7.1"
 syn = { version = "1.0.107", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgx'-based Postgres extensions"
@@ -37,13 +37,13 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.17.0"
 libc = "0.2.139"
-pgx-macros = { path = "../pgx-macros", version = "=0.7.0-beta.1" }
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.0-beta.1" }
+pgx-macros = { path = "../pgx-macros", version = "=0.7.0" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.0" }
 postgres = "0.19.4"
 regex = "1.7.1"
 serde = "1.0.152"
 serde_json = "1.0.91"
-sysinfo = "0.27.6"
+sysinfo = "0.27.7"
 time = "0.3.17"
 eyre = "0.6.8"
 thiserror = "1.0"
@@ -55,4 +55,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 path = "../pgx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.7.0-beta.1"
+version = "=0.7.0"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgx:  A Rust framework for creating Postgres extensions"
@@ -35,9 +35,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-macros = { path = "../pgx-macros", version = "=0.7.0-beta.1" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.7.0-beta.1" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.0-beta.1" }
+pgx-macros = { path = "../pgx-macros", version = "=0.7.0" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.7.0" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.0" }
 
 # used to internally impl things
 once_cell = "1.17.0" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
After two betas with minimal (reported) issues, pgx v0.7.0 is finally here!

The full set of code changes since pgx' previous version series (0.6.x) can be found [here](https://github.com/tcdi/pgx/compare/v0.6.1...v0.7.0).  It might also be beneficial to review the release notes for the 0.7.0-betas at [beta0](https://github.com/tcdi/pgx/releases/tag/v0.7.0-beta.0) and [beta1](https://github.com/tcdi/pgx/releases/tag/v0.7.0-beta.1)

Below is the small set of changes since beta1.

As always, please make sure to install the latest `cargo-pgx` with `cargo install cargo-pgx --version 0.7.0 --locked` and update your extension crate dependencies.

Thanks to all the contributors and users.  pgx wouldn't be possible without your participation!

## What's Changed

### A New Hook
* Add support for emit_log_hook by @feikesteenbergen in https://github.com/tcdi/pgx/pull/979

This allows extensions to intercept "ereport" messages as they're emitted by either Postgres or pgx.  Maybe you've always wanted to send log messages to some external collection system?  Now you can!

### Cross Compilation Support

* Allow manually choosing the scratch directory in `cargo pgx cross pgx-target` by @thomcc in https://github.com/tcdi/pgx/pull/1016
* Fix confusing typo in `CROSS_COMPILE.md` about `rustup target add` vs `rustup toolchain add` by @thomcc in https://github.com/tcdi/pgx/pull/1017
* enhance `PgConfig` to be able to construct itself from a set of environment variables by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/1019 and https://github.com/tcdi/pgx/pull/1020

### Other Cleanups

* add `PgHeapTuple::into_pg(self)` by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/1018
* Fix version in pg15 help text by @rustprooflabs in https://github.com/tcdi/pgx/pull/1013
* Bump the Nix flake.lock by @workingjubilee in https://github.com/tcdi/pgx/pull/1021

## New Contributors

* @feikesteenbergen made their first contribution in https://github.com/tcdi/pgx/pull/979

**Full Changelog**: https://github.com/tcdi/pgx/compare/v0.7.0-beta.1...v0.7.0