### PR TITLE
Use SPITupleTable->numvals when available

### DIFF
--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -578,7 +578,16 @@ impl<'a> SpiClient<'a> {
                     Some(pg_sys::SPI_tuptable)
                 }
             },
+            #[cfg(any(feature = "pg11", feature = "pg12"))]
             size: unsafe { pg_sys::SPI_processed as usize },
+            #[cfg(not(any(feature = "pg11", feature = "pg12")))]
+            size: unsafe {
+                if pg_sys::SPI_tuptable.is_null() {
+                    pg_sys::SPI_processed as usize
+                } else {
+                    (*pg_sys::SPI_tuptable).numvals as usize
+                }
+            },
             current: -1,
         })
     }

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -581,6 +581,7 @@ impl<'a> SpiClient<'a> {
             #[cfg(any(feature = "pg11", feature = "pg12"))]
             size: unsafe { pg_sys::SPI_processed as usize },
             #[cfg(not(any(feature = "pg11", feature = "pg12")))]
+            // SAFETY: no concurrent access
             size: unsafe {
                 if pg_sys::SPI_tuptable.is_null() {
                     pg_sys::SPI_processed as usize


### PR DESCRIPTION
Starting from PostgreSQL, SPI tuple table contains number of rows returned in `numvals`, with `SPI_processed` still available for "historical reasons":

"The fields tupdesc, vals, and numvals can be used by SPI callers; the remaining fields are internal. vals is an array of pointers to rows. The number of rows is given by numvals (for somewhat historical reasons, this count is also returned in SPI_processed)."

(https://www.postgresql.org/docs/current/spi-spi-execute.html)

Also:

"Some utility commands (COPY, CREATE TABLE AS) don't return a row set, so SPI_tuptable is NULL, but they still return the number of rows processed in SPI_processed."

So we're following this logic.

This is to ensure we're not relying on "historical" API going forward.