### PR TITLE
fix: check root by uid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "flate2",
  "fork",
  "libloading",
+ "nix",
  "num_cpus",
  "object 0.28.4",
  "once_cell",
@@ -1217,6 +1218,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2210,6 +2223,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -49,6 +49,7 @@ tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }
 tar = { version = "0.4.38", default-features = false }
 tempfile = "3.3.0"
+nix = { version = "0.26", default-features = false, features = ["user"] }
 
 [features]
 default = ["ureq/native-tls"]

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -433,10 +433,8 @@ fn get_pg_installdir(pgdir: &PathBuf) -> PathBuf {
 }
 
 fn is_root_user() -> bool {
-    match env::var("USER") {
-        Ok(val) => val == "root",
-        Err(_) => false,
-    }
+    use nix::unistd::Uid;
+    Uid::effective().is_root()
 }
 
 pub(crate) fn initdb(bindir: &PathBuf, datadir: &PathBuf) -> eyre::Result<()> {


### PR DESCRIPTION
In environment like docker containers, `USER` environment variable is not set, and therefore it might be a better idea to check root by UID instead of USER env variable.