### PR TITLE
Disable thin lto for dev builds by default in template

### DIFF
--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -23,7 +23,6 @@ pgx-tests = "=0.7.1"
 
 [profile.dev]
 panic = "unwind"
-lto = "thin"
 
 [profile.release]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -25,7 +25,6 @@ once_cell = "1.7.2"
 
 [profile.dev]
 panic = "unwind"
-lto = "thin"
 
 [profile.release]
 panic = "unwind"

--- a/pgx-examples/aggregate/Cargo.toml
+++ b/pgx-examples/aggregate/Cargo.toml
@@ -26,7 +26,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/bgworker/Cargo.toml
+++ b/pgx-examples/bgworker/Cargo.toml
@@ -24,7 +24,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/bytea/Cargo.toml
+++ b/pgx-examples/bytea/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/composite_type/Cargo.toml
+++ b/pgx-examples/composite_type/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/custom_sql/Cargo.toml
+++ b/pgx-examples/custom_sql/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/custom_types/Cargo.toml
+++ b/pgx-examples/custom_types/Cargo.toml
@@ -27,7 +27,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/errors/Cargo.toml
+++ b/pgx-examples/errors/Cargo.toml
@@ -24,7 +24,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/nostd/Cargo.toml
+++ b/pgx-examples/nostd/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/numeric/Cargo.toml
+++ b/pgx-examples/numeric/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 
 #[profile.dev]
 #panic = "unwind"
-#lto = "thin"
 #
 #[profile.release]
 #panic = "unwind"

--- a/pgx-examples/operators/Cargo.toml
+++ b/pgx-examples/operators/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/pgtrybuilder/Cargo.toml
+++ b/pgx-examples/pgtrybuilder/Cargo.toml
@@ -24,7 +24,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/schemas/Cargo.toml
+++ b/pgx-examples/schemas/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/shmem/Cargo.toml
+++ b/pgx-examples/shmem/Cargo.toml
@@ -26,7 +26,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/spi/Cargo.toml
+++ b/pgx-examples/spi/Cargo.toml
@@ -24,7 +24,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/spi_srf/Cargo.toml
+++ b/pgx-examples/spi_srf/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/srf/Cargo.toml
+++ b/pgx-examples/srf/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/strings/Cargo.toml
+++ b/pgx-examples/strings/Cargo.toml
@@ -24,7 +24,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 # [profile.dev]
 # panic = "unwind"
-# lto = "thin"
 
 # [profile.release]
 # panic = "unwind"

--- a/pgx-examples/triggers/Cargo.toml
+++ b/pgx-examples/triggers/Cargo.toml
@@ -25,7 +25,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 #[profile.dev]
 #panic = "unwind"
-# lto = "thin"
 
 #[profile.release]
 #panic = "unwind"

--- a/pgx-examples/versioned_so/Cargo.toml
+++ b/pgx-examples/versioned_so/Cargo.toml
@@ -24,7 +24,6 @@ pgx-tests = { path = "../../pgx-tests" }
 # uncomment these if compiling outside of 'pgx'
 #[profile.dev]
 #panic = "unwind"
-# lto = "thin"
 
 #[profile.release]
 #panic = "unwind"


### PR DESCRIPTION
When changing something trivial in the hello world project created by
`cargo pgx new`, it would take ~20 seconds to compile a dev build of the
generated crate on my machine. This seemed way slower than it should be.
It turns out that the thin LTO setting greatly inrceases compilation
times. By disabling it, compilation time of the crate is only 1 second.

As far as I can tell this setting was enabled initially as a workaround
for this bug in Rust: https://github.com/rust-lang/rust/issues/50007
Since this bug has been fixed since Rust 1.62, and current stable Rust
is version 1.67, this PR removes the workaround.
