### PR TITLE
Update version to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrays"
@@ -133,6 +133,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bgworker"
@@ -241,21 +247,21 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "camino"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
+checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-pgx"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "atty",
  "cargo_metadata",
  "cargo_toml",
- "clap 4.1.4",
+ "clap 4.1.6",
  "clap-cargo",
  "color-eyre",
  "env_proxy",
@@ -347,9 +353,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -375,13 +381,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive 4.1.0",
- "clap_lex 0.3.1",
+ "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -396,7 +402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca953650a7350560b61db95a0ab1d9c6f7b74d146a9e08fb258b834f3cf7e2c"
 dependencies = [
  "cargo_metadata",
- "clap 4.1.4",
+ "clap 4.1.6",
  "doc-comment",
 ]
 
@@ -437,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -718,23 +724,23 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -875,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -915,7 +921,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version 0.4.0",
- "spin 0.9.4",
+ "spin 0.9.5",
  "stable_deref_trait",
 ]
 
@@ -942,6 +948,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hmac"
@@ -999,14 +1011,14 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1059,9 +1071,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libflate"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
+checksum = "97822bf791bd4d5b403713886a5fbe8bf49520fe78e323b0dc480ca1a03e50b0"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -1070,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "libflate_lz77"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
 dependencies = [
  "rle-decode-fast",
 ]
@@ -1192,14 +1204,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1310,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
@@ -1436,9 +1448,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1446,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1464,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1489,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "pgx-sql-entity-graph",
  "proc-macro2",
@@ -1500,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "dirs",
  "eyre",
@@ -1515,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1535,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-sql-entity-graph"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "atty",
  "convert_case",
@@ -1556,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1623,11 +1635,11 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plist"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5329b8f106a176ab0dce4aae5da86bfcb139bb74fb00882859e03745011f3635"
+checksum = "9469799ca90293a376f68f6fcb8f11990d9cff55602cfba0ba83893c973a7f46"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "indexmap",
  "line-wrap",
  "quick-xml",
@@ -1655,7 +1667,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -1720,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1919,16 +1931,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2104,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -2157,9 +2169,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -2204,9 +2216,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
 dependencies = [
  "lock_api",
 ]
@@ -2280,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2368,12 +2380,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
 dependencies = [
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2404,18 +2416,19 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "serde",
@@ -2431,9 +2444,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -2449,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2495,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2659,7 +2672,7 @@ version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "flate2",
  "log",
  "native-tls",

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgx' to make Postgres extension development easy"
@@ -17,16 +17,16 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.15.3"
 cargo_toml = "0.11.8"
-clap = { version = "4.1.4", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.1.6", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.16"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.1" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.1" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.2" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.2" }
 prettyplease = "0.1.23"
-proc-macro2 = { version = "1.0.50", features = [ "span-locations" ] }
+proc-macro2 = { version = "1.0.51", features = [ "span-locations" ] }
 quote = "1.0.23"
 rayon = "1.6.1"
 regex = "1.7.1"
@@ -35,12 +35,12 @@ url = "2.3.1"
 serde = { version = "1.0.152", features = [ "derive" ] }
 serde_derive = "1.0.152"
 serde-xml-rs = "0.5.1"
-syn = { version = "1.0.107", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.108", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 fork = "0.1.20"
 libloading = "0.7.4"
 object = "0.28.4"
-once_cell = "1.17.0"
+once_cell = "1.17.1"
 eyre = "0.6.8"
 color-eyre = "0.6.2"
 tracing = "0.1.37"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.1"
+pgx = "=0.7.2"
 
 [dev-dependencies]
-pgx-tests = "=0.7.1"
+pgx-tests = "=0.7.2"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.1"
+pgx = "=0.7.2"
 
 [dev-dependencies]
-pgx-tests = "=0.7.1"
+pgx-tests = "=0.7.2"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-examples/bytea/Cargo.toml
+++ b/pgx-examples/bytea/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgx = { path = "../../pgx", default-features = false }
-libflate = "1.2.0"
+libflate = "1.3.0"
 
 [dev-dependencies]
 pgx-tests = { path = "../../pgx-tests" }

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgx'"
@@ -21,10 +21,10 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.1" }
-proc-macro2 = "1.0.50"
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.2" }
+proc-macro2 = "1.0.51"
 quote = "1.0.23"
-syn = { version = "1.0.107", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.108", features = [ "extra-traits", "full", "fold", "parsing" ] }
 
 [dev-dependencies]
 serde = { version = "1.0.152", features = ["derive"] } # for Documentation examples

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-config"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgx'"
@@ -19,6 +19,6 @@ pathsearch = "0.2.0"
 owo-colors = "3.5.0"
 serde = { version = "1.0.152", features = [ "derive" ] }
 serde_derive = "1.0.152"
-serde_json = "1.0.91"
+serde_json = "1.0.93"
 toml = "0.5.11"
 url = "2.3.1"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.6.5"
-pgx-macros = { path = "../pgx-macros/", version = "=0.7.1" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph/", version = "=0.7.1" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.7.2" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph/", version = "=0.7.2" }
 serde = { version = "1.0.152", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,10 +38,10 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.7.1" }
-proc-macro2 = "1.0.50"
+pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.7.2" }
+proc-macro2 = "1.0.51"
 quote = "1.0.23"
-syn = { version = "1.0.107", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.108", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps
-once_cell = "1.17.0"
+once_cell = "1.17.1"

--- a/pgx-pg-sys/src/pg11.rs
+++ b/pgx-pg-sys/src/pg11.rs
@@ -38636,6 +38636,165 @@ extern "C" {
         missing_ok: bool,
     );
 }
+pub type TYPCATEGORY = ::std::os::raw::c_char;
+pub const CoercionPathType_COERCION_PATH_NONE: CoercionPathType = 0;
+pub const CoercionPathType_COERCION_PATH_FUNC: CoercionPathType = 1;
+pub const CoercionPathType_COERCION_PATH_RELABELTYPE: CoercionPathType = 2;
+pub const CoercionPathType_COERCION_PATH_ARRAYCOERCE: CoercionPathType = 3;
+pub const CoercionPathType_COERCION_PATH_COERCEVIAIO: CoercionPathType = 4;
+pub type CoercionPathType = ::std::os::raw::c_uint;
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsBinaryCoercible(srctype: Oid, targettype: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsPreferredType(category: TYPCATEGORY, type_: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn TypeCategory(type_: Oid) -> TYPCATEGORY;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_target_type(
+        pstate: *mut ParseState,
+        expr: *mut Node,
+        exprtype: Oid,
+        targettype: Oid,
+        targettypmod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn can_coerce_type(
+        nargs: ::std::os::raw::c_int,
+        input_typeids: *mut Oid,
+        target_typeids: *mut Oid,
+        ccontext: CoercionContext,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        inputTypeId: Oid,
+        targetTypeId: Oid,
+        targetTypeMod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_domain(
+        arg: *mut Node,
+        baseTypeId: Oid,
+        baseTypeMod: int32,
+        typeId: Oid,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+        hideInputCoercion: bool,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_boolean(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type_typmod(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        targetTypmod: int32,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn parser_coercion_errposition(
+        pstate: *mut ParseState,
+        coerce_location: ::std::os::raw::c_int,
+        input_expr: *mut Node,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn select_common_type(
+        pstate: *mut ParseState,
+        exprs: *mut List,
+        context: *const ::std::os::raw::c_char,
+        which_expr: *mut *mut Node,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_common_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        context: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_generic_type_consistency(
+        actual_arg_types: *mut Oid,
+        declared_arg_types: *mut Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn enforce_generic_type_consistency(
+        actual_arg_types: *mut Oid,
+        declared_arg_types: *mut Oid,
+        nargs: ::std::os::raw::c_int,
+        rettype: Oid,
+        allow_poly: bool,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn resolve_generic_type(
+        declared_type: Oid,
+        context_actual_type: Oid,
+        context_declared_type: Oid,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_coercion_pathway(
+        targetTypeId: Oid,
+        sourceTypeId: Oid,
+        ccontext: CoercionContext,
+        funcid: *mut Oid,
+    ) -> CoercionPathType;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_typmod_coercion_function(typeId: Oid, funcid: *mut Oid) -> CoercionPathType;
+}
 pub const BackslashQuoteType_BACKSLASH_QUOTE_OFF: BackslashQuoteType = 0;
 pub const BackslashQuoteType_BACKSLASH_QUOTE_ON: BackslashQuoteType = 1;
 pub const BackslashQuoteType_BACKSLASH_QUOTE_SAFE_ENCODING: BackslashQuoteType = 2;

--- a/pgx-pg-sys/src/pg12.rs
+++ b/pgx-pg-sys/src/pg12.rs
@@ -40923,6 +40923,165 @@ extern "C" {
         missing_ok: bool,
     );
 }
+pub type TYPCATEGORY = ::std::os::raw::c_char;
+pub const CoercionPathType_COERCION_PATH_NONE: CoercionPathType = 0;
+pub const CoercionPathType_COERCION_PATH_FUNC: CoercionPathType = 1;
+pub const CoercionPathType_COERCION_PATH_RELABELTYPE: CoercionPathType = 2;
+pub const CoercionPathType_COERCION_PATH_ARRAYCOERCE: CoercionPathType = 3;
+pub const CoercionPathType_COERCION_PATH_COERCEVIAIO: CoercionPathType = 4;
+pub type CoercionPathType = ::std::os::raw::c_uint;
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsBinaryCoercible(srctype: Oid, targettype: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsPreferredType(category: TYPCATEGORY, type_: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn TypeCategory(type_: Oid) -> TYPCATEGORY;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_target_type(
+        pstate: *mut ParseState,
+        expr: *mut Node,
+        exprtype: Oid,
+        targettype: Oid,
+        targettypmod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn can_coerce_type(
+        nargs: ::std::os::raw::c_int,
+        input_typeids: *const Oid,
+        target_typeids: *const Oid,
+        ccontext: CoercionContext,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        inputTypeId: Oid,
+        targetTypeId: Oid,
+        targetTypeMod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_domain(
+        arg: *mut Node,
+        baseTypeId: Oid,
+        baseTypeMod: int32,
+        typeId: Oid,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+        hideInputCoercion: bool,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_boolean(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type_typmod(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        targetTypmod: int32,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn parser_coercion_errposition(
+        pstate: *mut ParseState,
+        coerce_location: ::std::os::raw::c_int,
+        input_expr: *mut Node,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn select_common_type(
+        pstate: *mut ParseState,
+        exprs: *mut List,
+        context: *const ::std::os::raw::c_char,
+        which_expr: *mut *mut Node,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_common_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        context: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn enforce_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *mut Oid,
+        nargs: ::std::os::raw::c_int,
+        rettype: Oid,
+        allow_poly: bool,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn resolve_generic_type(
+        declared_type: Oid,
+        context_actual_type: Oid,
+        context_declared_type: Oid,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_coercion_pathway(
+        targetTypeId: Oid,
+        sourceTypeId: Oid,
+        ccontext: CoercionContext,
+        funcid: *mut Oid,
+    ) -> CoercionPathType;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_typmod_coercion_function(typeId: Oid, funcid: *mut Oid) -> CoercionPathType;
+}
 pub const BackslashQuoteType_BACKSLASH_QUOTE_OFF: BackslashQuoteType = 0;
 pub const BackslashQuoteType_BACKSLASH_QUOTE_ON: BackslashQuoteType = 1;
 pub const BackslashQuoteType_BACKSLASH_QUOTE_SAFE_ENCODING: BackslashQuoteType = 2;

--- a/pgx-pg-sys/src/pg13.rs
+++ b/pgx-pg-sys/src/pg13.rs
@@ -42400,6 +42400,177 @@ extern "C" {
         missing_ok: bool,
     );
 }
+pub type TYPCATEGORY = ::std::os::raw::c_char;
+pub const CoercionPathType_COERCION_PATH_NONE: CoercionPathType = 0;
+pub const CoercionPathType_COERCION_PATH_FUNC: CoercionPathType = 1;
+pub const CoercionPathType_COERCION_PATH_RELABELTYPE: CoercionPathType = 2;
+pub const CoercionPathType_COERCION_PATH_ARRAYCOERCE: CoercionPathType = 3;
+pub const CoercionPathType_COERCION_PATH_COERCEVIAIO: CoercionPathType = 4;
+pub type CoercionPathType = ::std::os::raw::c_uint;
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsBinaryCoercible(srctype: Oid, targettype: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsPreferredType(category: TYPCATEGORY, type_: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn TypeCategory(type_: Oid) -> TYPCATEGORY;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_target_type(
+        pstate: *mut ParseState,
+        expr: *mut Node,
+        exprtype: Oid,
+        targettype: Oid,
+        targettypmod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn can_coerce_type(
+        nargs: ::std::os::raw::c_int,
+        input_typeids: *const Oid,
+        target_typeids: *const Oid,
+        ccontext: CoercionContext,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        inputTypeId: Oid,
+        targetTypeId: Oid,
+        targetTypeMod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_domain(
+        arg: *mut Node,
+        baseTypeId: Oid,
+        baseTypeMod: int32,
+        typeId: Oid,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+        hideInputCoercion: bool,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_boolean(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type_typmod(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        targetTypmod: int32,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn parser_coercion_errposition(
+        pstate: *mut ParseState,
+        coerce_location: ::std::os::raw::c_int,
+        input_expr: *mut Node,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn select_common_type(
+        pstate: *mut ParseState,
+        exprs: *mut List,
+        context: *const ::std::os::raw::c_char,
+        which_expr: *mut *mut Node,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_common_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        context: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn verify_common_type(common_type: Oid, exprs: *mut List) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn enforce_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *mut Oid,
+        nargs: ::std::os::raw::c_int,
+        rettype: Oid,
+        allow_poly: bool,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_valid_polymorphic_signature(
+        ret_type: Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_valid_internal_signature(
+        ret_type: Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_coercion_pathway(
+        targetTypeId: Oid,
+        sourceTypeId: Oid,
+        ccontext: CoercionContext,
+        funcid: *mut Oid,
+    ) -> CoercionPathType;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_typmod_coercion_function(typeId: Oid, funcid: *mut Oid) -> CoercionPathType;
+}
 pub const BackslashQuoteType_BACKSLASH_QUOTE_OFF: BackslashQuoteType = 0;
 pub const BackslashQuoteType_BACKSLASH_QUOTE_ON: BackslashQuoteType = 1;
 pub const BackslashQuoteType_BACKSLASH_QUOTE_SAFE_ENCODING: BackslashQuoteType = 2;

--- a/pgx-pg-sys/src/pg14.rs
+++ b/pgx-pg-sys/src/pg14.rs
@@ -43472,6 +43472,185 @@ extern "C" {
         missing_ok: bool,
     );
 }
+pub type TYPCATEGORY = ::std::os::raw::c_char;
+pub const CoercionPathType_COERCION_PATH_NONE: CoercionPathType = 0;
+pub const CoercionPathType_COERCION_PATH_FUNC: CoercionPathType = 1;
+pub const CoercionPathType_COERCION_PATH_RELABELTYPE: CoercionPathType = 2;
+pub const CoercionPathType_COERCION_PATH_ARRAYCOERCE: CoercionPathType = 3;
+pub const CoercionPathType_COERCION_PATH_COERCEVIAIO: CoercionPathType = 4;
+pub type CoercionPathType = ::std::os::raw::c_uint;
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsBinaryCoercible(srctype: Oid, targettype: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsPreferredType(category: TYPCATEGORY, type_: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn TypeCategory(type_: Oid) -> TYPCATEGORY;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_target_type(
+        pstate: *mut ParseState,
+        expr: *mut Node,
+        exprtype: Oid,
+        targettype: Oid,
+        targettypmod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn can_coerce_type(
+        nargs: ::std::os::raw::c_int,
+        input_typeids: *const Oid,
+        target_typeids: *const Oid,
+        ccontext: CoercionContext,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        inputTypeId: Oid,
+        targetTypeId: Oid,
+        targetTypeMod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_domain(
+        arg: *mut Node,
+        baseTypeId: Oid,
+        baseTypeMod: int32,
+        typeId: Oid,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+        hideInputCoercion: bool,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_boolean(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type_typmod(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        targetTypmod: int32,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn parser_coercion_errposition(
+        pstate: *mut ParseState,
+        coerce_location: ::std::os::raw::c_int,
+        input_expr: *mut Node,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn select_common_type(
+        pstate: *mut ParseState,
+        exprs: *mut List,
+        context: *const ::std::os::raw::c_char,
+        which_expr: *mut *mut Node,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_common_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        context: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn verify_common_type(common_type: Oid, exprs: *mut List) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn select_common_typmod(
+        pstate: *mut ParseState,
+        exprs: *mut List,
+        common_type: Oid,
+    ) -> int32;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn enforce_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *mut Oid,
+        nargs: ::std::os::raw::c_int,
+        rettype: Oid,
+        allow_poly: bool,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_valid_polymorphic_signature(
+        ret_type: Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_valid_internal_signature(
+        ret_type: Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_coercion_pathway(
+        targetTypeId: Oid,
+        sourceTypeId: Oid,
+        ccontext: CoercionContext,
+        funcid: *mut Oid,
+    ) -> CoercionPathType;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_typmod_coercion_function(typeId: Oid, funcid: *mut Oid) -> CoercionPathType;
+}
 #[pgx_macros::pg_guard]
 extern "C" {
     pub fn get_rte_attribute_name(

--- a/pgx-pg-sys/src/pg15.rs
+++ b/pgx-pg-sys/src/pg15.rs
@@ -43799,6 +43799,185 @@ extern "C" {
         missing_ok: bool,
     );
 }
+pub type TYPCATEGORY = ::std::os::raw::c_char;
+pub const CoercionPathType_COERCION_PATH_NONE: CoercionPathType = 0;
+pub const CoercionPathType_COERCION_PATH_FUNC: CoercionPathType = 1;
+pub const CoercionPathType_COERCION_PATH_RELABELTYPE: CoercionPathType = 2;
+pub const CoercionPathType_COERCION_PATH_ARRAYCOERCE: CoercionPathType = 3;
+pub const CoercionPathType_COERCION_PATH_COERCEVIAIO: CoercionPathType = 4;
+pub type CoercionPathType = ::std::os::raw::c_uint;
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsBinaryCoercible(srctype: Oid, targettype: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn IsPreferredType(category: TYPCATEGORY, type_: Oid) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn TypeCategory(type_: Oid) -> TYPCATEGORY;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_target_type(
+        pstate: *mut ParseState,
+        expr: *mut Node,
+        exprtype: Oid,
+        targettype: Oid,
+        targettypmod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn can_coerce_type(
+        nargs: ::std::os::raw::c_int,
+        input_typeids: *const Oid,
+        target_typeids: *const Oid,
+        ccontext: CoercionContext,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        inputTypeId: Oid,
+        targetTypeId: Oid,
+        targetTypeMod: int32,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_domain(
+        arg: *mut Node,
+        baseTypeId: Oid,
+        baseTypeMod: int32,
+        typeId: Oid,
+        ccontext: CoercionContext,
+        cformat: CoercionForm,
+        location: ::std::os::raw::c_int,
+        hideInputCoercion: bool,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_boolean(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_specific_type_typmod(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        targetTypmod: int32,
+        constructName: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn parser_coercion_errposition(
+        pstate: *mut ParseState,
+        coerce_location: ::std::os::raw::c_int,
+        input_expr: *mut Node,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn select_common_type(
+        pstate: *mut ParseState,
+        exprs: *mut List,
+        context: *const ::std::os::raw::c_char,
+        which_expr: *mut *mut Node,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn coerce_to_common_type(
+        pstate: *mut ParseState,
+        node: *mut Node,
+        targetTypeId: Oid,
+        context: *const ::std::os::raw::c_char,
+    ) -> *mut Node;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn verify_common_type(common_type: Oid, exprs: *mut List) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn select_common_typmod(
+        pstate: *mut ParseState,
+        exprs: *mut List,
+        common_type: Oid,
+    ) -> int32;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> bool;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn enforce_generic_type_consistency(
+        actual_arg_types: *const Oid,
+        declared_arg_types: *mut Oid,
+        nargs: ::std::os::raw::c_int,
+        rettype: Oid,
+        allow_poly: bool,
+    ) -> Oid;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_valid_polymorphic_signature(
+        ret_type: Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn check_valid_internal_signature(
+        ret_type: Oid,
+        declared_arg_types: *const Oid,
+        nargs: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_coercion_pathway(
+        targetTypeId: Oid,
+        sourceTypeId: Oid,
+        ccontext: CoercionContext,
+        funcid: *mut Oid,
+    ) -> CoercionPathType;
+}
+#[pgx_macros::pg_guard]
+extern "C" {
+    pub fn find_typmod_coercion_function(typeId: Oid, funcid: *mut Oid) -> CoercionPathType;
+}
 #[pgx_macros::pg_guard]
 extern "C" {
     pub fn get_rte_attribute_name(

--- a/pgx-sql-entity-graph/Cargo.toml
+++ b/pgx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-sql-entity-graph"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgx`"
@@ -18,11 +18,11 @@ no-schema-generation = []
 seq-macro = "0.3"
 convert_case = "0.5.0"
 eyre = "0.6.8"
-petgraph = "0.6.2"
-proc-macro2 = { version = "1.0.50", features = [ "span-locations" ] }
+petgraph = "0.6.3"
+proc-macro2 = { version = "1.0.51", features = [ "span-locations" ] }
 quote = "1.0.23"
 regex = "1.7.1"
-syn = { version = "1.0.107", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "1.0.108", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 tracing = "0.1.37"
 tracing-error = "0.2.0"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgx'-based Postgres extensions"
@@ -35,16 +35,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
-once_cell = "1.17.0"
+once_cell = "1.17.1"
 libc = "0.2.139"
-pgx-macros = { path = "../pgx-macros", version = "=0.7.1" }
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.1" }
+pgx-macros = { path = "../pgx-macros", version = "=0.7.2" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.2" }
 postgres = "0.19.4"
 regex = "1.7.1"
 serde = "1.0.152"
-serde_json = "1.0.91"
+serde_json = "1.0.93"
 sysinfo = "0.27.7"
-time = "0.3.17"
+time = "0.3.19"
 eyre = "0.6.8"
 thiserror = "1.0"
 
@@ -55,4 +55,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 path = "../pgx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.7.1"
+version = "=0.7.2"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgx:  A Rust framework for creating Postgres extensions"
@@ -34,12 +34,12 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-macros = { path = "../pgx-macros", version = "=0.7.1" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.7.1" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.1" }
+pgx-macros = { path = "../pgx-macros", version = "=0.7.2" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.7.2" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.2" }
 
 # used to internally impl things
-once_cell = "1.17.0" # polyfill until std::lazy::OnceCell stabilizes
+once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes
 seq-macro = "0.3" # impls loops in macros
 uuid = { version = "1.3.0", features = [ "v4" ] } # PgLwLock and shmem
 
@@ -57,6 +57,6 @@ libc = "0.2.139" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0.152", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
-serde_json = "1.0.91" # everything JSON
-time = { version = "0.3.17", features = ["formatting", "parsing", "alloc", "macros"], optional = true }
+serde_json = "1.0.93" # everything JSON
+time = { version = "0.3.19", features = ["formatting", "parsing", "alloc", "macros"], optional = true }
 


### PR DESCRIPTION
This is pgx v0.7.2.  It contains quite a few bugfixes and API changes (some of which are breaking).

When updating please make sure to update your crate dependencies and also:

```shell
$ cargo install cargo-pgx --version 0.7.2 --locked
```

## API Changes

* Made `Date::to_unix_epoch_days()` public by @osawyerr in https://github.com/tcdi/pgx/pull/1039

* Mapping PG interval type by @mhov in https://github.com/tcdi/pgx/pull/629

* Cleanup `PgTrigger` such that its public API can now be safe. by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/1055

There's quite a bit of changes to trigger support.  `PgTrigger` is now parameterized with a lifetime and `#[pg_trigger]` functions will need to adapt to this.  Additionally, `#[pg_trigger]` functions must now return an `Option<PgHeapTuple>>` (or `Result<Option<PgHeapTuple>, E>`) as previously it wasn't possible to return a NULL tuple (ie, `Option::None`), indicating that the row being acted upon should not be modified.

* overhaul our Postgres Range support by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/1050

Range support has been changed quite a bit to be more ergonomic and provide conversion from Rust `std::ops::Range*` types.  Check out the new example in [pgx-examples/range/](pgx-examples/range).

* a better Error type when conversion from Date to time::Date doesn't work by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/1052

This is only relevant when the `pgx/time-crate` feature is used

## Correctness Issues

* By default, require superuser privileges to install a pgx extension by @vadim2404 in https://github.com/tcdi/pgx/pull/1056

This only impacts new extension crates made with `cargo pgx new`.  It's better that pgx assume the extension you're about to make is wildly unsafe and for you to change that assumption in its `extname.control` file if you disagree.

* Fix the `IntoDatum` implementations for both `pg_sys::Point` and `pg_sys::BOX` by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/1042

* Extend UTF-8 detection in PGX init and test by @sumerman in https://github.com/tcdi/pgx/pull/1041

## Bug Fixes

* fix for #797 aggregate schemas by @mhov in https://github.com/tcdi/pgx/pull/1027

* Fix issue #1032 by @eeeebbbbrrrr in https://github.com/tcdi/pgx/pull/1033

pgx extensions can now be built against Postgres forks, but you'll need to turn on the `pgx/unsafe-postgres` feature for your `pgx` dependency.

* Use SPITupleTable->numvals when available by @yrashk in https://github.com/tcdi/pgx/pull/1037

* Support in `FromDatum` for binary coercible types (including domain types) by @EdMcBane in https://github.com/tcdi/pgx/pull/1028

This allows slightly more automatic conversions between data types for `Spi`.  Especially when the Postgres type is a DOMAIN over something like TEXT and the desired Rust type is a String

* Remove plrust-related feature flags by @workingjubilee in https://github.com/tcdi/pgx/pull/1053, Some cleanups around postgrestd and memctx handling by @thomcc in https://github.com/tcdi/pgx/pull/1051

pgx no longer knows that it's being used with `postgrestd`

* fix: check root by uid by @skyzh in https://github.com/tcdi/pgx/pull/1044

`cargo pgx init` no longer assumes a user named "root" exists on the system

## Miscellaneous 

* support backtrace for Rust panic by @skyzh in https://github.com/tcdi/pgx/pull/1049

If you run Postgres or `cargo pgx run` with `RUST_BACKTRACE=1` set in the environment, then whenever pgx catches a panic, it'll include a full backtrace!

* Ensure the `libpq{,N}-dev` package is removed in CI by @thomcc in https://github.com/tcdi/pgx/pull/1034

* Fix outdated documentation for `pgx::name!` by @Smittyvb in https://github.com/tcdi/pgx/pull/1036

* Disable thin lto for dev builds by default in template by @JelteF in https://github.com/tcdi/pgx/pull/1035

* Respect `RUSTC`/`CARGO` environment variables, and handle calls through `cargo` in `cargo-pgx` and `pgx-test` by @thomcc in https://github.com/tcdi/pgx/pull/1038

* Fix some warnings when the time-crate feature is disabled by @thomcc in https://github.com/tcdi/pgx/pull/1054

## New Contributors
* @sumerman made their first contribution in https://github.com/tcdi/pgx/pull/1041
* @skyzh made their first contribution in https://github.com/tcdi/pgx/pull/1044
* @JelteF made their first contribution in https://github.com/tcdi/pgx/pull/1035
* @vadim2404 made their first contribution in https://github.com/tcdi/pgx/pull/1056

Thanks everyone!

**Full Changelog**: https://github.com/tcdi/pgx/compare/v0.7.1...0.7.2