### PR TITLE
Memoize DB encoding for faster validation

### DIFF
--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -399,8 +399,6 @@ unsafe fn convert_varlena_to_str_memoized<'a>(varlena: *const pg_sys::varlena) -
                 panic!("datums converted to &str should be valid UTF-8")
             }
         }
-        // Already checked for at start, and should never happen anyways?
-        crate::Utf8Compat::No => core::hint::unreachable_unchecked(),
     }
 }
 

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -396,7 +396,7 @@ unsafe fn convert_varlena_to_str_memoized<'a>(varlena: *const pg_sys::varlena) -
             if bytes.is_ascii() {
                 core::str::from_utf8_unchecked(bytes)
             } else {
-                panic!("datums converted to &str should be valid UTF-8")
+                panic!("datums converted to &str should be valid UTF-8, database encoding is only UTF-8 compatible for ASCII")
             }
         }
     }

--- a/pgx/src/datum/from.rs
+++ b/pgx/src/datum/from.rs
@@ -9,9 +9,8 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 //! for converting a pg_sys::Datum and a corresponding "is_null" bool into a typed Option
 
-use crate::varlena;
 use crate::{
-    pg_sys, varlena_to_byte_slice, AllocatedByPostgres, IntoDatum, PgBox, PgMemoryContexts,
+    pg_sys, varlena, varlena_to_byte_slice, AllocatedByPostgres, IntoDatum, PgBox, PgMemoryContexts,
 };
 use core::ffi::CStr;
 use std::num::NonZeroUsize;
@@ -354,16 +353,8 @@ impl<'a> FromDatum for &'a str {
             // There are a lot of options for how to proceed in response.
             // This could return None, but Rust programmers may assume UTF-8,
             // so panics align more with informing programmers of wrong assumptions.
-            // PGX could check database settings and use those as a source of truth,
-            // but that may impose FFI overhead AND give false negatives, especially
-            // if a DB uses charsets that overlap with UTF-8 and all data that flows
-            // through Rust is UTF-8. Maybe as an optimization?
-            //
-            // Let's start with the minimum for correctness, though.
-            Some(
-                varlena::text_to_rust_str(varlena)
-                    .expect("datums converted to &str should be valid UTF-8"),
-            )
+            // In order to reduce optimization loss here, let's call into a memoized function.
+            Some(convert_varlena_to_str_memoized(varlena))
         }
     }
 
@@ -387,12 +378,29 @@ impl<'a> FromDatum for &'a str {
                 let varlena = pg_sys::pg_detoast_datum_packed(detoasted);
 
                 // and now we return it as a &str
-                Some(
-                    varlena::text_to_rust_str(varlena)
-                        .expect("datums converted to &str should be valid UTF-8"),
-                )
+                Some(convert_varlena_to_str_memoized(varlena))
             })
         }
+    }
+}
+
+// This is not marked inline on purpose, to allow it to be in a single code section
+// which is then branch-predicted on every time by the CPU.
+unsafe fn convert_varlena_to_str_memoized<'a>(varlena: *const pg_sys::varlena) -> &'a str {
+    match *crate::UTF8DATABASE {
+        crate::Utf8Compat::Yes => varlena::text_to_rust_str_unchecked(varlena),
+        crate::Utf8Compat::Maybe => varlena::text_to_rust_str(varlena)
+            .expect("datums converted to &str should be valid UTF-8"),
+        crate::Utf8Compat::Ascii => {
+            let bytes = varlena_to_byte_slice(varlena);
+            if bytes.is_ascii() {
+                core::str::from_utf8_unchecked(bytes)
+            } else {
+                panic!("datums converted to &str should be valid UTF-8")
+            }
+        }
+        // Already checked for at start, and should never happen anyways?
+        crate::Utf8Compat::No => core::hint::unreachable_unchecked(),
     }
 }
 

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -350,11 +350,4 @@ pub(crate) enum Utf8Compat {
 #[allow(unused)]
 pub fn initialize() {
     pg_sys::panic::register_pg_guard_panic_hook();
-    match Lazy::force(&UTF8DATABASE) {
-        Utf8Compat::Maybe => notice!("database encoding is not validated as UTF-8"),
-        Utf8Compat::Ascii => {
-            warning!("database encoding is not UTF-8, extension will accept ASCII only")
-        }
-        Utf8Compat::Yes => (), // perfect, no notes!
-    }
 }

--- a/pgx/src/lib.rs
+++ b/pgx/src/lib.rs
@@ -314,12 +314,12 @@ pub(crate) static UTF8DATABASE: Lazy<Utf8Compat> = Lazy::new(|| {
         pg_sys::pg_enc_PG_UTF8 => Utf8Compat::Yes,
         // The 0 encoding. It... may be UTF-8
         pg_sys::pg_enc_PG_SQL_ASCII => Utf8Compat::Maybe,
-        // Modifies ASCII, should never be seen: PG doesn't support it as server encoding
+        // Modifies ASCII, and should never be seen as PG doesn't support it as server encoding
         pg_sys::pg_enc_PG_SJIS | pg_sys::pg_enc_PG_SHIFT_JIS_2004
         // Not specified as an ASCII extension, also not a server encoding
         | pg_sys::pg_enc_PG_BIG5
-        // Wild vendor differences are possible, also not a server encoding
-        | pg_sys::pg_enc_PG_JOHAB => Utf8Compat::No,
+        // Wild vendor differences including non-ASCII are possible, also not a server encoding
+        | pg_sys::pg_enc_PG_JOHAB => unreachable!("impossible? unsupported non-ASCII-compatible database encoding is not a server encoding"),
         // Other Postgres encodings either extend US-ASCII or CP437 (which includes US-ASCII)
         // There may be a subtlety that requires us to revisit this later
         1..=41=> Utf8Compat::Ascii,
@@ -336,8 +336,6 @@ pub(crate) enum Utf8Compat {
     Maybe,
     /// An "extended ASCII" encoding, so we're fine if we only touch ASCII
     Ascii,
-    /// An encoding that modifies or does not specify it extends US-ASCII
-    No,
 }
 
 /// Initialize the extension with Postgres
@@ -357,7 +355,6 @@ pub fn initialize() {
         Utf8Compat::Ascii => {
             warning!("database encoding is not UTF-8, extension will accept ASCII only")
         }
-        Utf8Compat::No => unreachable!("unsupported database encoding encountered"),
         Utf8Compat::Yes => (), // perfect, no notes!
     }
 }


### PR DESCRIPTION
This performs a check for whether the database is UTF-8, and then uses that information to reduce text validation. An initial check is performed at database load time. If the result discovers a completely incompatible, not-even-ASCII encoding, then the extension will bail. This shouldn't happen as they aren't supported server-side but maybe Postgres will implement support in the future?