### PR TITLE
Fix issue #1032

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1476,7 @@ dependencies = [
  "atomic-traits",
  "bitflags",
  "bitvec",
+ "const_format",
  "heapless",
  "libc",
  "once_cell",
@@ -2619,6 +2640,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,26 +490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,7 +1456,6 @@ dependencies = [
  "atomic-traits",
  "bitflags",
  "bitvec",
- "const_format",
  "heapless",
  "libc",
  "once_cell",
@@ -2640,12 +2619,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/README.md
+++ b/README.md
@@ -251,13 +251,15 @@ dear compiler runner, can make this guarantee for yourself by specifying the `un
 feature flag.  Otherwise, a pgx extension will fail to compile with an error similar to:
 
 ```
-error: Unrecognized Postgres ABI.  Perhaps you need `--features unsafe-postgres`?
-   --> pgx/src/lib.rs:139:9
+error[E0080]: evaluation of constant value failed
+   --> pgx/src/lib.rs:151:5
     |
-139 | /         compile_error!(
-140 | |             "Unrecognized Postgres ABI.  Perhaps you need `--features unsafe-postgres`?"
-141 | |         );
-    | |_________^
+151 | /     assert!(
+152 | |         same_slice(pg_sys::FMGR_ABI_EXTRA, b"xPostgreSQL\0"),
+153 | |         "Unsupported Postgres ABI. Perhaps you need `--features unsafe-postgres`?",
+154 | |     );
+    | |_____^ the evaluated program panicked at 'Unsupported Postgres ABI. Perhaps you need `--features unsafe-postgres`?', pgx/src/lib.rs:151:5
+    |
 ```
 
 ### Experimental Features

--- a/README.md
+++ b/README.md
@@ -242,6 +242,24 @@ this feature is now considered deprecated in favor of a lower-overhead interop.
 You may still request implementations of `TryFrom<time::Type> for pgx::MatchingType`
 and `From<time::Type> for pgx::MatchingType` by enabling the `"time-crate"` feature.
 
+### "unsafe-postgres": Allow compilation for Postgres forks that have a different ABI
+
+As of Postgres v15, forks are allowed to specify they use a different ABI than canonical Postgres.
+Since pgx makes countless assumptions about Postgres' internal ABI it is not possible for it to 
+guarantee that a compiled pgx extension will probably execute within such a Postgres fork.  You,
+dear compiler runner, can make this guarantee for yourself by specifying the `unsafe-postgres` 
+feature flag.  Otherwise, a pgx extension will fail to compile with an error simiar to:
+
+```
+error: Unrecognized Postgres ABI.  Perhaps you need `--features unsafe-postgres`?
+   --> pgx/src/lib.rs:139:9
+    |
+139 | /         compile_error!(
+140 | |             "Unrecognized Postgres ABI.  Perhaps you need `--features unsafe-postgres`?"
+141 | |         );
+    | |_________^
+```
+
 ### Experimental Features
 
 Adding `pgx = { version = "0.5.0", features = ["postgrestd"] }` to your Cargo.toml

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -49,7 +49,6 @@ uuid = { version = "1.3.0", features = [ "v4" ] } # PgLwLock and shmem
 thiserror = "1.0"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
-const_format = "0.2.30"
 
 # exposed in public API
 atomic-traits = "0.3.0" # PgAtomic and shmem init

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -27,6 +27,7 @@ pg14 = [ "pgx-pg-sys/pg14" ]
 pg15 = [ "pgx-pg-sys/pg15" ]
 time-crate = ["dep:time"]
 no-schema-generation = ["pgx-macros/no-schema-generation", "pgx-sql-entity-graph/no-schema-generation"]
+unsafe-postgres = []     # when trying to compile against something that looks like Postgres but claims its diffent
 
 [package.metadata.docs.rs]
 features = ["pg14", "cshim"]
@@ -48,6 +49,7 @@ uuid = { version = "1.3.0", features = [ "v4" ] } # PgLwLock and shmem
 thiserror = "1.0"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
+const_format = "0.2.30"
 
 # exposed in public API
 atomic-traits = "0.3.0" # PgAtomic and shmem init

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -27,7 +27,7 @@ pg14 = [ "pgx-pg-sys/pg14" ]
 pg15 = [ "pgx-pg-sys/pg15" ]
 time-crate = ["dep:time"]
 no-schema-generation = ["pgx-macros/no-schema-generation", "pgx-sql-entity-graph/no-schema-generation"]
-unsafe-postgres = []     # when trying to compile against something that looks like Postgres but claims its diffent
+unsafe-postgres = []     # when trying to compile against something that looks like Postgres but claims to be diffent
 
 [package.metadata.docs.rs]
 features = ["pg14", "cshim"]

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -220,8 +220,9 @@ macro_rules! pg_magic_func {
                 namedatalen: pgx::pg_sys::NAMEDATALEN as i32,
                 float8byval: cfg!(target_pointer_width = "64") as i32,
                 abi_extra: {
-                    // array::from_fn isn't const yet, boohoo, so const-copy a bstr
-                    let magic = b"PostgreSQL";
+                    // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then pgx'
+                    // assumptions can't necessarily be assumed correct
+                    let magic = pgx::pg_sys::FMGR_ABI_EXTRA;
                     let mut abi = [0 as ::pgx::ffi::c_char; 32];
                     let mut i = 0;
                     while i < magic.len() {

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -128,6 +128,20 @@ pub use pg_sys::{
 #[doc(hidden)]
 pub use pgx_sql_entity_graph;
 
+// Postgres v15 has the concept of an ABI "name".  The default is `b"PostgreSQL\0"` and this is the
+// ABI that pgx extensions expect to be running under.  We will refuse to compile if it is detected
+// that we're trying to be built against some other kind of "postgres" that has its own ABI name.
+//
+// Unless the compiling user explicitly told us that they're aware of this via `--features unsafe-postgres`.
+#[cfg(all(feature = "pg15", not(feature = "unsafe-postgres")))]
+const _: () = {
+    if crate::pg_sys::FMGR_ABI_EXTRA.iter().zip(b"PostgreSQL\0".iter()).all(|(a, b)| a == b) {
+        compile_error!(
+            "Unrecognized Postgres ABI.  Perhaps you need `--features unsafe-postgres`?"
+        );
+    }
+};
+
 /// A macro for marking a library compatible with [`pgx`][crate].
 ///
 /// <div class="example-wrap" style="display:inline-block">
@@ -220,8 +234,8 @@ macro_rules! pg_magic_func {
                 namedatalen: pgx::pg_sys::NAMEDATALEN as i32,
                 float8byval: cfg!(target_pointer_width = "64") as i32,
                 abi_extra: {
-                    // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then pgx'
-                    // assumptions can't necessarily be assumed correct
+                    // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then we'll
+                    // raise a compilation error unless the `unsafe-postgres` feature is set
                     let magic = pgx::pg_sys::FMGR_ABI_EXTRA;
                     let mut abi = [0 as ::pgx::ffi::c_char; 32];
                     let mut i = 0;


### PR DESCRIPTION
Blindly use the `FMGR_ABI_EXTRA` constant as part of the magic block. Hardcoding to "PostgreSQL" isn't exactly correct when using bindings from, for example, a Postgres fork that has purposely changed its ABI "name".