### PR TITLE
Update version to 0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgx"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "pgx-sql-entity-graph",
  "proc-macro2",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "dirs",
  "eyre",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-sql-entity-graph"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "atty",
  "convert_case",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/cargo-pgx/Cargo.toml
+++ b/cargo-pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgx"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgx' to make Postgres extension development easy"
@@ -23,8 +23,8 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.3" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.3" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.4" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.4" }
 prettyplease = "0.1.24"
 proc-macro2 = { version = "1.0.52", features = [ "span-locations" ] }
 quote = "1.0.26"

--- a/cargo-pgx/src/templates/cargo_toml
+++ b/cargo-pgx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.3"
+pgx = "=0.7.4"
 
 [dev-dependencies]
-pgx-tests = "=0.7.3"
+pgx-tests = "=0.7.4"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.3"
+pgx = "=0.7.4"
 
 [dev-dependencies]
-pgx-tests = "=0.7.3"
+pgx-tests = "=0.7.4"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgx-macros/Cargo.toml
+++ b/pgx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-macros"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.3" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.4" }
 proc-macro2 = "1.0.52"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-pg-config/Cargo.toml
+++ b/pgx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-config"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgx'"

--- a/pgx-pg-sys/Cargo.toml
+++ b/pgx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-pg-sys"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.8.0"
-pgx-macros = { path = "../pgx-macros/", version = "=0.7.3" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph/", version = "=0.7.3" }
+pgx-macros = { path = "../pgx-macros/", version = "=0.7.4" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph/", version = "=0.7.4" }
 serde = { version = "1.0.156", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.7.3" }
+pgx-pg-config= { path = "../pgx-pg-config/", version = "=0.7.4" }
 proc-macro2 = "1.0.52"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgx-sql-entity-graph/Cargo.toml
+++ b/pgx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-sql-entity-graph"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgx`"

--- a/pgx-tests/Cargo.toml
+++ b/pgx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx-tests"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgx'-based Postgres extensions"
@@ -37,8 +37,8 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.17.1"
 libc = "0.2.140"
-pgx-macros = { path = "../pgx-macros", version = "=0.7.3" }
-pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.3" }
+pgx-macros = { path = "../pgx-macros", version = "=0.7.4" }
+pgx-pg-config = { path = "../pgx-pg-config", version = "=0.7.4" }
 postgres = "0.19.4"
 regex = "1.7.1"
 serde = "1.0.156"
@@ -55,4 +55,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 path = "../pgx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.7.3"
+version = "=0.7.4"

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgx:  A Rust framework for creating Postgres extensions"
@@ -34,9 +34,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgx-macros = { path = "../pgx-macros", version = "=0.7.3" }
-pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.7.3" }
-pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.3" }
+pgx-macros = { path = "../pgx-macros", version = "=0.7.4" }
+pgx-pg-sys = { path = "../pgx-pg-sys", version = "=0.7.4" }
+pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.4" }
 
 # used to internally impl things
 once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
This is pgx v0.7.4.  It is a very minor update.

As always, when upgrading please install the latest `cargo-pgx` like so:

```shell
$ cargo install cargo-pgx --locked
```

## What's Changed

* Make ErrorReportWithLevel::detail_with_backtrace an Option<String> by @ewencp in https://github.com/tcdi/pgx/pull/1071
* Remove several unnecessary deps from pgx-sql-entity-graph by @thomcc in https://github.com/tcdi/pgx/pull/1070
* Upgrade dependencies 5e02e7ae7799fc61b6c3af0aa04835dfb24f1041

**Full Changelog**: https://github.com/tcdi/pgx/compare/v0.7.3...v0.7.4