### PR TITLE
Ensure the `libpq{,N}-dev` package is removed in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         echo ""
 
         echo "----- Remove old postgres -----"
-        sudo apt remove -y postgres*
+        sudo apt remove -y '^postgres.*' '^libpq.*'
         echo ""
 
         echo "----- Set up PostgreSQL Apt repository -----"
@@ -289,7 +289,7 @@ jobs:
         echo ""
 
         echo "----- Remove existing installations of postgres -----"
-        sudo apt remove -y postgres*
+        sudo apt remove -y '^postgres.*' '^libpq.*'
         echo ""
 
         echo "----- Install system dependencies -----"


### PR DESCRIPTION
In apt `libpq-dev` (or something like `libpq5-dev`) provides a `pg_config` binary, so that the client libraries can be located. We should remove that with the other stuff, so that we can catch cases wehre we are accidentally using thw wrong `pg_config` (see #981).

I also changed the globs to regexs, since I'm not sure how the globbing was working in the first place (shouldn't the glob expand to paths) and the internet says that it `apt remove` can be given a regex.