### PR TITLE
Avoid some slow HashMap usage where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "enum-map"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "988f0d17a0fa38291e5f41f71ea8d46a5d5497b9054d5a759fae2cbb819f2356"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4da76b3b6116d758c7ba93f7ec6a35d2e2cf24feda76c6e38a375f4d5c59f2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_proxy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1427,7 @@ dependencies = [
  "atomic-traits",
  "bitflags",
  "bitvec",
+ "enum-map",
  "heapless",
  "libc",
  "once_cell",

--- a/pgx/Cargo.toml
+++ b/pgx/Cargo.toml
@@ -42,6 +42,7 @@ pgx-sql-entity-graph = { path = "../pgx-sql-entity-graph", version = "=0.7.4" }
 once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes
 seq-macro = "0.3" # impls loops in macros
 uuid = { version = "1.3.0", features = [ "v4" ] } # PgLwLock and shmem
+enum-map = "2.4.2"
 
 # error handling and logging
 thiserror = "1.0"


### PR DESCRIPTION
Because I was a little bit concerned about HashMap usage after the most recent postgrestd PR, I checked if we had some in `pgx`. Neither of these were concerning uses of `HashMap` from that perspective, but they... would be expected to have bad performance. They were both both maps which seem to use densely packed small integers as keys, so they can be replaced by vec/array.

This does that, by using `EnumMap<K, Option<V>>` in one place, and just a vector and offset in the other.

My one concern is if `SpiHeapTupleData`'s "map" needs to allow for being expanded after construction (specifically, if `TupleDescData::natts` can increase while the `SpiHeapTupleData` is alive). This doesn't seem to be the case (at least, we don't really handle it properly if it is), but it would mean my change to `set_by_ordinal` is probably wrong.