### PR TITLE
Extend UTF-8 detection in PGX init and test

### DIFF
--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -32,7 +32,11 @@ pub fn get_c_locale_flags() -> &'static [&'static str] {
     #[cfg(not(target_os = "macos"))]
     {
         match Command::new("locale").arg("-a").output() {
-            Ok(cmd) if String::from_utf8_lossy(&cmd.stdout).lines().any(|l| l == "C.UTF-8" || l == "C.utf8") => {
+            Ok(cmd)
+                if String::from_utf8_lossy(&cmd.stdout)
+                    .lines()
+                    .any(|l| l == "C.UTF-8" || l == "C.utf8") =>
+            {
                 &["--locale=C.UTF-8"]
             }
             // fallback to C if we can't list locales or don't have C.UTF-8

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -32,7 +32,7 @@ pub fn get_c_locale_flags() -> &'static [&'static str] {
     #[cfg(not(target_os = "macos"))]
     {
         match Command::new("locale").arg("-a").output() {
-            Ok(cmd) if String::from_utf8_lossy(&cmd.stdout).lines().any(|l| l == "C.UTF-8") => {
+            Ok(cmd) if String::from_utf8_lossy(&cmd.stdout).lines().any(|l| l == "C.UTF-8" || l == "C.utf8") => {
                 &["--locale=C.UTF-8"]
             }
             // fallback to C if we can't list locales or don't have C.UTF-8


### PR DESCRIPTION
Newer versions of Ubuntu output locale names differently, breaking the locale detection:
```
$ locale -a
C
C.utf8
POSIX
```