### PR TITLE
Make `Array::as_slice` unsafe

### DIFF
--- a/pgx-tests/src/tests/array_tests.rs
+++ b/pgx-tests/src/tests/array_tests.rs
@@ -37,13 +37,13 @@ fn sum_array_i64(values: Array<i64>) -> i64 {
 #[pg_extern(name = "sum_array_sliced")]
 #[allow(deprecated)]
 fn sum_array_i32_sliced(values: Array<i32>) -> i32 {
-    values.as_slice().iter().sum()
+    unsafe { values.as_slice() }.iter().sum()
 }
 
 #[pg_extern(name = "sum_array_sliced")]
 #[allow(deprecated)]
 fn sum_array_i64_sliced(values: Array<i64>) -> i64 {
-    values.as_slice().iter().sum()
+    unsafe { values.as_slice() }.iter().sum()
 }
 
 #[pg_extern]
@@ -54,7 +54,7 @@ fn count_true(values: Array<bool>) -> i32 {
 #[pg_extern]
 #[allow(deprecated)]
 fn count_true_sliced(values: Array<bool>) -> i32 {
-    values.as_slice().iter().filter(|b| **b).count() as i32
+    unsafe { values.as_slice() }.iter().filter(|b| **b).count() as i32
 }
 
 #[pg_extern]
@@ -153,13 +153,13 @@ fn arr_mapped_vec(arr: Array<i32>) -> Vec<i32> {
 #[pg_extern]
 #[allow(deprecated)]
 fn arr_into_vec(arr: Array<i32>) -> Vec<i32> {
-    arr.as_slice().to_vec()
+    unsafe { arr.as_slice() }.to_vec()
 }
 
 #[pg_extern]
 #[allow(deprecated)]
 fn arr_sort_uniq(arr: Array<i32>) -> Vec<i32> {
-    let mut v: Vec<i32> = arr.as_slice().into();
+    let mut v: Vec<i32> = unsafe { arr.as_slice() }.into();
     v.sort();
     v.dedup();
     v

--- a/pgx-tests/src/tests/heap_tuple.rs
+++ b/pgx-tests/src/tests/heap_tuple.rs
@@ -128,7 +128,7 @@ mod arguments {
             let dogs: pgx::VariadicArray<PgHeapTuple<AllocatedByRust>> = dogs;
 
             let mut names = Vec::with_capacity(dogs.len());
-            for dog in dogs.as_slice() {
+            for dog in unsafe { dogs.as_slice() } {
                 let name = dog.get_by_name("name").unwrap().unwrap();
                 names.push(name);
             }

--- a/pgx/src/datum/array.rs
+++ b/pgx/src/datum/array.rs
@@ -210,7 +210,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
         even `unsafe fn as_slice(&self) -> &[T]` is not sound for all `&[T]`\n\
         if you are sure your usage is sound, consider RawArray"
     )]
-    pub fn as_slice(&self) -> &[T] {
+    pub unsafe fn as_slice(&self) -> &[T] {
         const DATUM_SIZE: usize = mem::size_of::<pg_sys::Datum>();
         if self.null_slice.any() {
             panic!("null detected: can't expose potentially uninit data as a slice!")
@@ -300,7 +300,7 @@ impl<'a, T: FromDatum> VariadicArray<'a, T> {
         if you are sure your usage is sound, consider RawArray"
     )]
     #[allow(deprecated)]
-    pub fn as_slice(&self) -> &[T] {
+    pub unsafe fn as_slice(&self) -> &[T] {
         self.0.as_slice()
     }
 


### PR DESCRIPTION
I happened to stumble across this, and it seems kind of bad. Making it unsafe would at least stop it from being usable in `plrust`, although IDK if that's currently possible anyway.