### PR TITLE
Add safe quoting functions

### DIFF
--- a/pgx-tests/src/tests/spi_tests.rs
+++ b/pgx-tests/src/tests/spi_tests.rs
@@ -478,4 +478,34 @@ mod tests {
         // cidr is binary coercible to inet
         Spi::get_one::<pgx::Inet>("select '10.0.0.1/32'::cidr")
     }
+
+    #[pg_test]
+    fn test_quote_identifier() {
+        assert_eq!("unquoted", spi::quote_identifier("unquoted"));
+        assert_eq!(r#""actually-quoted""#, spi::quote_identifier("actually-quoted"));
+        assert_eq!(r#""quoted-string""#, spi::quote_identifier(String::from("quoted-string")));
+    }
+
+    #[pg_test]
+    fn test_quote_qualified_identifier() {
+        assert_eq!(
+            r#"unquoted."actually-quoted""#,
+            spi::quote_qualified_identifier("unquoted", "actually-quoted")
+        );
+        assert_eq!(
+            r#""actually-quoted".unquoted"#,
+            spi::quote_qualified_identifier("actually-quoted", "unquoted")
+        );
+        assert_eq!(
+            r#""actually-quoted1"."actually-quoted2""#,
+            spi::quote_qualified_identifier("actually-quoted1", "actually-quoted2")
+        );
+    }
+
+    #[pg_test]
+    fn test_quote_literal() {
+        assert_eq!("'quoted'", spi::quote_literal("quoted"));
+        assert_eq!("'quoted-with-''quotes'''", spi::quote_literal("quoted-with-'quotes'"));
+        assert_eq!("'quoted-string'", spi::quote_literal(String::from("quoted-string")));
+    }
 }

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -80,7 +80,8 @@ impl std::fmt::Display for SpiErrorCodes {
     }
 }
 
-/// A safe wrapper around pg_sys::quote_identifier
+/// A safe wrapper around [`pg_sys::quote_identifier`]. Returns a properly quoted identifier. For
+/// instance for a column or table name such as `"my-table-name"`
 pub fn quote_identifier<StringLike: AsRef<str>>(ident: StringLike) -> String {
     let ident_cstr = CString::new(ident.as_ref()).unwrap();
     // SAFETY: quote_identifier expects a null terminated string and returns one.
@@ -91,7 +92,9 @@ pub fn quote_identifier<StringLike: AsRef<str>>(ident: StringLike) -> String {
     quoted_cstr.to_str().unwrap().to_string()
 }
 
-/// A safe wrapper around pg_sys::quote_qualified_identifier
+/// A safe wrapper around [`pg_sys::quote_qualified_identifier`]. Returns a properly quoted name of
+/// the following format qualifier.ident. A common usecase is to qualify a table_name for example
+/// `"my schema"."my table"`
 pub fn quote_qualified_identifier<StringLike: AsRef<str>>(
     qualifier: StringLike,
     ident: StringLike,
@@ -107,7 +110,8 @@ pub fn quote_qualified_identifier<StringLike: AsRef<str>>(
     quoted_cstr.to_str().unwrap().to_string()
 }
 
-/// A safe wrapper around pg_sys::quote_literal_cstr
+/// A safe wrapper around [`pg_sys::quote_literal_cstr`]. Returns a properly quoted literal such as
+/// a `TEXT` literal like `'my string with spaces'`.
 pub fn quote_literal<StringLike: AsRef<str>>(literal: StringLike) -> String {
     let literal_cstr = CString::new(literal.as_ref()).unwrap();
     // SAFETY: quote_literal_cstr expects a null terminated string and returns one.

--- a/pgx/src/spi.rs
+++ b/pgx/src/spi.rs
@@ -80,6 +80,44 @@ impl std::fmt::Display for SpiErrorCodes {
     }
 }
 
+/// A safe wrapper around pg_sys::quote_identifier
+pub fn quote_identifier<StringLike: AsRef<str>>(ident: StringLike) -> String {
+    let ident_cstr = CString::new(ident.as_ref()).unwrap();
+    // SAFETY: quote_identifier expects a null terminated string and returns one.
+    let quoted_cstr = unsafe {
+        let quoted_ptr = pg_sys::quote_identifier(ident_cstr.as_ptr());
+        CStr::from_ptr(quoted_ptr)
+    };
+    quoted_cstr.to_str().unwrap().to_string()
+}
+
+/// A safe wrapper around pg_sys::quote_qualified_identifier
+pub fn quote_qualified_identifier<StringLike: AsRef<str>>(
+    qualifier: StringLike,
+    ident: StringLike,
+) -> String {
+    let qualifier_cstr = CString::new(qualifier.as_ref()).unwrap();
+    let ident_cstr = CString::new(ident.as_ref()).unwrap();
+    // SAFETY: quote_qualified_identifier expects null terminated strings and returns one.
+    let quoted_cstr = unsafe {
+        let quoted_ptr =
+            pg_sys::quote_qualified_identifier(qualifier_cstr.as_ptr(), ident_cstr.as_ptr());
+        CStr::from_ptr(quoted_ptr)
+    };
+    quoted_cstr.to_str().unwrap().to_string()
+}
+
+/// A safe wrapper around pg_sys::quote_literal_cstr
+pub fn quote_literal<StringLike: AsRef<str>>(literal: StringLike) -> String {
+    let literal_cstr = CString::new(literal.as_ref()).unwrap();
+    // SAFETY: quote_literal_cstr expects a null terminated string and returns one.
+    let quoted_cstr = unsafe {
+        let quoted_ptr = pg_sys::quote_literal_cstr(literal_cstr.as_ptr());
+        CStr::from_ptr(quoted_ptr)
+    };
+    quoted_cstr.to_str().unwrap().to_string()
+}
+
 #[derive(Debug)]
 pub struct UnknownVariant;
 


### PR DESCRIPTION
When building SQL that should be executed using SPI quoting identifiers
and literals is useful. Postgres provides C functions for this purpose,
but these are unsafe to call. This adds safe wrappers around those
functions.

Fixes #561

The only open question I have is:
Should this be part of the `spi` module, or should a new one be created? These
functions are not part of `spi` related files in the Postgres source code, but
issue #561 was tagged as `spi`. So, for now I put them there.
