### PR TITLE
Allow `clippy::no_mangle_with_rust_abi` in the entity graph

### DIFF
--- a/pgx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgx-sql-entity-graph/src/aggregate/mod.rs
@@ -633,6 +633,7 @@ impl ToEntityGraphTokens for PgAggregate {
         quote! {
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 let submission = ::pgx::pgx_sql_entity_graph::PgAggregateEntity {
                     full_path: ::core::any::type_name::<#target_ident>(),

--- a/pgx-sql-entity-graph/src/extension_sql/mod.rs
+++ b/pgx-sql-entity-graph/src/extension_sql/mod.rs
@@ -98,6 +98,7 @@ impl ToEntityGraphTokens for ExtensionSqlFile {
         quote! {
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;
@@ -194,6 +195,7 @@ impl ToEntityGraphTokens for ExtensionSql {
             syn::Ident::new(&format!("__pgx_internals_sql_{}", name.value()), Span::call_site());
         quote! {
             #[no_mangle]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;

--- a/pgx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_extern/mod.rs
@@ -308,6 +308,7 @@ impl PgExtern {
         quote_spanned! { self.func.sig.span() =>
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 #[allow(unused_imports)]

--- a/pgx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -123,6 +123,7 @@ impl ToEntityGraphTokens for PgTrigger {
         quote! {
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 use core::any::TypeId;
                 extern crate alloc;

--- a/pgx-sql-entity-graph/src/postgres_enum/mod.rs
+++ b/pgx-sql-entity-graph/src/postgres_enum/mod.rs
@@ -139,6 +139,7 @@ impl ToEntityGraphTokens for PostgresEnum {
 
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;

--- a/pgx-sql-entity-graph/src/postgres_hash/mod.rs
+++ b/pgx-sql-entity-graph/src/postgres_hash/mod.rs
@@ -104,6 +104,7 @@ impl ToEntityGraphTokens for PostgresHash {
         quote! {
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 use core::any::TypeId;
                 extern crate alloc;

--- a/pgx-sql-entity-graph/src/postgres_ord/mod.rs
+++ b/pgx-sql-entity-graph/src/postgres_ord/mod.rs
@@ -105,6 +105,7 @@ impl ToEntityGraphTokens for PostgresOrd {
         quote! {
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 use core::any::TypeId;
                 extern crate alloc;

--- a/pgx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgx-sql-entity-graph/src/postgres_type/mod.rs
@@ -156,6 +156,7 @@ impl ToEntityGraphTokens for PostgresType {
 
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;

--- a/pgx-sql-entity-graph/src/schema/mod.rs
+++ b/pgx-sql-entity-graph/src/schema/mod.rs
@@ -83,6 +83,7 @@ impl Schema {
         quote! {
             #[no_mangle]
             #[doc(hidden)]
+            #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgx::pgx_sql_entity_graph::SqlGraphEntity {
                 extern crate alloc;
                 use alloc::vec::Vec;


### PR DESCRIPTION
TBH, we really should be using `extern "C"` for these (#892), but anyway...