### PR TITLE
Made Date::to_unix_epoch_days() public

### DIFF
--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -83,6 +83,7 @@ impl Date {
         self.0
     }
 
+    /// Returns the date as an i32 representing the elapsed time since UNIX epoch in days
     #[inline]
     pub fn to_unix_epoch_days(&self) -> i32 {
         self.0 + POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE

--- a/pgx/src/datum/date.rs
+++ b/pgx/src/datum/date.rs
@@ -84,7 +84,7 @@ impl Date {
     }
 
     #[inline]
-    fn to_unix_epoch_days(&self) -> i32 {
+    pub fn to_unix_epoch_days(&self) -> i32 {
         self.0 + POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE
     }
 


### PR DESCRIPTION
Made Date::to_unix_epoch_days() public. @eeeebbbbrrrr confirmed there was no specific reason why its private