### PR TITLE
Remove plrust-related feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,30 +268,6 @@ error[E0080]: evaluation of constant value failed
     |
 ```
 
-### Experimental Features
-
-Adding `pgx = { version = "0.5.0", features = ["postgrestd"] }` to your Cargo.toml
-will enable a **highly** experimental variant of `pgx` designed for integration with `postgrestd`,
-a modified Rust standard library that executes the Rust runtime atop the Postgres runtime,
-instead of using the operating system's ordinary C runtime.
-This reduces the programmatic and performance impedance between Rust and Postgres.
-This feature is neither complete, nor is it completely enabled just by enabling the feature,
-as it requires additional code not in this crate in the form of the modified sysroot.
-
-Because the `postgrestd` feature is designed around control over `std`,
-some of `pgx`'s insulating guard code around the C FFI with Postgres is disabled.
-Combined with its "pre-alpha" stage, you should assume this feature can enable undefined behavior,
-even if you know what you are doing. Especially if you know exactly what you're doing, in fact,
-as that almost certainly means you are developing this feature,
-and further extending both runtimes in ways neither initially had imagined.
-If you absolutely must enable this feature, you may wish to discuss it first on [Discord].
-
-Adding `pgx = { version = "0.5.0", features = ["plrust"] }` to your Cargo.toml
-will enable an even more experimental variant of the above with special carve-outs
-specifically for usage with `PL/Rust`. This feature may not last long,
-as it is likely that code may move into a separate crate.
-
-As a reminder: "THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND..."
 
 ## Contributing
 

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -17,7 +17,6 @@ pg12 = [ ]
 pg13 = [ ]
 pg14 = [ ]
 pg15 = [ ]
-postgrestd = [ ]
 cshim = [ ]
 
 [package.metadata.docs.rs]

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -17,8 +17,6 @@ crate-type = [ "rlib" ]
 
 [features]
 default = [ "cshim" ]
-plrust = [ "postgrestd" ]
-postgrestd = ["pgx-pg-sys/postgrestd"]
 cshim = [ "pgx-pg-sys/cshim" ]
 pg11 = [ "pgx-pg-sys/pg11" ]
 pg12 = [ "pgx-pg-sys/pg12" ]

--- a/pgx/src/memcxt.rs
+++ b/pgx/src/memcxt.rs
@@ -577,24 +577,6 @@ impl PgMemoryContexts {
         leaked_ptr
     }
 
-    /// Allocates and then leaks a "trivially dropped" type in the appropriate memory context.
-    /// If `feature = "postgrestd"` is enabled, this "forgets" it entirely, assuming that it is fine
-    /// to let Postgres `pfree` it later. Otherwise it is equivalent to `fn leak_and_drop_on_delete`.
-    ///
-    /// Accordingly, this may prove unwise to use on something that actually needs to run its Drop.
-    /// But note it is not actually unsound to `mem::forget` something in this way, just annoying
-    /// if you were expecting it to actually execute its Drop.
-    pub fn leak_trivial_alloc<T>(&mut self, v: T) -> *mut T {
-        #[cfg(feature = "postgrestd")]
-        {
-            Box::leak(Box::new(v))
-        }
-        #[cfg(not(feature = "postgrestd"))]
-        {
-            self.leak_and_drop_on_delete(v)
-        }
-    }
-
     /// helper function
     fn exec_in_context<R, F: FnOnce(&mut PgMemoryContexts) -> R>(
         context: pg_sys::MemoryContext,


### PR DESCRIPTION
Removes the last of the code and associated documentation.
It has been replaced, in function, by plrust's trusted-pgx subset.