### PR TITLE
Remove several unnecessary deps from pgx-sql-entity-graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,7 +1482,6 @@ dependencies = [
  "petgraph",
  "proc-macro2",
  "quote",
- "seq-macro",
  "syn",
  "syntect",
  "unescape",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,13 +1482,9 @@ dependencies = [
  "petgraph",
  "proc-macro2",
  "quote",
- "regex",
  "seq-macro",
  "syn",
  "syntect",
- "tracing",
- "tracing-error",
- "tracing-subscriber",
  "unescape",
 ]
 

--- a/pgx-sql-entity-graph/Cargo.toml
+++ b/pgx-sql-entity-graph/Cargo.toml
@@ -21,12 +21,8 @@ eyre = "0.6.8"
 petgraph = "0.6.3"
 proc-macro2 = { version = "1.0.51", features = [ "span-locations" ] }
 quote = "1.0.23"
-regex = "1.7.1"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
-tracing = "0.1.37"
-tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 
 # colorized sql output
 atty = { version = "0.2.14", optional = true }

--- a/pgx-sql-entity-graph/Cargo.toml
+++ b/pgx-sql-entity-graph/Cargo.toml
@@ -15,7 +15,6 @@ syntax-highlighting = ["dep:syntect", "dep:owo-colors", "dep:atty"]
 no-schema-generation = []
 
 [dependencies]
-seq-macro = "0.3"
 convert_case = "0.6.0"
 eyre = "0.6.8"
 petgraph = "0.6.3"

--- a/pgx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgx-sql-entity-graph/src/aggregate/entity.rs
@@ -168,7 +168,6 @@ impl SqlGraphIdentifier for PgAggregateEntity {
 }
 
 impl ToSql for PgAggregateEntity {
-    #[tracing::instrument(level = "debug", err, skip(self, context), fields(identifier = %self.rust_identifier()))]
     fn to_sql(&self, context: &PgxSql) -> eyre::Result<String> {
         let self_index = context.aggregates[self];
         let mut optional_attributes = Vec::new();
@@ -472,7 +471,6 @@ impl ToSql for PgAggregateEntity {
                 + &optional_attributes_string
                 + if optional_attributes.len() == 0 { "" } else { "\n" },
         );
-        tracing::trace!(%sql);
         Ok(sql)
     }
 }

--- a/pgx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgx-sql-entity-graph/src/extension_sql/entity.rs
@@ -68,7 +68,6 @@ impl SqlGraphIdentifier for ExtensionSqlEntity {
 }
 
 impl ToSql for ExtensionSqlEntity {
-    #[tracing::instrument(level = "debug", skip(self, _context), fields(identifier = self.full_path))]
     fn to_sql(&self, _context: &PgxSql) -> eyre::Result<String> {
         let sql = format!(
             "\n\
@@ -115,7 +114,6 @@ impl ToSql for ExtensionSqlEntity {
             finalize = if self.finalize { "-- finalize\n" } else { "" },
             sql = self.sql,
         );
-        tracing::trace!(%sql);
         Ok(sql)
     }
 }

--- a/pgx-sql-entity-graph/src/lib.rs
+++ b/pgx-sql-entity-graph/src/lib.rs
@@ -190,7 +190,6 @@ impl SqlGraphIdentifier for SqlGraphEntity {
 }
 
 impl ToSql for SqlGraphEntity {
-    #[tracing::instrument(level = "debug", skip(self, context), fields(identifier = %self.rust_identifier()))]
     fn to_sql(&self, context: &PgxSql) -> eyre::Result<String> {
         match self {
             SqlGraphEntity::Schema(item) => {
@@ -205,23 +204,29 @@ impl ToSql for SqlGraphEntity {
                 if let Some(result) = item.to_sql_config.to_sql(self, context) {
                     return result;
                 }
-                if context.graph.neighbors_undirected(context.externs.get(item).unwrap().clone()).any(|neighbor| {
-                    let neighbor_item = &context.graph[neighbor];
-                    match neighbor_item {
-                        SqlGraphEntity::Type(PostgresTypeEntity { in_fn, in_fn_module_path, out_fn, out_fn_module_path, .. }) => {
-                            let is_in_fn = item.full_path.starts_with(in_fn_module_path) && item.full_path.ends_with(in_fn);
-                            if is_in_fn {
-                                tracing::trace!(r#type = %neighbor_item.dot_identifier(), "Skipping, is an in_fn.");
+                if context
+                    .graph
+                    .neighbors_undirected(context.externs.get(item).unwrap().clone())
+                    .any(|neighbor| {
+                        let neighbor_item = &context.graph[neighbor];
+                        match neighbor_item {
+                            SqlGraphEntity::Type(PostgresTypeEntity {
+                                in_fn,
+                                in_fn_module_path,
+                                out_fn,
+                                out_fn_module_path,
+                                ..
+                            }) => {
+                                let is_in_fn = item.full_path.starts_with(in_fn_module_path)
+                                    && item.full_path.ends_with(in_fn);
+                                let is_out_fn = item.full_path.starts_with(out_fn_module_path)
+                                    && item.full_path.ends_with(out_fn);
+                                is_in_fn || is_out_fn
                             }
-                            let is_out_fn = item.full_path.starts_with(out_fn_module_path) && item.full_path.ends_with(out_fn);
-                            if is_out_fn {
-                                tracing::trace!(r#type = %neighbor_item.dot_identifier(), "Skipping, is an out_fn.");
-                            }
-                            is_in_fn || is_out_fn
-                        },
-                        _ => false,
-                    }
-                }) {
+                            _ => false,
+                        }
+                    })
+                {
                     Ok(String::default())
                 } else {
                     item.to_sql(context)

--- a/pgx-sql-entity-graph/src/metadata/function_metadata.rs
+++ b/pgx-sql-entity-graph/src/metadata/function_metadata.rs
@@ -76,104 +76,112 @@ impl FunctionMetadata<(), ()> for unsafe fn() {
         FunctionMetadataEntity { arguments: vec![], retval: None, path: self.path() }
     }
 }
-seq_macro::seq!(I in 0..=32 {
-    #(
-        seq_macro::seq!(N in 0..=I {
-            impl<#(Input~N,)* Output> FunctionMetadata<(#(Input~N,)*), Output> for fn(#(Input~N,)*) -> Output
-            where
-                #(
-                    Input~N: SqlTranslatable,
-                )*
-                Output: SqlTranslatable,
-            {
-                fn entity(&self) -> FunctionMetadataEntity {
-                    let mut arguments = Vec::new();
-                    #(
-                        arguments.push({
-                            let marker: PhantomData<Input~N> = PhantomData;
-                            marker.entity()
-                        });
-                    )*
-                    FunctionMetadataEntity {
-                        arguments,
-                        retval: {
-                            let marker: PhantomData<Output> = PhantomData;
-                            Some(marker.entity())
-                        },
-                        path: self.path(),
-                    }
-                }
-            }
 
-            impl<#(Input~N,)* Output> FunctionMetadata<(#(Input~N,)*), Output> for unsafe fn(#(Input~N,)*) -> Output
-            where
-                #(
-                    Input~N: SqlTranslatable,
-                )*
-                Output: SqlTranslatable,
-            {
-                fn entity(&self) -> FunctionMetadataEntity {
-                    let mut arguments = Vec::new();
-                    #(
-                        arguments.push({
-                            let marker: PhantomData<Input~N> = PhantomData;
-                            marker.entity()
-                        });
-                    )*
-                    FunctionMetadataEntity {
-                        arguments,
-                        retval: {
-                            let marker: PhantomData<Output> = PhantomData;
-                            Some(marker.entity())
-                        },
-                        path: self.path(),
-                    }
+macro_rules! impl_fn {
+    ($($T:ident),* $(,)?) => {
+        impl<$($T: SqlTranslatable,)* Output: SqlTranslatable> FunctionMetadata<($($T,)*), Output> for fn($($T,)*) -> Output {
+            fn entity(&self) -> FunctionMetadataEntity {
+                FunctionMetadataEntity {
+                    arguments: vec![$(PhantomData::<$T>.entity()),+],
+                    retval: Some(PhantomData::<Output>.entity()),
+                    path: self.path(),
                 }
             }
-
-            impl<#(Input~N,)*> FunctionMetadata<(#(Input~N,)*), ()> for fn(#(Input~N,)*)
-            where
-                #(
-                    Input~N: SqlTranslatable,
-                )*
-            {
-                fn entity(&self) -> FunctionMetadataEntity {
-                    let mut arguments = Vec::new();
-                    #(
-                        arguments.push({
-                            let marker: PhantomData<Input~N> = PhantomData;
-                            marker.entity()
-                        });
-                    )*
-                    FunctionMetadataEntity {
-                        arguments,
-                        retval: None,
-                        path: self.path(),
-                    }
+        }
+        impl<$($T: SqlTranslatable,)* Output: SqlTranslatable> FunctionMetadata<($($T,)*), Output> for unsafe fn($($T,)*) -> Output {
+            fn entity(&self) -> FunctionMetadataEntity {
+                FunctionMetadataEntity {
+                    arguments: vec![$(PhantomData::<$T>.entity()),+],
+                    retval: Some(PhantomData::<Output>.entity()),
+                    path: self.path(),
                 }
             }
-
-            impl<#(Input~N,)*> FunctionMetadata<(#(Input~N,)*), ()> for unsafe fn(#(Input~N,)*)
-            where
-                #(
-                    Input~N: SqlTranslatable,
-                )*
-            {
-                fn entity(&self) -> FunctionMetadataEntity {
-                    let mut arguments = Vec::new();
-                    #(
-                        arguments.push({
-                            let marker: PhantomData<Input~N> = PhantomData;
-                            marker.entity()
-                        });
-                    )*
-                    FunctionMetadataEntity {
-                        arguments,
-                        retval: None,
-                        path: self.path(),
-                    }
+        }
+        impl<$($T: SqlTranslatable,)*> FunctionMetadata<($($T,)*), ()> for fn($($T,)*) {
+            fn entity(&self) -> FunctionMetadataEntity {
+                FunctionMetadataEntity {
+                    arguments: vec![$(PhantomData::<$T>.entity()),+],
+                    retval: None,
+                    path: self.path(),
                 }
             }
-        });
-    )*
-});
+        }
+        impl<$($T: SqlTranslatable,)*> FunctionMetadata<($($T,)*), ()> for unsafe fn($($T,)*) {
+            fn entity(&self) -> FunctionMetadataEntity {
+                FunctionMetadataEntity {
+                    arguments: vec![$(PhantomData::<$T>.entity()),+],
+                    retval: None,
+                    path: self.path(),
+                }
+            }
+        }
+    };
+}
+// empty tuples are above
+impl_fn!(T0);
+impl_fn!(T0, T1);
+impl_fn!(T0, T1, T2);
+impl_fn!(T0, T1, T2, T3);
+impl_fn!(T0, T1, T2, T3, T4);
+impl_fn!(T0, T1, T2, T3, T4, T5);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);
+impl_fn!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24, T25
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24, T25, T26
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24, T25, T26, T27
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24, T25, T26, T27, T28
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24, T25, T26, T27, T28, T29
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24, T25, T26, T27, T28, T29, T30
+);
+impl_fn!(
+    T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20,
+    T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31
+);

--- a/pgx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -74,11 +74,6 @@ impl SqlGraphIdentifier for PgExternEntity {
 }
 
 impl ToSql for PgExternEntity {
-    #[tracing::instrument(
-        level = "error",
-        skip(self, context),
-        fields(identifier = %self.rust_identifier()),
-    )]
     fn to_sql(&self, context: &PgxSql) -> eyre::Result<String> {
         let self_index = context.externs[self];
         let mut extern_attrs = self.extern_attrs.clone();
@@ -449,7 +444,6 @@ impl ToSql for PgExternEntity {
                 }
             },
         );
-        tracing::trace!(sql = %ext_sql);
 
         let rendered = if let Some(op) = &self.operator {
             let mut optionals = vec![];
@@ -602,7 +596,6 @@ impl ToSql for PgExternEntity {
                                                     maybe_comma = if optionals.len() >= 1 { "," } else { "" },
                                                     optionals = if !optionals.is_empty() { optionals.join(",\n") + "\n" } else { "".to_string() },
                                             );
-            tracing::trace!(sql = %operator_sql);
             ext_sql + &operator_sql
         } else {
             ext_sql

--- a/pgx-sql-entity-graph/src/pg_trigger/entity.rs
+++ b/pgx-sql-entity-graph/src/pg_trigger/entity.rs
@@ -31,11 +31,6 @@ impl From<PgTriggerEntity> for SqlGraphEntity {
 }
 
 impl ToSql for PgTriggerEntity {
-    #[tracing::instrument(
-        level = "error",
-        skip(self, context),
-        fields(identifier = %self.rust_identifier()),
-    )]
     fn to_sql(&self, context: &PgxSql) -> eyre::Result<String> {
         let self_index = context.triggers[self];
         let schema = context.schema_prefix_for(&self_index);

--- a/pgx-sql-entity-graph/src/postgres_enum/entity.rs
+++ b/pgx-sql-entity-graph/src/postgres_enum/entity.rs
@@ -64,7 +64,6 @@ impl SqlGraphIdentifier for PostgresEnumEntity {
 }
 
 impl ToSql for PostgresEnumEntity {
-    #[tracing::instrument(level = "debug", err, skip(self, context), fields(identifier = %self.rust_identifier()))]
     fn to_sql(&self, context: &PgxSql) -> eyre::Result<String> {
         let self_index = context.enums[self];
         let sql = format!(
@@ -88,7 +87,6 @@ impl ToSql for PostgresEnumEntity {
                 .join(",\n")
                 + "\n",
         );
-        tracing::trace!(%sql);
         Ok(sql)
     }
 }

--- a/pgx-sql-entity-graph/src/postgres_hash/entity.rs
+++ b/pgx-sql-entity-graph/src/postgres_hash/entity.rs
@@ -61,7 +61,6 @@ impl SqlGraphIdentifier for PostgresHashEntity {
 }
 
 impl ToSql for PostgresHashEntity {
-    #[tracing::instrument(level = "debug", err, skip(self, _context), fields(identifier = %self.rust_identifier()))]
     fn to_sql(&self, _context: &PgxSql) -> eyre::Result<String> {
         let sql = format!("\n\
                             -- {file}:{line}\n\
@@ -77,7 +76,6 @@ impl ToSql for PostgresHashEntity {
                           line = self.line,
                           fn_name = self.fn_name(),
         );
-        tracing::trace!(%sql);
         Ok(sql)
     }
 }

--- a/pgx-sql-entity-graph/src/postgres_ord/entity.rs
+++ b/pgx-sql-entity-graph/src/postgres_ord/entity.rs
@@ -81,7 +81,6 @@ impl SqlGraphIdentifier for PostgresOrdEntity {
 }
 
 impl ToSql for PostgresOrdEntity {
-    #[tracing::instrument(level = "debug", err, skip(self, _context), fields(identifier = %self.rust_identifier()))]
     fn to_sql(&self, _context: &PgxSql) -> eyre::Result<String> {
         let sql = format!("\n\
                             -- {file}:{line}\n\
@@ -101,7 +100,6 @@ impl ToSql for PostgresOrdEntity {
                           line = self.line,
                           cmp_fn_name = self.cmp_fn_name(),
         );
-        tracing::trace!(%sql);
         Ok(sql)
     }
 }

--- a/pgx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgx-sql-entity-graph/src/postgres_type/entity.rs
@@ -68,7 +68,6 @@ impl SqlGraphIdentifier for PostgresTypeEntity {
 }
 
 impl ToSql for PostgresTypeEntity {
-    #[tracing::instrument(level = "debug", err, skip(self, context), fields(identifier = %self.rust_identifier()))]
     fn to_sql(&self, context: &PgxSql) -> eyre::Result<String> {
         let self_index = context.types[self];
         let item_node = &context.graph[self_index];
@@ -109,9 +108,7 @@ impl ToSql for PostgresTypeEntity {
                 _ => None,
             })
             .ok_or_else(|| eyre!("Could not find in_fn graph entity."))?;
-        tracing::trace!(in_fn = ?in_fn_path, "Found matching `in_fn`");
         let in_fn_sql = in_fn.to_sql(context)?;
-        tracing::trace!(%in_fn_sql);
 
         let out_fn_module_path = if !item.out_fn_module_path.is_empty() {
             item.out_fn_module_path.clone()
@@ -139,9 +136,7 @@ impl ToSql for PostgresTypeEntity {
                 _ => None,
             })
             .ok_or_else(|| eyre!("Could not find out_fn graph entity."))?;
-        tracing::trace!(out_fn = ?out_fn_path, "Found matching `out_fn`");
         let out_fn_sql = out_fn.to_sql(context)?;
-        tracing::trace!(%out_fn_sql);
 
         let shell_type = format!(
             "\n\
@@ -155,7 +150,6 @@ impl ToSql for PostgresTypeEntity {
             line = item.line,
             name = item.name,
         );
-        tracing::trace!(sql = %shell_type);
 
         let materialized_type = format! {
             "\n\
@@ -180,7 +174,6 @@ impl ToSql for PostgresTypeEntity {
             out_fn = item.out_fn,
             out_fn_path = out_fn_path,
         };
-        tracing::trace!(sql = %materialized_type);
 
         Ok(shell_type + "\n" + &in_fn_sql + "\n" + &out_fn_sql + "\n" + &materialized_type)
     }

--- a/pgx-sql-entity-graph/src/schema/entity.rs
+++ b/pgx-sql-entity-graph/src/schema/entity.rs
@@ -51,7 +51,6 @@ impl SqlGraphIdentifier for SchemaEntity {
 }
 
 impl ToSql for SchemaEntity {
-    #[tracing::instrument(level = "debug", err, skip(self, _context), fields(identifier = %self.rust_identifier()))]
     fn to_sql(&self, _context: &PgxSql) -> eyre::Result<String> {
         let sql = format!(
             "\n\
@@ -63,7 +62,6 @@ impl ToSql for SchemaEntity {
             line = self.line,
             module_path = self.module_path,
         );
-        tracing::trace!(%sql);
         Ok(sql)
     }
 }


### PR DESCRIPTION
- `regex`: totally unused.
- `tracing-{error,subscriber}`: also totally unused.
- `tracing`: not set up in a way where it can possibly work (used from a different cdylib than what configures tracing, never enabled even if that wasn't the case), and nobody noticed, so doesn't seem worth keeping around. If we move this code into something else where the logging would work and be more useful, I'll go back to the old commits prior to these ones and grab the logging.
- `seq-macro`: nested proc macro build and invocation in a proc-macro crate is a big costjust to avoid a few lines of boilerplate.

Leads to modest improvements for plrust build speed and plrust workdir per-build disk usage. (The fundamental issue where plrust rebuilds way more than it needs is not caused by any of this, though)