### PR TITLE
Don't assume HTTPS_PROXY is HTTPS.

### DIFF
--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -194,10 +194,10 @@ fn download_postgres(pg_config: &PgConfig, pgx_home: &PathBuf) -> eyre::Result<P
     );
     let url = pg_config.url().expect("no url for pg_config").as_str();
     tracing::debug!(url = %url, "Fetching");
-    let http_client = if let Some((host, port)) =
-        for_url_str(pg_config.url().expect("no url for pg_config")).host_port()
+    let http_client = if let Some(proxy_url) =
+        for_url_str(pg_config.url().expect("no url for pg_config")).to_string()
     {
-        AgentBuilder::new().proxy(Proxy::new(format!("https://{host}:{port}"))?).build()
+        AgentBuilder::new().proxy(Proxy::new(proxy_url)?).build()
     } else {
         Agent::new()
     };

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -182,8 +182,7 @@ pub(crate) fn init_pgx(pgx: &Pgx, init: &Init) -> eyre::Result<()> {
 
 #[tracing::instrument(level = "error", skip_all, fields(pg_version = %pg_config.version()?, pgx_home))]
 fn download_postgres(pg_config: &PgConfig, pgx_home: &PathBuf) -> eyre::Result<PgConfig> {
-    use env_proxy::for_url_str;
-    use ureq::{Agent, AgentBuilder, Proxy};
+    use crate::command::build_agent_for_url;
 
     println!(
         "{} Postgres v{}.{} from {}",
@@ -194,13 +193,7 @@ fn download_postgres(pg_config: &PgConfig, pgx_home: &PathBuf) -> eyre::Result<P
     );
     let url = pg_config.url().expect("no url for pg_config").as_str();
     tracing::debug!(url = %url, "Fetching");
-    let http_client = if let Some(proxy_url) =
-        for_url_str(pg_config.url().expect("no url for pg_config")).to_string()
-    {
-        AgentBuilder::new().proxy(Proxy::new(proxy_url)?).build()
-    } else {
-        Agent::new()
-    };
+    let http_client = build_agent_for_url(url)?;
     let http_response = http_client.get(url).call()?;
     let status = http_response.status();
     tracing::trace!(status_code = %status, url = %url, "Fetched");

--- a/cargo-pgx/src/command/mod.rs
+++ b/cargo-pgx/src/command/mod.rs
@@ -7,6 +7,9 @@ All rights reserved.
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
 
+use env_proxy::for_url_str;
+use ureq::{Agent, AgentBuilder, Proxy};
+
 pub(crate) mod connect;
 pub(crate) mod cross;
 pub(crate) mod get;
@@ -22,3 +25,13 @@ pub(crate) mod status;
 pub(crate) mod stop;
 pub(crate) mod test;
 pub(crate) mod version;
+
+// Build a ureq::Agent by the given url. Requests from this agent are proxied if we have
+// set the HTTPS_PROXY/HTTP_PROXY environment variables.
+pub(self) fn build_agent_for_url(url: &str) -> eyre::Result<Agent> {
+    if let Some(proxy_url) = for_url_str(url).to_string() {
+        Ok(AgentBuilder::new().proxy(Proxy::new(proxy_url)?).build())
+    } else {
+        Ok(Agent::new())
+    }
+}

--- a/cargo-pgx/src/command/version.rs
+++ b/cargo-pgx/src/command/version.rs
@@ -10,13 +10,13 @@ pub(crate) fn pgx_default(supported_major_versions: &[u16]) -> eyre::Result<Pgx>
 }
 
 mod rss {
-    use env_proxy::for_url_str;
     use eyre::WrapErr;
     use owo_colors::OwoColorize;
     use pgx_pg_config::PgVersion;
     use serde_derive::Deserialize;
-    use ureq::{Agent, AgentBuilder, Proxy};
     use url::Url;
+
+    use crate::command::build_agent_for_url;
 
     pub(super) struct PostgreSQLVersionRss;
 
@@ -24,12 +24,7 @@ mod rss {
         pub(super) fn new(supported_major_versions: &[u16]) -> eyre::Result<Vec<PgVersion>> {
             static VERSIONS_RSS_URL: &str = "https://www.postgresql.org/versions.rss";
 
-            let http_client = if let Some(proxy_url) = for_url_str(VERSIONS_RSS_URL).to_string() {
-                AgentBuilder::new().proxy(Proxy::new(proxy_url)?).build()
-            } else {
-                Agent::new()
-            };
-
+            let http_client = build_agent_for_url(VERSIONS_RSS_URL)?;
             let response = http_client
                 .get(VERSIONS_RSS_URL)
                 .call()

--- a/cargo-pgx/src/command/version.rs
+++ b/cargo-pgx/src/command/version.rs
@@ -24,9 +24,8 @@ mod rss {
         pub(super) fn new(supported_major_versions: &[u16]) -> eyre::Result<Vec<PgVersion>> {
             static VERSIONS_RSS_URL: &str = "https://www.postgresql.org/versions.rss";
 
-            let http_client = if let Some((host, port)) = for_url_str(VERSIONS_RSS_URL).host_port()
-            {
-                AgentBuilder::new().proxy(Proxy::new(format!("https://{host}:{port}"))?).build()
+            let http_client = if let Some(proxy_url) = for_url_str(VERSIONS_RSS_URL).to_string() {
+                AgentBuilder::new().proxy(Proxy::new(proxy_url)?).build()
             } else {
                 Agent::new()
             };


### PR DESCRIPTION
cargo-pgx complains when I use it behind a proxy.

```
➜ export https_proxy=http://localhost:7890
➜ cargo pgx init
Error:
   0: Malformed proxy

Location:
   /home/v/.cargo/registry/src/mirrors.ustc.edu.cn-12df342d903acd47/cargo-pgx-0.7.2/src/command/version.rs:29

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

   0: cargo_pgx::command::init::execute
      at /home/v/.cargo/registry/src/mirrors.ustc.edu.cn-12df342d903acd47/cargo-pgx-0.7.2/src/command/init.rs:71

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

After debugging it, I noticed that cargo-pgx assumes the HTTPS_PROXY environment variable is an HTTPS URL. Actually, HTTPS_PROXY can be assigned with an HTTP URL. This patch helps fix it.