### PR TITLE
support backtrace for Rust panic

### DIFF
--- a/pgx-pg-sys/src/submodules/ffi.rs
+++ b/pgx-pg-sys/src/submodules/ffi.rs
@@ -171,7 +171,7 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
                     message,
                     detail,
                     hint,
-                    location: ErrorReportLocation { file, funcname, line, col: 0 },
+                    location: ErrorReportLocation { file, funcname, line, col: 0, backtrace: None },
                 },
             }))
         }

--- a/pgx-pg-sys/src/submodules/panic.rs
+++ b/pgx-pg-sys/src/submodules/panic.rs
@@ -183,6 +183,7 @@ impl ErrorReportWithLevel {
         self.inner.detail()
     }
 
+    /// Get the detail line with backtrace. If backtrace is not available, it will just return the detail.
     pub fn detail_with_backtrace(&self) -> String {
         match (self.detail(), self.backtrace()) {
             (Some(d), Some(bt)) if bt.status() == std::backtrace::BacktraceStatus::Captured => {


### PR DESCRIPTION
I feel debugging is hard without a backtrace, and therefore I added a new field to error report and added backtrace to the Postgres error report. As we are using `std::backtrace`, MSRV is now 1.65.0, but we can switch to `backtrace` crate if we don't want to affect MSRV. Comments welcomed, and thanks for review!

Backtrace needs to be manually enabled by using `RUST_BACKTRACE=1`.

```
RUST_BACKTRACE=1 cargo pgx run
```

```
db721_fdw=# \set VERBOSITY verbose
db721_fdw=# explain <something that panics>
ERROR:  test panic
DETAIL:  
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/backtrace.rs:332:13
   3: std::backtrace::Backtrace::capture
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/backtrace.rs:298:9
   4: pgx_pg_sys::submodules::panic::register_pg_guard_panic_hook::{{closure}}::{{closure}}
             at /Users/skyzh/Work/pgx/pgx-pg-sys/src/submodules/panic.rs:294:48
   5: std::thread::local::LocalKey<T>::try_with
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/thread/local.rs:446:16
   6: std::thread::local::LocalKey<T>::with
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/thread/local.rs:422:9
   7: pgx_pg_sys::submodules::panic::register_pg_guard_panic_hook::{{closure}}
             at /Users/skyzh/Work/pgx/pgx-pg-sys/src/submodules/panic.rs:291:9
   8: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/alloc/src/boxed.rs:2002:9
   9: std::panicking::rust_panic_with_hook
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/panicking.rs:692:13
  10: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/panicking.rs:577:13
  11: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/sys_common/backtrace.rs:137:18
  12: rust_begin_unwind
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/panicking.rs:575:5
  13: core::panicking::panic_fmt
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/core/src/panicking.rs:64:14
  14: db721_fdw::get_foreign_paths::get_foreign_paths_inner
             at /Users/skyzh/Work/fdw721/src/lib.rs:97:5
  15: db721_fdw::get_foreign_paths::{{closure}}
             at /Users/skyzh/Work/fdw721/src/lib.rs:70:1
  16: std::panicking::try::do_call
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/panicking.rs:483:40
  17: ___rust_try
  18: std::panicking::try
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/panicking.rs:447:19
  19: std::panic::catch_unwind
             at /rustc/065852def0903296da33a9eaf557f230bcf3a61a/library/std/src/panic.rs:140:14
  20: pgx_pg_sys::submodules::panic::run_guarded
             at /Users/skyzh/Work/pgx/pgx-pg-sys/src/submodules/panic.rs:390:11
  21: pgx_pg_sys::submodules::panic::pgx_extern_c_guard
             at /Users/skyzh/Work/pgx/pgx-pg-sys/src/submodules/panic.rs:367:11
  22: db721_fdw::get_foreign_paths
             at /Users/skyzh/Work/fdw721/src/lib.rs:71:5
  23: set_foreign_pathlist
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/path/allpaths.c:933:2
  24: set_rel_pathlist
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/path/allpaths.c:493:6
  25: set_base_rel_pathlists
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/path/allpaths.c:355:3
  26: make_one_rel
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/path/allpaths.c:225:2
  27: query_planner
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/plan/planmain.c:276:14
  28: grouping_planner
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/plan/planner.c:1470:17
  29: subquery_planner
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/plan/planner.c:1047:2
  30: standard_planner
             at /Users/skyzh/.pgx/15.2/src/backend/optimizer/plan/planner.c:406:9
  31: pg_plan_query
             at /Users/skyzh/.pgx/15.2/src/backend/tcop/postgres.c:883:9
  32: ExplainOneQuery
             at /Users/skyzh/.pgx/15.2/src/backend/commands/explain.c:397:10
  33: ExplainQuery
             at /Users/skyzh/.pgx/15.2/src/backend/commands/explain.c:281:4
  34: standard_ProcessUtility
             at /Users/skyzh/.pgx/15.2/src/backend/tcop/utility.c:870:4
  35: PortalRunUtility
             at /Users/skyzh/.pgx/15.2/src/backend/tcop/pquery.c:1158:2
  36: FillPortalStore
             at /Users/skyzh/.pgx/15.2/src/backend/tcop/pquery.c:1031:4
  37: PortalRun
             at /Users/skyzh/.pgx/15.2/src/backend/tcop/pquery.c:763:6
  38: exec_simple_query
             at /Users/skyzh/.pgx/15.2/src/backend/tcop/postgres.c:1250:10
  39: PostgresMain
  40: BackendRun
             at /Users/skyzh/.pgx/15.2/src/backend/postmaster/postmaster.c:4511:2
  41: BackendStartup
             at /Users/skyzh/.pgx/15.2/src/backend/postmaster/postmaster.c:4239:3
  42: ServerLoop
             at /Users/skyzh/.pgx/15.2/src/backend/postmaster/postmaster.c:1806:7
  43: PostmasterMain
             at /Users/skyzh/.pgx/15.2/src/backend/postmaster/postmaster.c:1478:11
  44: main
             at /Users/skyzh/.pgx/15.2/src/backend/main/main.c:202:3
```