### PR TITLE
Use a slice instead of a vec in direct_function_call and related functions

### DIFF
--- a/pgx-tests/src/tests/anyarray_tests.rs
+++ b/pgx-tests/src/tests/anyarray_tests.rs
@@ -12,7 +12,7 @@ use pgx::{direct_function_call, AnyArray, IntoDatum, Json};
 
 #[pg_extern]
 fn anyarray_arg(array: AnyArray) -> Json {
-    unsafe { direct_function_call::<Json>(pg_sys::array_to_json, vec![array.into_datum()]) }
+    unsafe { direct_function_call::<Json>(pg_sys::array_to_json, &[array.into_datum()]) }
         .expect("conversion to json returned null")
 }
 

--- a/pgx-tests/src/tests/fcinfo_tests.rs
+++ b/pgx-tests/src/tests/fcinfo_tests.rs
@@ -185,10 +185,8 @@ mod tests {
     #[pg_test]
     unsafe fn test_takes_i16() {
         let input = 42i16;
-        let result = direct_pg_extern_function_call::<i16>(
-            super::takes_i16_wrapper,
-            vec![input.into_datum()],
-        );
+        let result =
+            direct_pg_extern_function_call::<i16>(super::takes_i16_wrapper, &[input.into_datum()]);
         let result = result.expect("result is NULL");
         assert_eq!(result, input);
     }
@@ -196,10 +194,8 @@ mod tests {
     #[pg_test]
     unsafe fn test_takes_i32() {
         let input = 42i32;
-        let result = direct_pg_extern_function_call::<i32>(
-            super::takes_i32_wrapper,
-            vec![input.into_datum()],
-        );
+        let result =
+            direct_pg_extern_function_call::<i32>(super::takes_i32_wrapper, &[input.into_datum()]);
         let result = result.expect("result is NULL");
         assert_eq!(result, input);
     }
@@ -207,10 +203,8 @@ mod tests {
     #[pg_test]
     unsafe fn test_takes_i64() {
         let input = 42i64;
-        let result = direct_pg_extern_function_call::<i64>(
-            super::takes_i64_wrapper,
-            vec![input.into_datum()],
-        );
+        let result =
+            direct_pg_extern_function_call::<i64>(super::takes_i64_wrapper, &[input.into_datum()]);
         let result = result.expect("result is NULL");
         assert_eq!(result, input);
     }
@@ -220,7 +214,7 @@ mod tests {
         let input = true;
         let result = direct_pg_extern_function_call::<bool>(
             super::takes_bool_wrapper,
-            vec![input.into_datum()],
+            &[input.into_datum()],
         );
         let result = result.expect("result is NULL");
         assert_eq!(result, input);
@@ -229,10 +223,8 @@ mod tests {
     #[pg_test]
     unsafe fn test_takes_f32() {
         let input = 42.424_244;
-        let result = direct_pg_extern_function_call::<f32>(
-            super::takes_f32_wrapper,
-            vec![input.into_datum()],
-        );
+        let result =
+            direct_pg_extern_function_call::<f32>(super::takes_f32_wrapper, &[input.into_datum()]);
         let result = result.expect("result is NULL");
         assert!(result.eq(&input));
     }
@@ -240,10 +232,8 @@ mod tests {
     #[pg_test]
     unsafe fn test_takes_f64() {
         let input = 42.424_242_424_242f64;
-        let result = direct_pg_extern_function_call::<f64>(
-            super::takes_f64_wrapper,
-            vec![input.into_datum()],
-        );
+        let result =
+            direct_pg_extern_function_call::<f64>(super::takes_f64_wrapper, &[input.into_datum()]);
         let result = result.expect("result is NULL");
         assert!(result.eq(&input));
     }
@@ -262,7 +252,7 @@ mod tests {
 
     #[pg_test]
     unsafe fn test_takes_option_with_null_arg() {
-        let result = direct_pg_extern_function_call::<i32>(super::takes_option_wrapper, vec![None]);
+        let result = direct_pg_extern_function_call::<i32>(super::takes_option_wrapper, &[None]);
         assert_eq!(-1, result.expect("result is NULL"))
     }
 
@@ -271,7 +261,7 @@ mod tests {
         let input = 42i32;
         let result = direct_pg_extern_function_call::<i32>(
             super::takes_option_wrapper,
-            vec![input.into_datum()],
+            &[input.into_datum()],
         );
         let result = result.expect("result is NULL");
         assert_eq!(result, input);
@@ -280,10 +270,8 @@ mod tests {
     #[pg_test]
     unsafe fn test_takes_str() {
         let input = "this is a test";
-        let result = direct_pg_extern_function_call::<&str>(
-            super::takes_str_wrapper,
-            vec![input.into_datum()],
-        );
+        let result =
+            direct_pg_extern_function_call::<&str>(super::takes_str_wrapper, &[input.into_datum()]);
         let result = result.expect("result is NULL");
         assert_eq!(result, input);
     }
@@ -293,7 +281,7 @@ mod tests {
         let input = "this is a test".to_string();
         let result = direct_pg_extern_function_call::<String>(
             super::takes_str_wrapper,
-            vec![input.clone().into_datum()],
+            &[input.clone().into_datum()],
         );
         let result = result.expect("result is NULL");
         assert_eq!(result, input);
@@ -301,13 +289,13 @@ mod tests {
 
     #[pg_test]
     unsafe fn test_returns_some() {
-        let result = direct_pg_extern_function_call::<i32>(super::returns_some_wrapper, vec![]);
+        let result = direct_pg_extern_function_call::<i32>(super::returns_some_wrapper, &[]);
         assert!(result.is_some());
     }
 
     #[pg_test]
     unsafe fn test_returns_none() {
-        let result = direct_pg_extern_function_call::<i32>(super::returns_none_wrapper, vec![]);
+        let result = direct_pg_extern_function_call::<i32>(super::returns_none_wrapper, &[]);
         assert!(result.is_none())
     }
 

--- a/pgx/src/datum/inet.rs
+++ b/pgx/src/datum/inet.rs
@@ -98,7 +98,7 @@ impl FromDatum for Inet {
         if is_null {
             None
         } else {
-            let cstr = direct_function_call::<&CStr>(pg_sys::inet_out, vec![Some(datum)]);
+            let cstr = direct_function_call::<&CStr>(pg_sys::inet_out, &[Some(datum)]);
             Some(Inet(
                 cstr.unwrap().to_str().expect("unable to convert &cstr inet into &str").to_owned(),
             ))
@@ -109,9 +109,7 @@ impl FromDatum for Inet {
 impl IntoDatum for Inet {
     fn into_datum(self) -> Option<pg_sys::Datum> {
         let cstr = alloc::ffi::CString::new(self.0).expect("failed to convert inet into CString");
-        unsafe {
-            direct_function_call_as_datum(pg_sys::inet_in, vec![cstr.as_c_str().into_datum()])
-        }
+        unsafe { direct_function_call_as_datum(pg_sys::inet_in, &[cstr.as_c_str().into_datum()]) }
     }
 
     fn type_oid() -> pg_sys::Oid {

--- a/pgx/src/datum/interval.rs
+++ b/pgx/src/datum/interval.rs
@@ -166,7 +166,7 @@ impl serde::Serialize for Interval {
             let interval = self.0.as_ptr();
             let cstr = direct_function_call::<&std::ffi::CStr>(
                 pg_sys::interval_out,
-                vec![Some(pg_sys::Datum::from(interval as *const _))],
+                &[Some(pg_sys::Datum::from(interval as *const _))],
             )
             .expect("failed to convert interval to a cstring");
 

--- a/pgx/src/datum/json.rs
+++ b/pgx/src/datum/json.rs
@@ -65,7 +65,7 @@ impl FromDatum for JsonB {
 
             let cstr = direct_function_call::<&core::ffi::CStr>(
                 pg_sys::jsonb_out,
-                vec![Some(detoasted.into())],
+                &[Some(detoasted.into())],
             )
             .expect("failed to convert jsonb to a cstring");
 
@@ -138,9 +138,7 @@ impl IntoDatum for JsonB {
         let cstring =
             alloc::ffi::CString::new(string).expect("string version of jsonb is not valid UTF8");
 
-        unsafe {
-            direct_function_call_as_datum(pg_sys::jsonb_in, vec![Some(cstring.as_ptr().into())])
-        }
+        unsafe { direct_function_call_as_datum(pg_sys::jsonb_in, &[Some(cstring.as_ptr().into())]) }
     }
 
     fn type_oid() -> pg_sys::Oid {

--- a/pgx/src/datum/numeric.rs
+++ b/pgx/src/datum/numeric.rs
@@ -68,7 +68,7 @@ impl Drop for AnyNumeric {
 impl Display for AnyNumeric {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         let numeric_out = unsafe {
-            direct_function_call::<&CStr>(pg_sys::numeric_out, vec![self.as_datum()]).unwrap()
+            direct_function_call::<&CStr>(pg_sys::numeric_out, &[self.as_datum()]).unwrap()
         };
         let s = numeric_out.to_str().expect("numeric_out is not a valid UTF8 string");
         fmt.pad(s)
@@ -130,42 +130,41 @@ impl AnyNumeric {
 
     /// The absolute value of this [`AnyNumeric`]
     pub fn abs(&self) -> Self {
-        unsafe { direct_function_call(pg_sys::numeric_abs, vec![self.as_datum()]).unwrap() }
+        unsafe { direct_function_call(pg_sys::numeric_abs, &[self.as_datum()]).unwrap() }
     }
 
     /// Compute the logarithm of this [`AnyNumeric`] in the given base
     pub fn log(&self, base: AnyNumeric) -> Self {
         unsafe {
-            direct_function_call(pg_sys::numeric_log, vec![self.as_datum(), base.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_log, &[self.as_datum(), base.as_datum()]).unwrap()
         }
     }
 
     /// Raise `e` to the power of `x`
     pub fn exp(x: &AnyNumeric) -> Self {
-        unsafe { direct_function_call(pg_sys::numeric_exp, vec![x.as_datum()]).unwrap() }
+        unsafe { direct_function_call(pg_sys::numeric_exp, &[x.as_datum()]).unwrap() }
     }
 
     /// Compute the square root of this [`AnyNumeric`]
     pub fn sqrt(&self) -> Self {
-        unsafe { direct_function_call(pg_sys::numeric_sqrt, vec![self.as_datum()]).unwrap() }
+        unsafe { direct_function_call(pg_sys::numeric_sqrt, &[self.as_datum()]).unwrap() }
     }
 
     /// Return the smallest integer greater than or equal to this [`AnyNumeric`]
     pub fn ceil(&self) -> Self {
-        unsafe { direct_function_call(pg_sys::numeric_ceil, vec![self.as_datum()]).unwrap() }
+        unsafe { direct_function_call(pg_sys::numeric_ceil, &[self.as_datum()]).unwrap() }
     }
 
     /// Return the largest integer equal to or less than this [`AnyNumeric`]
     pub fn floor(&self) -> Self {
-        unsafe { direct_function_call(pg_sys::numeric_floor, vec![self.as_datum()]).unwrap() }
+        unsafe { direct_function_call(pg_sys::numeric_floor, &[self.as_datum()]).unwrap() }
     }
 
     /// Calculate the greatest common divisor of this an another [`AnyNumeric`]
     #[cfg(not(any(feature = "pg11", feature = "pg12")))]
     pub fn gcd(&self, n: &AnyNumeric) -> AnyNumeric {
         unsafe {
-            direct_function_call(pg_sys::numeric_gcd, vec![self.as_datum(), n.as_datum()]).unwrap()
+            direct_function_call(pg_sys::numeric_gcd, &[self.as_datum(), n.as_datum()]).unwrap()
         }
     }
 

--- a/pgx/src/datum/numeric_support/cmp.rs
+++ b/pgx/src/datum/numeric_support/cmp.rs
@@ -7,16 +7,14 @@ impl PartialEq<AnyNumeric> for AnyNumeric {
     #[inline]
     fn eq(&self, other: &AnyNumeric) -> bool {
         unsafe {
-            direct_function_call(pg_sys::numeric_eq, vec![self.as_datum(), other.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_eq, &[self.as_datum(), other.as_datum()]).unwrap()
         }
     }
 
     #[inline]
     fn ne(&self, other: &AnyNumeric) -> bool {
         unsafe {
-            direct_function_call(pg_sys::numeric_ne, vec![self.as_datum(), other.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_ne, &[self.as_datum(), other.as_datum()]).unwrap()
         }
     }
 }
@@ -34,32 +32,28 @@ impl PartialOrd for AnyNumeric {
     #[inline]
     fn lt(&self, other: &Self) -> bool {
         unsafe {
-            direct_function_call(pg_sys::numeric_lt, vec![self.as_datum(), other.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_lt, &[self.as_datum(), other.as_datum()]).unwrap()
         }
     }
 
     #[inline]
     fn le(&self, other: &Self) -> bool {
         unsafe {
-            direct_function_call(pg_sys::numeric_le, vec![self.as_datum(), other.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_le, &[self.as_datum(), other.as_datum()]).unwrap()
         }
     }
 
     #[inline]
     fn gt(&self, other: &Self) -> bool {
         unsafe {
-            direct_function_call(pg_sys::numeric_gt, vec![self.as_datum(), other.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_gt, &[self.as_datum(), other.as_datum()]).unwrap()
         }
     }
 
     #[inline]
     fn ge(&self, other: &Self) -> bool {
         unsafe {
-            direct_function_call(pg_sys::numeric_ge, vec![self.as_datum(), other.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_ge, &[self.as_datum(), other.as_datum()]).unwrap()
         }
     }
 }
@@ -68,8 +62,7 @@ impl Ord for AnyNumeric {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         let cmp: i32 = unsafe {
-            direct_function_call(pg_sys::numeric_cmp, vec![self.as_datum(), other.as_datum()])
-                .unwrap()
+            direct_function_call(pg_sys::numeric_cmp, &[self.as_datum(), other.as_datum()]).unwrap()
         };
         if cmp < 0 {
             Ordering::Less

--- a/pgx/src/datum/numeric_support/convert.rs
+++ b/pgx/src/datum/numeric_support/convert.rs
@@ -21,11 +21,11 @@ pub(crate) fn from_primitive_helper<I: IntoDatum, const P: u32, const S: u32>(
             debug_assert_eq!(I::type_oid(), pg_sys::CSTRINGOID);
             direct_function_call(
                 pg_sys::numeric_in,
-                vec![datum, pg_sys::InvalidOid.into_datum(), make_typmod(P, S).into_datum()],
+                &[datum, pg_sys::InvalidOid.into_datum(), make_typmod(P, S).into_datum()],
             )
         } else if func == pg_sys::numeric {
             debug_assert_eq!(I::type_oid(), pg_sys::NUMERICOID);
-            direct_function_call(pg_sys::numeric, vec![datum, make_typmod(P, S).into_datum()])
+            direct_function_call(pg_sys::numeric, &[datum, make_typmod(P, S).into_datum()])
         } else {
             debug_assert!(
                 func == pg_sys::float4_numeric
@@ -35,13 +35,13 @@ pub(crate) fn from_primitive_helper<I: IntoDatum, const P: u32, const S: u32>(
                     || func == pg_sys::int8_numeric
             );
             // use the user-provided `func` to make a Numeric from some primitive type
-            let numeric_datum = direct_function_call_as_datum(func, vec![datum]);
+            let numeric_datum = direct_function_call_as_datum(func, &[datum]);
 
             if P != 0 || S != 0 {
                 // and if it has a precision or a scale, try to coerce it into those constraints
                 direct_function_call(
                     pg_sys::numeric,
-                    vec![numeric_datum, make_typmod(P, S).into_datum()],
+                    &[numeric_datum, make_typmod(P, S).into_datum()],
                 )
             } else {
                 numeric_datum

--- a/pgx/src/datum/numeric_support/convert_anynumeric.rs
+++ b/pgx/src/datum/numeric_support/convert_anynumeric.rs
@@ -21,7 +21,7 @@ macro_rules! anynumeric_from_signed {
         impl From<$ty> for AnyNumeric {
             #[inline]
             fn from(value: $ty) -> Self {
-                call_numeric_func(pg_sys::$func, vec![(value as $as_).into_datum()])
+                call_numeric_func(pg_sys::$func, &[(value as $as_).into_datum()])
             }
         }
     };
@@ -74,7 +74,7 @@ macro_rules! anynumeric_from_float {
                     }
                 }
 
-                Ok(call_numeric_func(pg_sys::$func, vec![value.into_datum()]))
+                Ok(call_numeric_func(pg_sys::$func, &[value.into_datum()]))
             }
         }
     };

--- a/pgx/src/datum/numeric_support/convert_primitive.rs
+++ b/pgx/src/datum/numeric_support/convert_primitive.rs
@@ -108,7 +108,7 @@ fn to_primitive_helper<T: FromDatum>(
     let datum = value.as_datum();
     PgTryBuilder::new(|| unsafe {
         // SAFETY: if 'func' returns, it won't be NULL
-        Ok(direct_function_call::<T>(func, vec![datum]).unwrap_unchecked())
+        Ok(direct_function_call::<T>(func, &[datum]).unwrap_unchecked())
     })
     .catch_when(PgSqlErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE, |e| {
         if let CaughtError::PostgresError(ref ereport) = e {

--- a/pgx/src/datum/numeric_support/hash.rs
+++ b/pgx/src/datum/numeric_support/hash.rs
@@ -6,7 +6,7 @@ impl Hash for AnyNumeric {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         unsafe {
-            let hash = direct_function_call(pg_sys::hash_numeric, vec![self.as_datum()]).unwrap();
+            let hash = direct_function_call(pg_sys::hash_numeric, &[self.as_datum()]).unwrap();
             state.write_i32(hash)
         }
     }

--- a/pgx/src/datum/numeric_support/mod.rs
+++ b/pgx/src/datum/numeric_support/mod.rs
@@ -15,7 +15,7 @@ pub mod sql;
 #[inline]
 pub(super) fn call_numeric_func(
     func: unsafe fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum,
-    args: Vec<Option<pg_sys::Datum>>,
+    args: &[Option<pg_sys::Datum>],
 ) -> AnyNumeric {
     unsafe {
         // SAFETY: this call to direct_function_call_as_datum will never return None

--- a/pgx/src/datum/numeric_support/ops.rs
+++ b/pgx/src/datum/numeric_support/ops.rs
@@ -21,7 +21,7 @@ macro_rules! anynumeric_math_op {
 
             #[inline]
             fn $trait_fnname(self, rhs: AnyNumeric) -> Self::Output {
-                call_numeric_func(pg_sys::$pg_func, vec![self.as_datum(), rhs.as_datum()])
+                call_numeric_func(pg_sys::$pg_func, &[self.as_datum(), rhs.as_datum()])
             }
         }
 
@@ -31,7 +31,7 @@ macro_rules! anynumeric_math_op {
 
             #[inline]
             fn $trait_fnname(self, rhs: AnyNumeric) -> Self::Output {
-                call_numeric_func(pg_sys::$pg_func, vec![self.as_datum(), rhs.as_datum()])
+                call_numeric_func(pg_sys::$pg_func, &[self.as_datum(), rhs.as_datum()])
             }
         }
     };
@@ -53,7 +53,7 @@ macro_rules! numeric_math_op {
 
             #[inline]
             fn $trait_fnname(self, rhs: Numeric<Q, T>) -> Self::Output {
-                call_numeric_func(pg_sys::$pg_func, vec![self.as_datum(), rhs.as_datum()])
+                call_numeric_func(pg_sys::$pg_func, &[self.as_datum(), rhs.as_datum()])
             }
         }
 
@@ -63,7 +63,7 @@ macro_rules! numeric_math_op {
 
             #[inline]
             fn $trait_fnname(self, rhs: Numeric<Q, T>) -> Self::Output {
-                call_numeric_func(pg_sys::$pg_func, vec![self.as_datum(), rhs.as_datum()])
+                call_numeric_func(pg_sys::$pg_func, &[self.as_datum(), rhs.as_datum()])
             }
         }
     };
@@ -80,7 +80,7 @@ impl Neg for AnyNumeric {
 
     #[inline]
     fn neg(self) -> Self::Output {
-        call_numeric_func(pg_sys::numeric_uminus, vec![self.as_datum()])
+        call_numeric_func(pg_sys::numeric_uminus, &[self.as_datum()])
     }
 }
 
@@ -89,7 +89,7 @@ impl<const P: u32, const S: u32> Neg for Numeric<P, S> {
 
     #[inline]
     fn neg(self) -> Self::Output {
-        Numeric(call_numeric_func(pg_sys::numeric_uminus, vec![self.as_datum()]))
+        Numeric(call_numeric_func(pg_sys::numeric_uminus, &[self.as_datum()]))
     }
 }
 
@@ -97,7 +97,7 @@ macro_rules! anynumeric_assign_op_from_anynumeric {
     ($opname:ident, $trait_fname:ident, $pg_func:ident) => {
         impl $opname<AnyNumeric> for AnyNumeric {
             fn $trait_fname(&mut self, rhs: AnyNumeric) {
-                *self = call_numeric_func(pg_sys::$pg_func, vec![self.as_datum(), rhs.as_datum()]);
+                *self = call_numeric_func(pg_sys::$pg_func, &[self.as_datum(), rhs.as_datum()]);
             }
         }
     };
@@ -230,7 +230,7 @@ macro_rules! primitive_math_op {
             fn $trait_fnname(self, rhs: $primitive) -> Self::Output {
                 call_numeric_func(
                     pg_sys::$pg_func,
-                    vec![self.as_datum(), AnyNumeric::try_from(rhs).unwrap().as_datum()],
+                    &[self.as_datum(), AnyNumeric::try_from(rhs).unwrap().as_datum()],
                 )
             }
         }
@@ -243,7 +243,7 @@ macro_rules! primitive_math_op {
             fn $trait_fnname(self, rhs: AnyNumeric) -> Self::Output {
                 call_numeric_func(
                     pg_sys::$pg_func,
-                    vec![AnyNumeric::try_from(self).unwrap().as_datum(), rhs.as_datum()],
+                    &[AnyNumeric::try_from(self).unwrap().as_datum(), rhs.as_datum()],
                 )
             }
         }
@@ -256,7 +256,7 @@ macro_rules! primitive_math_op {
             fn $trait_fnname(self, rhs: $primitive) -> Self::Output {
                 call_numeric_func(
                     pg_sys::$pg_func,
-                    vec![self.as_datum(), AnyNumeric::try_from(rhs).unwrap().as_datum()],
+                    &[self.as_datum(), AnyNumeric::try_from(rhs).unwrap().as_datum()],
                 )
             }
         }
@@ -269,7 +269,7 @@ macro_rules! primitive_math_op {
             fn $trait_fnname(self, rhs: Numeric<P, S>) -> Self::Output {
                 call_numeric_func(
                     pg_sys::$pg_func,
-                    vec![rhs.as_datum(), AnyNumeric::try_from(self).unwrap().as_datum()],
+                    &[rhs.as_datum(), AnyNumeric::try_from(self).unwrap().as_datum()],
                 )
             }
         }

--- a/pgx/src/datum/time.rs
+++ b/pgx/src/datum/time.rs
@@ -112,9 +112,8 @@ impl serde::Serialize for Time {
     where
         S: serde::Serializer,
     {
-        let cstr: Option<&core::ffi::CStr> = unsafe {
-            crate::direct_function_call(pg_sys::time_out, vec![self.clone().into_datum()])
-        };
+        let cstr: Option<&core::ffi::CStr> =
+            unsafe { crate::direct_function_call(pg_sys::time_out, &[self.clone().into_datum()]) };
         serializer.serialize_str(cstr.and_then(|c| c.to_str().ok()).unwrap())
     }
 }

--- a/pgx/src/datum/time_with_timezone.rs
+++ b/pgx/src/datum/time_with_timezone.rs
@@ -64,7 +64,7 @@ impl TimeWithTimeZone {
     #[deprecated(
         since = "0.5.0",
         note = "the repr of pgx::TimeWithTimeZone is no longer time::Time \
-    and this fn will be removed in a future version"
+         and this fn will be removed in a future version"
     )]
     #[cfg(feature = "time-crate")]
     pub fn new(time: time::Time, at_tz_offset: time::UtcOffset) -> Self {
@@ -101,7 +101,7 @@ impl serde::Serialize for TimeWithTimeZone {
         let cstr: Option<&core::ffi::CStr> = unsafe {
             crate::direct_function_call(
                 pg_sys::timetz_out,
-                vec![Some(pg_sys::Datum::from(self as *const Self))],
+                &[Some(pg_sys::Datum::from(self as *const Self))],
             )
         };
         serializer.serialize_str(cstr.and_then(|c| c.to_str().ok()).unwrap())

--- a/pgx/src/rel.rs
+++ b/pgx/src/rel.rs
@@ -111,7 +111,7 @@ impl PgRelation {
     ///
     /// As such, this function is unsafe as we cannot guarantee that this requirement is true.
     pub unsafe fn open_with_name(relname: &str) -> std::result::Result<Self, &'static str> {
-        match direct_function_call::<pg_sys::Oid>(pg_sys::to_regclass, vec![relname.into_datum()]) {
+        match direct_function_call::<pg_sys::Oid>(pg_sys::to_regclass, &[relname.into_datum()]) {
             Some(oid) => Ok(PgRelation::open(oid)),
             None => Err("no such relation"),
         }
@@ -128,10 +128,8 @@ impl PgRelation {
     /// dropped.
     pub fn open_with_name_and_share_lock(relname: &str) -> std::result::Result<Self, &'static str> {
         unsafe {
-            match direct_function_call::<pg_sys::Oid>(
-                pg_sys::to_regclass,
-                vec![relname.into_datum()],
-            ) {
+            match direct_function_call::<pg_sys::Oid>(pg_sys::to_regclass, &[relname.into_datum()])
+            {
                 Some(oid) => {
                     Ok(PgRelation::with_lock(oid, pg_sys::AccessShareLock as pg_sys::LOCKMODE))
                 }

--- a/pgx/src/wrappers.rs
+++ b/pgx/src/wrappers.rs
@@ -16,7 +16,7 @@ pub fn regtypein(type_name: &str) -> pg_sys::Oid {
     let cstr =
         alloc::ffi::CString::new(type_name).expect("specified type_name has embedded NULL byte");
     unsafe {
-        direct_function_call::<pg_sys::Oid>(pg_sys::regtypein, vec![cstr.as_c_str().into_datum()])
+        direct_function_call::<pg_sys::Oid>(pg_sys::regtypein, &[cstr.as_c_str().into_datum()])
             .expect("type lookup returned NULL")
     }
 }


### PR DESCRIPTION
This is breaking change to this API, so perhaps it should be held off to the next release.

This always struck me as pointlessly heavyweight to allocate this on each call, so now it just passes a slice.