### PR TITLE
Add support for specifying GUC flags

### DIFF
--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -839,6 +839,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     Ok(stream)
 }
 
+/// Derives the `GucEnum` trait, so that normal Rust enums can be used as a GUC.
 #[proc_macro_derive(PostgresGucEnum, attributes(hidden))]
 pub fn postgres_guc_enum(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as syn::DeriveInput);

--- a/pgx-tests/src/tests/guc_tests.rs
+++ b/pgx-tests/src/tests/guc_tests.rs
@@ -25,6 +25,7 @@ mod tests {
             "test bool gucs",
             &GUC,
             GucContext::Userset,
+            GucFlags::default(),
         );
         assert_eq!(GUC.get(), true);
 
@@ -46,6 +47,7 @@ mod tests {
             -1,
             42,
             GucContext::Userset,
+            GucFlags::default(),
         );
         assert_eq!(GUC.get(), 42);
 
@@ -54,6 +56,25 @@ mod tests {
 
         Spi::run("SET test.int = 12").expect("SPI failed");
         assert_eq!(GUC.get(), 12);
+    }
+
+    #[pg_test]
+    fn test_mb_guc() {
+        static GUC: GucSetting<i32> = GucSetting::new(42);
+        GucRegistry::define_int_guc(
+            "test.megabytes",
+            "test megabytes guc",
+            "test megabytes guc",
+            &GUC,
+            -1,
+            42000,
+            GucContext::Userset,
+            GucFlags::UNIT_MB,
+        );
+        assert_eq!(GUC.get(), 42);
+
+        Spi::run("SET test.megabytes = '1GB'").expect("SPI failed");
+        assert_eq!(GUC.get(), 1024);
     }
 
     #[pg_test]
@@ -67,6 +88,7 @@ mod tests {
             -1.0f64,
             43.0f64,
             GucContext::Userset,
+            GucFlags::default(),
         );
         assert_eq!(GUC.get(), 42.42);
 
@@ -89,6 +111,7 @@ mod tests {
             "test string guc",
             &GUC,
             GucContext::Userset,
+            GucFlags::default(),
         );
         assert!(GUC.get().is_some());
         assert_eq!(GUC.get().unwrap(), "this is a test");
@@ -109,6 +132,7 @@ mod tests {
             "test string guc",
             &GUC,
             GucContext::Userset,
+            GucFlags::default(),
         );
         assert!(GUC.get().is_none());
 
@@ -134,6 +158,7 @@ mod tests {
             "test enum guc",
             &GUC,
             GucContext::Userset,
+            GucFlags::default(),
         );
         assert_eq!(GUC.get(), TestEnum::Two);
 


### PR DESCRIPTION
When creating GUCs they can be passed many flags to change their
behaviour. This PR adds support for most of those flags to `pgx`.

The following flags were not included for the following reasons:
1. `LIST_INPUT` & `LIST_QUOTE`: these require more thought, because the
   GUC becomes a list. Also `LIST_QUOTE` is not even allowed to be used
   by extensions, because of problems with `pg_dump`.
2. `GUC_NOT_IN_SAMPLE`: No extension GUC is listed in
   `postgresql.conf.sample` anyway.
3. `GUC_UNIT_MEMORY`, `GUC_UNIT_TIME` & `GUC_UNIT`: These are masks, not
   flags. So these should not be passed to the `define_xxx_guc` functions.

In passing adds some basic docs for all the items in the `guc` module.
