### PR TITLE
By default, require superuser privileges to install a pgx extension

### DIFF
--- a/cargo-pgx/src/templates/control
+++ b/cargo-pgx/src/templates/control
@@ -2,4 +2,4 @@ comment = '{name}:  Created by pgx'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/{name}'
 relocatable = false
-superuser = false
+superuser = true


### PR DESCRIPTION
An error occurs when the user without root privileges tries to install extensions compiled via `pgx`.

For instance, `pg_graphql` is written on `Rust` using `pgx`. And if the user has access only to one database created especially for him, he'll see

```sql
create extension pg_graphql;

ERROR: permission denied for language c (SQLSTATE 42501)
```

It happens because the `C` language is untrusted by default in Postgres. These changes allow non-privileged users to install extensions without marking `C` as trusted.