### PR TITLE
Support in `FromDatum` for binary coercible types (including domain types)

### DIFF
--- a/pgx-pg-sys/include/pg11.h
+++ b/pgx-pg-sys/include/pg11.h
@@ -82,6 +82,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parse_func.h"
 #include "parser/parse_oper.h"
 #include "parser/parse_type.h"
+#include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"

--- a/pgx-pg-sys/include/pg12.h
+++ b/pgx-pg-sys/include/pg12.h
@@ -82,6 +82,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parse_func.h"
 #include "parser/parse_oper.h"
 #include "parser/parse_type.h"
+#include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"

--- a/pgx-pg-sys/include/pg13.h
+++ b/pgx-pg-sys/include/pg13.h
@@ -82,6 +82,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parse_func.h"
 #include "parser/parse_oper.h"
 #include "parser/parse_type.h"
+#include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"

--- a/pgx-pg-sys/include/pg14.h
+++ b/pgx-pg-sys/include/pg14.h
@@ -82,6 +82,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parse_func.h"
 #include "parser/parse_oper.h"
 #include "parser/parse_type.h"
+#include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"

--- a/pgx-pg-sys/include/pg15.h
+++ b/pgx-pg-sys/include/pg15.h
@@ -82,6 +82,7 @@ Use of this source code is governed by the MIT license that can be found in the 
 #include "parser/parse_func.h"
 #include "parser/parse_oper.h"
 #include "parser/parse_type.h"
+#include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "postmaster/bgworker.h"

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -459,4 +459,11 @@ mod tests {
         assert_eq!(with_select, with_get_one);
         Ok(())
     }
+
+    #[pg_test]
+    fn spi_can_read_domain_types() -> spi::Result<Option<String>> {
+        Spi::run("CREATE DOMAIN my_text_type TEXT")?;
+        Spi::get_one::<String>("SELECT 'hello'::my_text_type")
+
+    }
 }

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -466,4 +466,12 @@ mod tests {
         Spi::get_one::<String>("SELECT 'hello'::my_text_type")
 
     }
+
+    #[pg_test]
+    fn spi_can_read_domain_types_based_on_domain_types() -> spi::Result<Option<String>> {
+        Spi::run("CREATE DOMAIN my_text_type TEXT")?;
+        Spi::run("CREATE DOMAIN my_other_text_type my_text_type")?;
+        Spi::get_one::<String>("SELECT 'hello'::my_other_text_type")
+
+    }
 }

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -464,7 +464,6 @@ mod tests {
     fn spi_can_read_domain_types() -> spi::Result<Option<String>> {
         Spi::run("CREATE DOMAIN my_text_type TEXT")?;
         Spi::get_one::<String>("SELECT 'hello'::my_text_type")
-
     }
 
     #[pg_test]
@@ -472,6 +471,5 @@ mod tests {
         Spi::run("CREATE DOMAIN my_text_type TEXT")?;
         Spi::run("CREATE DOMAIN my_other_text_type my_text_type")?;
         Spi::get_one::<String>("SELECT 'hello'::my_other_text_type")
-
     }
 }

--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -472,4 +472,10 @@ mod tests {
         Spi::run("CREATE DOMAIN my_other_text_type my_text_type")?;
         Spi::get_one::<String>("SELECT 'hello'::my_other_text_type")
     }
+
+    #[pg_test]
+    fn spi_can_read_binary_coercible_types() -> spi::Result<Option<pgx::Inet>> {
+        // cidr is binary coercible to inet
+        Spi::get_one::<pgx::Inet>("select '10.0.0.1/32'::cidr")
+    }
 }

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -117,7 +117,7 @@ pub trait FromDatum {
     where
         Self: Sized + IntoDatum,
     {
-        if !is_output_compatible::<Self>(type_oid) {
+        if !is_binary_coercible::<Self>(type_oid) {
             Err(TryFromDatumError::IncompatibleTypes {
                 rust_type: std::any::type_name::<Self>(),
                 rust_oid: Self::type_oid(),
@@ -140,7 +140,7 @@ pub trait FromDatum {
     where
         Self: Sized + IntoDatum,
     {
-        if !is_output_compatible::<Self>(type_oid) {
+        if !is_binary_coercible::<Self>(type_oid) {
             Err(TryFromDatumError::IncompatibleTypes {
                 rust_type: std::any::type_name::<Self>(),
                 rust_oid: Self::type_oid(),
@@ -153,19 +153,11 @@ pub trait FromDatum {
     }
 }
 
-fn is_output_compatible<T: IntoDatum>(mut type_oid: pg_sys::Oid) -> bool {
-    loop {
-        if T::is_compatible_with(type_oid) {
-            return true;
-        }
-        type_oid = unsafe {
-            (*pg_sys::lookup_type_cache(type_oid, pg_sys::TYPECACHE_DOMAIN_BASE_INFO as i32))
-                .domainBaseType
-        };
-        if type_oid == pg_sys::InvalidOid {
-            return false;
-        }
+fn is_binary_coercible<T: IntoDatum>(type_oid: pg_sys::Oid) -> bool {
+    if T::is_compatible_with(type_oid) {
+        return true;
     }
+    unsafe { pg_sys::IsBinaryCoercible(type_oid, T::type_oid()) }
 }
 
 /// Retrieves a Postgres type name given its Oid

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -159,7 +159,8 @@ fn is_output_compatible<T: IntoDatum>(mut type_oid: pg_sys::Oid) -> bool {
             return true;
         }
         type_oid = unsafe {
-            (*pg_sys::lookup_type_cache(type_oid, pg_sys::TYPECACHE_DOMAIN_BASE_INFO as i32)).domainBaseType
+            (*pg_sys::lookup_type_cache(type_oid, pg_sys::TYPECACHE_DOMAIN_BASE_INFO as i32))
+                .domainBaseType
         };
         if type_oid == pg_sys::InvalidOid {
             return false;

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -154,10 +154,7 @@ pub trait FromDatum {
 }
 
 fn is_binary_coercible<T: IntoDatum>(type_oid: pg_sys::Oid) -> bool {
-    if T::is_compatible_with(type_oid) {
-        return true;
-    }
-    unsafe { pg_sys::IsBinaryCoercible(type_oid, T::type_oid()) }
+    T::is_compatible_with(type_oid) || unsafe { pg_sys::IsBinaryCoercible(type_oid, T::type_oid()) }
 }
 
 /// Retrieves a Postgres type name given its Oid


### PR DESCRIPTION
Add support for deserializing domain types into rust types compatible with the base type.
If the initial oid compatibility check fails, we iteratively check the type cache for the domain base type and test against that.