### PR TITLE
Fix outdated documentation for `pgx::name!`

### DIFF
--- a/pgx/src/fcinfo.rs
+++ b/pgx/src/fcinfo.rs
@@ -54,7 +54,7 @@ macro_rules! default {
 pub struct NULL;
 
 /// A macro for providing SQL names for the returned fields for functions that return a Rust tuple,
-/// especially those that return a `std::iter::Iterator<Item=(f1, f2, f3)>`
+/// especially those that return a [`TableIterator`][crate::iter::TableIterator].
 ///
 /// ## Examples
 ///


### PR DESCRIPTION
Since a few versions ago, `TableIterator`s are used instead of an iterator of tuples for table returning functions. The documentation for `pgx::name!` didn't reflect that change though, this PR fixes it.